### PR TITLE
refactor(react/form-elements): universal APIs

### DIFF
--- a/packages/react/src/Checkbox/CheckAll.spec.tsx
+++ b/packages/react/src/Checkbox/CheckAll.spec.tsx
@@ -62,7 +62,7 @@ describe('<CheckAll />', () => {
 
       function testPassProps() {
         expect(checkboxForAll.props.disabled).toBe(expectProps.disabled);
-        expect(checkboxForAll.props.name).toBe(expectProps.name);
+        expect(checkboxForAll.props.inputProps?.name).toBe(expectProps.name);
         expect(checkboxForAll.props.size).toBe(expectProps.size);
       }
 

--- a/packages/react/src/Checkbox/CheckAll.tsx
+++ b/packages/react/src/Checkbox/CheckAll.tsx
@@ -56,7 +56,9 @@ const CheckAll = forwardRef<HTMLDivElement, CheckAllProps>(function CheckAll(pro
           checked={allChecked}
           disabled={disabled}
           indeterminate={indeterminate}
-          name={name}
+          inputProps={{
+            name,
+          }}
           onChange={(event) => {
             if (onChange) {
               if (!event.target.checked) {

--- a/packages/react/src/Checkbox/Checkbox.spec.tsx
+++ b/packages/react/src/Checkbox/Checkbox.spec.tsx
@@ -26,12 +26,11 @@ describe('<Checkbox />', () => {
     (className) => render(<Checkbox className={className} />),
   );
 
-  it('should pass children,disabled,error,htmlFor,size to InputCheck', () => {
+  it('should pass children,disabled,error,size to InputCheck', () => {
     const testInstance = TestRenderer.create(
       <Checkbox
         disabled
         error
-        htmlFor="bar"
         size="large"
       >
         foo
@@ -42,7 +41,6 @@ describe('<Checkbox />', () => {
     expect(inputCheckInstance.props.children).toBe('foo');
     expect(inputCheckInstance.props.disabled).toBe(true);
     expect(inputCheckInstance.props.error).toBe(true);
-    expect(inputCheckInstance.props.htmlFor).toBe('bar');
     expect(inputCheckInstance.props.size).toBe('large');
   });
 
@@ -150,17 +148,6 @@ describe('<Checkbox />', () => {
     });
   });
 
-  describe('prop: htmlFor', () => {
-    it('should be passed to both htmlFor of label and id of input', () => {
-      const { getHostHTMLElement } = render(<Checkbox htmlFor="foo" />);
-      const element = getHostHTMLElement();
-      const [inputElement] = element.getElementsByTagName('input');
-
-      expect(element.getAttribute('for')).toBe('foo');
-      expect(inputElement.getAttribute('id')).toBe('foo');
-    });
-  });
-
   describe('prop: indeterminate', () => {
     function testIndeterminateAriaChecked(element: HTMLElement, ariaChecked: string) {
       const [inputElement] = element.getElementsByTagName('input');
@@ -207,10 +194,21 @@ describe('<Checkbox />', () => {
     });
   });
 
-  describe('prop: name', () => {
-    it('should be bound to input', () => {
+  describe('prop: inputProps', () => {
+    it('should pass inputProps.id to InputCheck.htmlFor', () => {
+      const testId = 'foo';
+
+      const { getHostHTMLElement } = render(<Checkbox inputProps={{ id: testId }} />);
+      const element = getHostHTMLElement();
+      const [inputElement] = element.getElementsByTagName('input');
+
+      expect(element.getAttribute('for')).toBe(testId);
+      expect(inputElement.getAttribute('id')).toBe(testId);
+    });
+
+    it('should inputProps.name be bound to input', () => {
       const { getHostHTMLElement } = render(
-        <Checkbox name="foo" />,
+        <Checkbox inputProps={{ name: 'foo' }} />,
       );
       const element = getHostHTMLElement();
       const [input] = element.getElementsByTagName('input');
@@ -218,11 +216,11 @@ describe('<Checkbox />', () => {
       expect(input.name).toBe('foo');
     });
 
-    it('should use name from checkbox group if name not passed', () => {
+    it('should use name from checkbox group if inputProps.name not passed', () => {
       const { getHostHTMLElement } = render(
         <CheckboxGroup name="foo">
           <Checkbox />
-          <Checkbox name="bar" />
+          <Checkbox inputProps={{ name: 'bar' }} />
         </CheckboxGroup>,
       );
       const element = getHostHTMLElement();

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -5,8 +5,14 @@ import InputCheck, { InputCheckProps } from '../_internal/InputCheck';
 import { useCheckboxControlValue } from '../Form/useCheckboxControlValue';
 import { FormControlContext } from '../Form';
 import { CheckboxGroupContext } from './CheckboxGroupContext';
+import { NativeElementPropsWithoutKeyAndRef } from '../utils/jsx-types';
 
-export interface CheckboxProps extends Omit<InputCheckProps, 'control'> {
+export interface CheckboxProps
+  extends
+  Omit<InputCheckProps,
+  | 'control'
+  | 'htmlFor'
+  > {
   /**
    * Whether the checkbox is checked.
    */
@@ -22,9 +28,25 @@ export interface CheckboxProps extends Omit<InputCheckProps, 'control'> {
    */
   indeterminate?: boolean;
   /**
-   * The name of input in checkbox.
+   * Since at Mezzanine we use a host element to wrap our input, most derived props will be passed to the host element.
+   *  If you need direct control to the input element, use this prop to provide to it.
+   *
+   * Noticed that if you pass in an id within this prop,
+   *  the rendered label element will have `htmlFor` sync with passed in id.
    */
-  name?: string;
+  inputProps?: Omit<
+  NativeElementPropsWithoutKeyAndRef<'input'>,
+  | 'checked'
+  | 'defaultChecked'
+  | 'disabled'
+  | 'onChange'
+  | 'placeholder'
+  | 'readOnly'
+  | 'required'
+  | 'type'
+  | 'value'
+  | `aria-${'disabled' | 'checked'}`
+  >;
   /**
    * The change event handler of input in checkbox.
    */
@@ -60,14 +82,18 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(function Checkbox(p
     defaultChecked,
     disabled = (disabledFromGroup ?? disabledFromFormControl) || false,
     error = severity === 'error' || false,
-    htmlFor,
     indeterminate: indeterminateProp = false,
-    name = nameFromGroup,
     onChange: onChangeProp,
     size = sizeFromGroup || 'medium',
     value,
+    inputProps,
     ...rest
   } = props;
+  const {
+    id: inputId,
+    name = nameFromGroup,
+    ...restInputProps
+  } = inputProps || {};
   const [checked, onChange] = useCheckboxControlValue({
     checkboxGroup,
     checked: checkedProp,
@@ -92,11 +118,12 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(function Checkbox(p
           )}
         >
           <input
+            {...restInputProps}
             aria-checked={indeterminate ? 'mixed' : checked}
             aria-disabled={disabled}
             checked={checked}
             disabled={disabled}
-            id={htmlFor}
+            id={inputId}
             onChange={onChange}
             name={name}
             type="checkbox"
@@ -106,7 +133,7 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(function Checkbox(p
       )}
       disabled={disabled}
       error={error}
-      htmlFor={htmlFor}
+      htmlFor={inputId}
       size={size}
     >
       {children}

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -30,7 +30,13 @@ export interface InputProps extends Omit<TextFieldProps, 'active' | 'children' |
    */
   inputProps?: Omit<
   NativeElementPropsWithoutKeyAndRef<'input'>,
-  | Exclude<keyof InputProps, 'className'>
+  | 'defaultValue'
+  | 'disabled'
+  | 'onChange'
+  | 'placeholder'
+  | 'readOnly'
+  | 'required'
+  | 'value'
   | `aria-${'disabled' | 'multiline' | 'readonly' | 'required'}`
   >;
   /**

--- a/packages/react/src/Radio/Radio.spec.tsx
+++ b/packages/react/src/Radio/Radio.spec.tsx
@@ -26,12 +26,11 @@ describe('<Radio />', () => {
     (className) => render(<Radio className={className} />),
   );
 
-  it('should pass children,disabled,error,htmlFor,size to InputCheck', () => {
+  it('should pass children, disabled, error, size to InputCheck', () => {
     const testInstance = TestRenderer.create(
       <Radio
         disabled
         error
-        htmlFor="bar"
         size="large"
       >
         foo
@@ -42,7 +41,6 @@ describe('<Radio />', () => {
     expect(inputCheckInstance.props.children).toBe('foo');
     expect(inputCheckInstance.props.disabled).toBe(true);
     expect(inputCheckInstance.props.error).toBe(true);
-    expect(inputCheckInstance.props.htmlFor).toBe('bar');
     expect(inputCheckInstance.props.size).toBe('large');
   });
 
@@ -150,21 +148,21 @@ describe('<Radio />', () => {
     });
   });
 
-  describe('prop: htmlFor', () => {
-    it('should be passed to both htmlFor of label and id of input', () => {
-      const { getHostHTMLElement } = render(<Radio htmlFor="foo" />);
+  describe('prop: inputProps', () => {
+    it('should pass inputProps.id to InputCheck.htmlFor', () => {
+      const testId = 'foo';
+
+      const { getHostHTMLElement } = render(<Radio inputProps={{ id: testId }} />);
       const element = getHostHTMLElement();
       const [inputElement] = element.getElementsByTagName('input');
 
-      expect(element.getAttribute('for')).toBe('foo');
-      expect(inputElement.getAttribute('id')).toBe('foo');
+      expect(element.getAttribute('for')).toBe(testId);
+      expect(inputElement.getAttribute('id')).toBe(testId);
     });
-  });
 
-  describe('prop: name', () => {
-    it('should be bound to input', () => {
+    it('should inputProps.name be bound to input', () => {
       const { getHostHTMLElement } = render(
-        <Radio name="foo" />,
+        <Radio inputProps={{ name: 'foo' }} />,
       );
       const element = getHostHTMLElement();
       const [input] = element.getElementsByTagName('input');
@@ -172,11 +170,11 @@ describe('<Radio />', () => {
       expect(input.name).toBe('foo');
     });
 
-    it('should use name from radio group if name not passed', () => {
+    it('should use name from Radio group if inputProps.name not passed', () => {
       const { getHostHTMLElement } = render(
         <RadioGroup name="foo">
           <Radio />
-          <Radio name="bar" />
+          <Radio inputProps={{ name: 'bar' }} />
         </RadioGroup>,
       );
       const element = getHostHTMLElement();

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -5,8 +5,14 @@ import { cx } from '../utils/cx';
 import { useRadioControlValue } from '../Form/useRadioControlValue';
 import { FormControlContext } from '../Form';
 import { RadioGroupContext } from './RadioGroupContext';
+import { NativeElementPropsWithoutKeyAndRef } from '../utils/jsx-types';
 
-export interface RadioProps extends Omit<InputCheckProps, 'control'> {
+export interface RadioProps
+  extends
+  Omit<InputCheckProps,
+  | 'control'
+  | 'htmlFor'
+  > {
   /**
    * Whether the radio is checked.
    */
@@ -17,9 +23,25 @@ export interface RadioProps extends Omit<InputCheckProps, 'control'> {
    */
   defaultChecked?: boolean;
   /**
-   * The name of input in radio.
+   * Since at Mezzanine we use a host element to wrap our input, most derived props will be passed to the host element.
+   *  If you need direct control to the input element, use this prop to provide to it.
+   *
+   * Noticed that if you pass an id within this prop,
+   *  the rendered label element will have `htmlFor` sync with passed in id.
    */
-  name?: string;
+  inputProps?: Omit<
+  NativeElementPropsWithoutKeyAndRef<'input'>,
+  | 'checked'
+  | 'defaultChecked'
+  | 'disabled'
+  | 'onChange'
+  | 'placeholder'
+  | 'readOnly'
+  | 'required'
+  | 'type'
+  | 'value'
+  | `aria-${'disabled' | 'checked'}`
+  >;
   /**
    * The change event handler of input in radio.
    */
@@ -55,13 +77,17 @@ const Radio = forwardRef<HTMLLabelElement, RadioProps>(function Radio(props, ref
     defaultChecked,
     disabled = (disabledFromGroup ?? disabledFromFormControl) || false,
     error = severity === 'error' || false,
-    htmlFor,
-    name = nameFromGroup,
+    inputProps,
     onChange: onChangeProp,
     size = sizeFromGroup || 'medium',
     value,
     ...rest
   } = props;
+  const {
+    id: inputId,
+    name = nameFromGroup,
+    ...restInputProps
+  } = inputProps || {};
   const [checked, onChange] = useRadioControlValue({
     checked: checkedProp,
     defaultChecked,
@@ -84,11 +110,12 @@ const Radio = forwardRef<HTMLLabelElement, RadioProps>(function Radio(props, ref
           )}
         >
           <input
+            {...restInputProps}
             aria-checked={checked}
             aria-disabled={disabled}
             checked={checked}
             disabled={disabled}
-            id={htmlFor}
+            id={inputId}
             onChange={onChange}
             name={name}
             type="radio"
@@ -98,7 +125,7 @@ const Radio = forwardRef<HTMLLabelElement, RadioProps>(function Radio(props, ref
       )}
       disabled={disabled}
       error={error}
-      htmlFor={htmlFor}
+      htmlFor={inputId}
       size={size}
     >
       {children}

--- a/packages/react/src/Select/Select.tsx
+++ b/packages/react/src/Select/Select.tsx
@@ -76,8 +76,29 @@ export interface SelectProps
    */
   inputProps?: Omit<
   NativeElementPropsWithoutKeyAndRef<'input'>,
-  | Exclude<keyof SelectProps, 'className'>
-  | `aria-${'disabled' | 'multiline' | 'readonly' | 'required'}`
+  | 'autoComplete'
+  | 'defaultValue'
+  | 'disabled'
+  | 'onBlur'
+  | 'onChange'
+  | 'onFocus'
+  | 'placeholder'
+  | 'readOnly'
+  | 'required'
+  | 'role'
+  | 'type'
+  | 'value'
+  | `aria-${
+    | 'disabled'
+    | 'multiline'
+    | 'readonly'
+    | 'required'
+    | 'controls'
+    | 'autocomplete'
+    | 'expanded'
+    | 'haspopup'
+    | 'owns'
+    }`
   >;
   /**
    * The mode of selector

--- a/packages/react/src/Switch/Switch.tsx
+++ b/packages/react/src/Switch/Switch.tsx
@@ -26,6 +26,21 @@ export interface SwitchProps extends Omit<NativeElementPropsWithoutKeyAndRef<'sp
    */
   disabled?: boolean;
   /**
+   * Since at Mezzanine we use a host element to wrap our input, most derived props will be passed to the host element.
+   *  If you need direct control to the input element, use this prop to provide to it.
+   */
+  inputProps?: Omit<
+  NativeElementPropsWithoutKeyAndRef<'input'>,
+  | 'checked'
+  | 'defaultChecked'
+  | 'disabled'
+  | 'onChange'
+  | 'placeholder'
+  | 'type'
+  | 'value'
+  | `aria-${'disabled' | 'checked'}`
+  >;
+  /**
    * Whether the switch is loading.
    * @default false
    */
@@ -53,6 +68,7 @@ const Switch = forwardRef<HTMLSpanElement, SwitchProps>(function Switch(props, r
     className,
     defaultChecked,
     disabled: disabledProp = disabledFromFormControl,
+    inputProps,
     loading = false,
     onChange: onChangeProp,
     size = 'medium',
@@ -83,6 +99,7 @@ const Switch = forwardRef<HTMLSpanElement, SwitchProps>(function Switch(props, r
         {loading && <Icon icon={SwitchSpinnerIcon} spin />}
       </span>
       <input
+        {...inputProps}
         aria-checked={checked}
         aria-disabled={disabled}
         checked={checked}

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -1,7 +1,6 @@
 import {
   forwardRef,
   MouseEventHandler,
-  KeyboardEventHandler,
   ReactNode,
   cloneElement,
   ReactElement,
@@ -49,14 +48,6 @@ export interface TextFieldProps
    * The callback will be fired after clear icon clicked.
    */
   onClear?: MouseEventHandler;
-  /**
-   * The callback will be fired when mouse clicked.
-   */
-  onClick?: MouseEventHandler;
-  /**
-   * The callback will be fired when keyboard key down
-   */
-  onKeyDown?: KeyboardEventHandler;
   /**
    * The prefix addon of the field.
    */

--- a/packages/react/src/Textarea/Textarea.tsx
+++ b/packages/react/src/Textarea/Textarea.tsx
@@ -61,7 +61,15 @@ export interface TextareaProps extends Omit<TextFieldProps, 'active' | 'children
    */
   textareaProps?: Omit<
   NativeElementPropsWithoutKeyAndRef<'textarea'>,
-  | Exclude<keyof TextareaProps, 'className'>
+  | 'defaultValue'
+  | 'disabled'
+  | 'maxLength'
+  | 'onChange'
+  | 'placeholder'
+  | 'readOnly'
+  | 'required'
+  | 'rows'
+  | 'value'
   | `aria-${'disabled' | 'multiline' | 'readonly' | 'required'}`
   >;
   /**


### PR DESCRIPTION

Affected components: input, textarea, radio, checkbox, select and switch.

Most native input props are passing via `inputProps` except value and onChange.

Having this change has below concerns: 
1. id, className and style will be bound to the host element by intuition 
2. following 1., if the component props directly extend input props, the separation of id will be confusing
3. Considering complicated form elements like Date-picker and Select, it is necessary for them to have inputProps rather than extending it since the behaviours are different. An `inputProps` prop seems more universal.