### PR TITLE
feat(react/date-picker): add on-calendar-toggle prop

### DIFF
--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -41,6 +41,10 @@ export interface DatePickerProps
    */
   format?: string;
   /**
+   * A function that fires when calendar toggle. Receive open status in boolean format as props.
+   */
+  onCalendarToggle?: (open: boolean) => void;
+  /**
    * Change handler. Takes your declared `DateType` as argument.
    */
   onChange?: (target?: DateType) => void;
@@ -86,6 +90,7 @@ function DatePicker(props: DatePickerProps) {
     isMonthDisabled,
     isYearDisabled,
     mode = 'day',
+    onCalendarToggle: onCalendarToggleProp,
     onChange,
     placeholder,
     popperProps,
@@ -142,6 +147,13 @@ function DatePicker(props: DatePickerProps) {
 
   /** Calender display control */
   const [open, setOpen] = useState(false);
+  const onCalendarToggle = (currentOpen: boolean) => {
+    setOpen(currentOpen);
+
+    if (onCalendarToggleProp) {
+      onCalendarToggleProp(currentOpen);
+    }
+  };
 
   /** Popper positioning */
   const [anchor, setAnchor] = useState<HTMLDivElement | null>(null);
@@ -153,7 +165,7 @@ function DatePicker(props: DatePickerProps) {
   const onCalendarChange = (val: DateType) => {
     resolvedChangeHandler(val);
 
-    setOpen(false);
+    onCalendarToggle(false);
   };
 
   /** Trigger input handlers */
@@ -170,13 +182,13 @@ function DatePicker(props: DatePickerProps) {
     onInputChange,
     onKeyDown: onKeyDownProp,
     readOnly,
-    setOpen,
+    setOpen: onCalendarToggle,
   });
 
   /** Trigger click handler for closing calendar */
   const onTriggerClick = () => {
     if (!open && !readOnly) {
-      setOpen(false);
+      onCalendarToggle(false);
     }
   };
 
@@ -198,7 +210,7 @@ function DatePicker(props: DatePickerProps) {
 
       return (event) => {
         if (!calendarRef.current?.contains(event.target as HTMLElement)) {
-          setOpen(false);
+          onCalendarToggle(false);
         }
       };
     },
@@ -209,7 +221,7 @@ function DatePicker(props: DatePickerProps) {
   /** Close calendar when escape key down */
   useDocumentEscapeKeyDown(() => () => {
     if (open) {
-      setOpen(false);
+      onCalendarToggle(false);
 
       htmlInputRef.current?.blur();
     }
@@ -217,7 +229,7 @@ function DatePicker(props: DatePickerProps) {
 
   /** Close calendar when tab key down */
   useTabKeyClose(
-    () => { setOpen(false); },
+    () => { onCalendarToggle(false); },
     htmlInputRef,
     [],
   );
@@ -238,7 +250,7 @@ function DatePicker(props: DatePickerProps) {
         onClick={onTriggerClick}
         onIconClick={(e) => {
           e.stopPropagation();
-          setOpen(!open);
+          onCalendarToggle(!open);
         }}
         placeholder={placeholder}
         prefix={prefix}

--- a/packages/react/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePicker.tsx
@@ -57,6 +57,10 @@ export interface DateRangePickerProps
    */
   format?: string;
   /**
+   * A function that fires when calendar toggle. Receive open status in boolean format as props.
+   */
+  onCalendarToggle?: (open: boolean) => void;
+  /**
    * Change handler. Takes an array of your declared `DateType` which represents from and to in order.
    */
   onChange?: (target?: DateRangePickerValue) => void;
@@ -111,6 +115,7 @@ function DateRangePicker(props: DateRangePickerProps) {
     isMonthDisabled,
     isYearDisabled,
     mode = 'day',
+    onCalendarToggle: onCalendarToggleProp,
     onChange,
     popperProps,
     prefix,
@@ -166,6 +171,13 @@ function DateRangePicker(props: DateRangePickerProps) {
 
   /** Calendar panel toggle */
   const [open, setOpen] = useState(false);
+  const onCalendarToggle = useCallback((currentOpen: boolean) => {
+    setOpen(currentOpen);
+
+    if (onCalendarToggleProp) {
+      onCalendarToggleProp(currentOpen);
+    }
+  }, [onCalendarToggleProp]);
 
   const onFromFocus = useCallback((event: FocusEvent<HTMLInputElement>) => {
     if (onFromFocusProp) {
@@ -173,9 +185,9 @@ function DateRangePicker(props: DateRangePickerProps) {
     }
 
     if (!readOnly) {
-      setOpen(true);
+      onCalendarToggle(true);
     }
-  }, [onFromFocusProp, readOnly]);
+  }, [onCalendarToggle, onFromFocusProp, readOnly]);
 
   const onToFocus = useCallback((event: FocusEvent<HTMLInputElement>) => {
     if (onToFocusProp) {
@@ -183,9 +195,9 @@ function DateRangePicker(props: DateRangePickerProps) {
     }
 
     if (!readOnly) {
-      setOpen(true);
+      onCalendarToggle(true);
     }
-  }, [onToFocusProp, readOnly]);
+  }, [onCalendarToggle, onToFocusProp, readOnly]);
 
   /** Values and onChange */
   const [range, setRange] = useState(() => sortValues(value || []));
@@ -239,7 +251,7 @@ function DateRangePicker(props: DateRangePickerProps) {
 
     if (!val) {
       clear();
-      setOpen(false);
+      onCalendarToggle(false);
 
       return;
     }
@@ -261,8 +273,8 @@ function DateRangePicker(props: DateRangePickerProps) {
       }
     }
 
-    setOpen(false);
-  }, [format, formatToString, from, onChange, sortValues, to, value, valueLocale]);
+    onCalendarToggle(false);
+  }, [format, formatToString, from, onCalendarToggle, onChange, sortValues, to, value, valueLocale]);
 
   const onCalendarChange = useCallback((val: DateType) => {
     const firstVal = from || to;
@@ -464,7 +476,7 @@ function DateRangePicker(props: DateRangePickerProps) {
   /** Trigger click handler for closing calendar */
   const onTriggerClick = () => {
     if (!open && !readOnly) {
-      setOpen(false);
+      onCalendarToggle(false);
     }
   };
 
@@ -496,7 +508,7 @@ function DateRangePicker(props: DateRangePickerProps) {
   /** Close calendar when escape key down */
   useDocumentEscapeKeyDown(() => () => {
     if (open) {
-      setOpen(false);
+      onCalendarToggle(false);
 
       commitChange(value || []);
     }
@@ -504,7 +516,7 @@ function DateRangePicker(props: DateRangePickerProps) {
 
   /** Close calendar when tab key down */
   useTabKeyClose(
-    () => { setOpen(false); },
+    () => { onCalendarToggle(false); },
     inputToRef,
     [],
   );
@@ -528,7 +540,7 @@ function DateRangePicker(props: DateRangePickerProps) {
         onClick={onTriggerClick}
         onIconClick={(e) => {
           e.stopPropagation();
-          setOpen(!open);
+          onCalendarToggle(!open);
         }}
         onInputFromChange={inputFromOnChange}
         onInputToChange={inputToOnChange}


### PR DESCRIPTION
Add this prop for someone who wants to do things when calendar toggled. Currently in need because
we have to disable other `click away` hook when calendar is open.

#53