### PR TITLE
Refactor/table

### DIFF
--- a/packages/core/src/table/table.ts
+++ b/packages/core/src/table/table.ts
@@ -50,7 +50,7 @@ export type TableColumn<SourceType> = {
   width?: number;
   // == Feature sorting ==
   sorter?(a: any, b: any): number;
-  onSorted?(sortedDataSource: SourceType[]): void;
+  onSorted?(dataIndex: string, sortedType: string): void;
   // == Feature editing ==
   editable?: boolean;
   setCellProps?(record: SourceType): TableRecord<unknown>;

--- a/packages/react/src/Table/Table.stories.tsx
+++ b/packages/react/src/Table/Table.stories.tsx
@@ -49,6 +49,8 @@ const columns: TableColumn<DataType>[] = [{
 
     return -1;
   },
+  // eslint-disable-next-line no-console
+  onSorted: (dataIndex, sortedType) => { console.log(dataIndex, sortedType); },
 }, {
   title: 'Address',
   dataIndex: 'address',
@@ -59,7 +61,7 @@ const columns: TableColumn<DataType>[] = [{
   forceShownTooltipWhenHovered: true,
   sorter: (a: number, b: number) => b - a,
   // eslint-disable-next-line no-console
-  onSorted: (newSources) => { console.log(newSources); },
+  onSorted: (dataIndex, sortedType) => { console.log(dataIndex, sortedType); },
   width: 80,
 }, {
   title: 'Tel',

--- a/packages/react/src/Table/TableHeader.tsx
+++ b/packages/react/src/Table/TableHeader.tsx
@@ -93,7 +93,7 @@ const TableHeader = forwardRef<HTMLDivElement, NativeElementPropsWithoutKeyAndRe
               style={getCellStyle(column)}
             >
               {column.renderTitle?.(classes) || column.title}
-              {typeof column.sorter === 'function' ? (
+              {typeof column.sorter === 'function' || typeof column.onSorted === 'function' ? (
                 <TableSortingIcon
                   column={column}
                 />

--- a/packages/react/src/Table/sorting/useTableSorting.spec.tsx
+++ b/packages/react/src/Table/sorting/useTableSorting.spec.tsx
@@ -33,16 +33,7 @@ describe('useTableSorting()', () => {
     count: 250,
   }];
 
-  let afterSources: typeof originSources;
-
   const numberSorter = (a: number, b: number) => b - a;
-  const onAgeSorted = jest.fn<void, [TableDataSource[]]>((sources) => {
-    afterSources = sources;
-  });
-
-  beforeEach(() => {
-    afterSources = [];
-  });
 
   it('should sorted order be `none -> desc -> asc -> none`', () => {
     const { result } = renderHook(
@@ -141,7 +132,15 @@ describe('useTableSorting()', () => {
     expect(result.current[0][2].id).toBe(originSources[1].id);
   });
 
-  it('should notify parent for sources changing when onSorted given', () => {
+  it('should notify parent for dataIndex and sortedType changing when onSorted given', () => {
+    let afterSortedType = 'none';
+    let currentSortedIndex = '';
+
+    const onAgeSorted = jest.fn((dataIndex, sortedType) => {
+      currentSortedIndex = dataIndex;
+      afterSortedType = sortedType;
+    });
+
     const { result } = renderHook(
       () => useTableSorting({
         dataSource: originSources,
@@ -162,9 +161,8 @@ describe('useTableSorting()', () => {
     });
 
     /** current should be 'desc' */
-    expect(afterSources.length).toBe(originSources.length);
-    expect(afterSources[0].id).toBe(maxAgeId);
-    expect(afterSources[2].id).toBe(minAgeId);
+    expect(currentSortedIndex).toBe('age');
+    expect(afterSortedType).toBe('desc');
   });
 
   it('should `resetAll` reset all the current status', () => {

--- a/packages/react/src/Table/sorting/useTableSorting.ts
+++ b/packages/react/src/Table/sorting/useTableSorting.ts
@@ -72,18 +72,18 @@ export function useTableSorting(props: UseTableSorting) {
   ) => void>(
     (opts) => {
       const { dataIndex, sorter, onSorted } = opts;
+      const isChosenFromOneToAnother = sortedOn && dataIndex !== sortedOn;
+      const nextSortedType = getNextSortedType(isChosenFromOneToAnother ? 'none' : sortedType);
 
       const onMappingSources = (sources: TableDataSource[]) => {
         setDataSource(sources);
 
-        onSorted?.(sources);
+        onSorted?.(dataIndex, nextSortedType);
       };
 
       // only apply changes when column sorter is given
-      if (typeof sorter === 'function') {
+      if (typeof sorter === 'function' || typeof onSorted === 'function') {
         // should update next sorted type first
-        const isChosenFromOneToAnother = sortedOn && dataIndex !== sortedOn;
-        const nextSortedType = getNextSortedType(isChosenFromOneToAnother ? 'none' : sortedType);
 
         setSortedType(nextSortedType);
 
@@ -96,11 +96,13 @@ export function useTableSorting(props: UseTableSorting) {
             // getting new source instance (when switch between sorter, should use origin dataSource)
             let newSource = (isChosenFromOneToAnother ? dataSourceProp : dataSource).slice(0);
 
-            // sort by given sorter
-            newSource = newSource.sort((a, b) => (
-              // reverse result when sorted type is ascending
-              (sorter(get(a, dataIndex), get(b, dataIndex))) * (nextSortedType === 'asc' ? -1 : 1)
-            ));
+            if (typeof sorter === 'function') {
+              // sort by given sorter
+              newSource = newSource.sort((a, b) => (
+                // reverse result when sorted type is ascending
+                (sorter(get(a, dataIndex), get(b, dataIndex))) * (nextSortedType === 'asc' ? -1 : 1)
+              ));
+            }
 
             // map back the data source
             onMappingSources(newSource);


### PR DESCRIPTION
onSorted 改寫了，以前是傳 source 出去，現在是 (dataIndex, sortedType)
然後過去 sorter 存在時，table header 才會有箭頭，現在是 sorter 或 onSorted 存在都會有箭頭
只是 sorter 有給的情況下才會內部排序
只有給 onSorted 的話雖然箭頭會變，但內容完全不會動，然後只會把狀態傳出去

至於 sorter 和 onSorted 只能給定一方這個後來想想好像又不太合理
就算是使用內部的 sorter func 感覺也是可以讓他知道排序狀態來做某些事情 