### PR TITLE
fix(deps): Correct react-transition-group import pathname

### DIFF
--- a/packages/react/src/Transition/Transition.tsx
+++ b/packages/react/src/Transition/Transition.tsx
@@ -8,7 +8,7 @@ import {
 import ReactTransition, {
   TransitionStatus as TransitionState,
   TransitionChildren,
-} from 'react-transition-group/transition';
+} from 'react-transition-group/Transition';
 import { NativeElementTag } from '../utils/jsx-types';
 
 export { TransitionState };


### PR DESCRIPTION
In case sensitive disk system, incorrect pathname will break webpack build