### PR TITLE
change base date type to string

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,15 @@
     "build": "node ../../scripts/build.js",
     "build:clean": "node ../../scripts/cleanBuild.js"
   },
+  "peerDependencies": {
+    "lodash": "^4.17.21",
+    "moment": "^2.29.1"
+  },
+  "peerDependenciesMeta": {
+    "moment": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@mezzanine-ui/icons": "^0.9.2",
     "@mezzanine-ui/system": "^0.7.0",

--- a/packages/core/src/calendar/calendar.ts
+++ b/packages/core/src/calendar/calendar.ts
@@ -1,13 +1,9 @@
-import { Moment } from 'moment';
 
 /** Types */
 export type CalendarMode = 'year' | 'month' | 'week' | 'day';
-/**
- * @NOTE 2021/04/13
- * we want `DateType` is given from user, but it will cause compile error now,
- * so we set to Moment as default to fix this problem. (If you have any idea, let me know)
-*/
-export type DateType = Moment;
+
+/** ISO 8601 text */
+export type DateType = string;
 
 /** Classes */
 export const calendarPrefix = 'mzn-calendar';

--- a/packages/core/src/calendar/presets/moment.ts
+++ b/packages/core/src/calendar/presets/moment.ts
@@ -1,22 +1,22 @@
-import moment, { Moment, unitOfTime } from 'moment';
+import moment, { unitOfTime } from 'moment';
 import range from 'lodash/range';
 import chunk from 'lodash/chunk';
 import { CalendarMethods as CalendarMethodsType } from './typings';
 
-export const CalendarMethods: CalendarMethodsType<Moment> = {
+export const CalendarMethods: CalendarMethodsType = {
   /** Get date infos */
-  getNow: () => moment(),
-  getSecond: (date) => date.second(),
-  getMinute: (date) => date.minute(),
-  getHour: (date) => date.hour(),
-  getDate: (date) => date.date(),
+  getNow: () => moment().toISOString(),
+  getSecond: (date) => moment(date).second(),
+  getMinute: (date) => moment(date).minute(),
+  getHour: (date) => moment(date).hour(),
+  getDate: (date) => moment(date).date(),
   getWeekDay: (date) => {
-    const clone = date.clone().locale('en_US');
+    const clone = moment(date).locale('en_US');
 
     return clone.weekday() + clone.localeData().firstDayOfWeek();
   },
-  getMonth: (date) => date.month(),
-  getYear: (date) => date.year(),
+  getMonth: (date) => moment(date).month(),
+  getYear: (date) => moment(date).year(),
   getWeekDayNames: (locale) => {
     const date = moment().locale(locale);
 
@@ -35,57 +35,58 @@ export const CalendarMethods: CalendarMethodsType<Moment> = {
 
   /** Manipulate */
   addDay: (date, diff) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.add(diff, 'day');
+    return clone.add(diff, 'day').toISOString();
   },
   addYear: (date, diff) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.add(diff, 'year');
+    return clone.add(diff, 'year').toISOString();
   },
   addMonth: (date, diff) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.add(diff, 'month');
+    return clone.add(diff, 'month').toISOString();
   },
   setSecond: (date, second) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.second(second);
+    return clone.second(second).toISOString();
   },
   setMinute: (date, minute) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.minute(minute);
+    return clone.minute(minute).toISOString();
   },
   setHour: (date, hour) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.hour(hour);
+    return clone.hour(hour).toISOString();
   },
   setMonth: (date, month) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.month(month);
+    return clone.month(month).toISOString();
   },
   setYear: (date, year) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.year(year);
+    return clone.year(year).toISOString();
   },
   setDate: (date, target) => {
-    const clone = date.clone();
+    const clone = moment(date);
 
-    return clone.date(target);
+    return clone.date(target).toISOString();
   },
-  startOf: (target, granularity: unitOfTime.StartOf) => target.startOf(granularity),
+  startOf: (target, granularity: unitOfTime.StartOf) => moment(target).startOf(granularity).toISOString(),
 
   /** Generate day calendar */
   getCalendarGrid: (target) => {
-    const lastDateOfPrevMonth = target.clone().subtract(1, 'month').endOf('month').date();
-    const firstDayOfCurrentMonth = target.clone().date(1).day();
-    const lastDateOfCurrentMonth = target.clone().endOf('month').date();
+    const lastDateOfPrevMonth = moment(target).subtract(1, 'month').endOf('month')
+      .date();
+    const firstDayOfCurrentMonth = moment(target).date(1).day();
+    const lastDateOfCurrentMonth = moment(target).endOf('month').date();
 
     return chunk(
       [
@@ -98,24 +99,26 @@ export const CalendarMethods: CalendarMethodsType<Moment> = {
   },
 
   /** Compares */
-  isBefore: (target, comparison) => target.isBefore(comparison),
+  isBefore: (target, comparison) => moment(target).isBefore(comparison),
   isBetween: (
     value,
     target1,
     target2,
     granularity: unitOfTime.StartOf,
-  ) => value.isBetween(target1, target2, granularity),
-  isSameDate: (dateOne, dateTwo) => dateOne.isSame(dateTwo, 'date'),
-  isSameWeek: (dateOne, dateTwo) => dateOne.isSame(dateTwo, 'week'),
-  isInMonth: (target, month) => target.month() === month,
-  isDateIncluded: (date, targets) => targets.some((target) => date.isSame(target, 'day')),
-  isWeekIncluded: (firstDateOfWeek, targets) => targets.some((target) => firstDateOfWeek.isSame(target, 'week')),
-  isMonthIncluded: (date, targets) => targets.some((target) => date.isSame(target, 'month')),
-  isYearIncluded: (date, targets) => targets.some((target) => date.isSame(target, 'year')),
+  ) => moment(value).isBetween(target1, target2, granularity),
+  isSameDate: (dateOne, dateTwo) => moment(dateOne).isSame(moment(dateTwo), 'date'),
+  isSameWeek: (dateOne, dateTwo) => moment(dateOne).isSame(moment(dateTwo), 'week'),
+  isInMonth: (target, month) => moment(target).month() === month,
+  isDateIncluded: (date, targets) => targets.some((target) => moment(date).isSame(moment(target), 'day')),
+  isWeekIncluded: (firstDateOfWeek, targets) => targets.some(
+    (target) => moment(firstDateOfWeek).isSame(moment(target), 'week'),
+  ),
+  isMonthIncluded: (date, targets) => targets.some((target) => moment(date).isSame(moment(target), 'month')),
+  isYearIncluded: (date, targets) => targets.some((target) => moment(date).isSame(moment(target), 'year')),
 
   /** Format */
   formatToString: (locale, date, format) => {
-    const clone = date.clone();
+    const clone = moment(date);
     const result = clone.locale(locale);
 
     return result.format(format);
@@ -142,7 +145,7 @@ export const CalendarMethods: CalendarMethodsType<Moment> = {
       const date = moment(formatText, format, locale, true);
 
       if (date.isValid()) {
-        return date;
+        return date.toISOString();
       }
     }
 

--- a/packages/core/src/calendar/presets/typings.ts
+++ b/packages/core/src/calendar/presets/typings.ts
@@ -1,47 +1,49 @@
+import { DateType } from '../calendar';
+
 /** Method Types */
-export type CalendarMethods<DateType> = {
+export type CalendarMethods<TDateType = DateType> = {
   /** Get date infos */
-  getNow: () => DateType;
-  getSecond: (value: DateType) => number;
-  getMinute: (value: DateType) => number;
-  getHour: (value: DateType) => number;
-  getDate: (value: DateType) => number;
-  getWeekDay: (value: DateType) => number;
-  getMonth: (value: DateType) => number;
-  getYear: (value: DateType) => number;
+  getNow: () => TDateType;
+  getSecond: (value: TDateType) => number;
+  getMinute: (value: TDateType) => number;
+  getHour: (value: TDateType) => number;
+  getDate: (value: TDateType) => number;
+  getWeekDay: (value: TDateType) => number;
+  getMonth: (value: TDateType) => number;
+  getYear: (value: TDateType) => number;
   getWeekDayNames: (locale: string) => string[];
   getMonthShortName: (value: number, locale: string) => string;
   getMonthShortNames: (locale: string) => Readonly<string[]>;
 
   /** Manipulate */
-  addDay: (value: DateType, diff: number) => DateType;
-  addYear: (value: DateType, diff: number) => DateType;
-  addMonth: (value: DateType, diff: number) => DateType;
-  setSecond: (value: DateType, second: number) => DateType;
-  setMinute: (value: DateType, minute: number) => DateType;
-  setHour: (value: DateType, hour: number) => DateType;
-  setYear: (value: DateType, year: number) => DateType;
-  setMonth: (value: DateType, month: number) => DateType;
-  setDate: (value: DateType, date: number) => DateType;
-  startOf: (value: DateType, granularity: any) => DateType;
+  addDay: (value: TDateType, diff: number) => TDateType;
+  addYear: (value: TDateType, diff: number) => TDateType;
+  addMonth: (value: TDateType, diff: number) => TDateType;
+  setSecond: (value: TDateType, second: number) => TDateType;
+  setMinute: (value: TDateType, minute: number) => TDateType;
+  setHour: (value: TDateType, hour: number) => TDateType;
+  setYear: (value: TDateType, year: number) => TDateType;
+  setMonth: (value: TDateType, month: number) => TDateType;
+  setDate: (value: TDateType, date: number) => TDateType;
+  startOf: (value: TDateType, granularity: any) => TDateType;
 
   /** Generate day calendar */
-  getCalendarGrid: (target: DateType) => number[][];
+  getCalendarGrid: (target: TDateType) => number[][];
 
   /** Compares */
-  isBefore: (target: DateType, comparison: DateType) => boolean;
-  isBetween: (value: DateType, target1: DateType, target2: DateType, granularity: any) => boolean;
-  isSameDate: (dateOne: DateType, dateTwo: DateType) => boolean;
-  isSameWeek: (dateOne: DateType, dateTwo: DateType) => boolean;
-  isInMonth: (target: DateType, month: number) => boolean;
-  isDateIncluded: (date: DateType, targets: DateType[]) => boolean;
-  isWeekIncluded: (firstDateOfWeek: DateType, targets: DateType[]) => boolean;
-  isMonthIncluded: (date: DateType, targets: DateType[]) => boolean;
-  isYearIncluded: (date: DateType, targets: DateType[]) => boolean;
+  isBefore: (target: TDateType, comparison: TDateType) => boolean;
+  isBetween: (value: TDateType, target1: TDateType, target2: TDateType, granularity: any) => boolean;
+  isSameDate: (dateOne: TDateType, dateTwo: TDateType) => boolean;
+  isSameWeek: (dateOne: TDateType, dateTwo: TDateType) => boolean;
+  isInMonth: (target: TDateType, month: number) => boolean;
+  isDateIncluded: (date: TDateType, targets: TDateType[]) => boolean;
+  isWeekIncluded: (firstDateOfWeek: TDateType, targets: TDateType[]) => boolean;
+  isMonthIncluded: (date: TDateType, targets: TDateType[]) => boolean;
+  isYearIncluded: (date: TDateType, targets: TDateType[]) => boolean;
 
   /** Format */
-  formatToString: (locale: string, date: DateType, format: string) => string;
+  formatToString: (locale: string, date: TDateType, format: string) => string;
 
   /** Parse */
-  parse: (locale: string, text: string, formats: string[]) => DateType | undefined;
+  parse: (locale: string, text: string, formats: string[]) => TDateType | undefined;
 };

--- a/packages/core/src/picker/picker.ts
+++ b/packages/core/src/picker/picker.ts
@@ -9,9 +9,9 @@ export const pickerClasses = {
 } as const;
 
 /** Types */
-export type RangePickerValue = undefined[] | [DateType, DateType];
-export type RangePickerPickingValue =
+export type RangePickerValue<T = DateType> = undefined[] | [T, T];
+export type RangePickerPickingValue<T = DateType> =
  | RangePickerValue
- | [DateType]
- | [undefined, DateType]
- | [DateType, undefined];
+ | [T]
+ | [undefined, T]
+ | [T, undefined];

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,6 @@
   },
   "peerDependencies": {
     "lodash": "^4.17.21",
-    "moment": "^2.29.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/packages/react/src/Calendar/Calendar.spec.tsx
+++ b/packages/react/src/Calendar/Calendar.spec.tsx
@@ -39,7 +39,7 @@ describe('<Calendar />', () => {
     HTMLDivElement,
     (ref) => render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
-        <Calendar ref={ref} referenceDate={moment()} />
+        <Calendar ref={ref} referenceDate={moment().toISOString()} />
       </CalendarConfigProvider>,
     ),
   );
@@ -49,7 +49,7 @@ describe('<Calendar />', () => {
     (className) => render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
         <Calendar
-          referenceDate={moment()}
+          referenceDate={moment().toISOString()}
           className={className}
         />
       </CalendarConfigProvider>,
@@ -59,7 +59,7 @@ describe('<Calendar />', () => {
   it('should bind host class', () => {
     const { getHostHTMLElement } = render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
-        <Calendar referenceDate={moment()} />
+        <Calendar referenceDate={moment().toISOString()} />
       </CalendarConfigProvider>,
     );
     const element = getHostHTMLElement();
@@ -71,7 +71,7 @@ describe('<Calendar />', () => {
     it('default to "day"', () => {
       const testInstance = TestRenderer.create(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <Calendar referenceDate={moment()} />
+          <Calendar referenceDate={moment().toISOString()} />
         </CalendarConfigProvider>,
       );
 
@@ -87,7 +87,7 @@ describe('<Calendar />', () => {
         const testInstance = TestRenderer.create(
           <CalendarConfigProvider methods={CalendarMethodsMoment}>
             <Calendar
-              referenceDate={moment()}
+              referenceDate={moment().toISOString()}
               mode={mode}
             />
           </CalendarConfigProvider>,
@@ -105,7 +105,7 @@ describe('<Calendar />', () => {
         const isDateInRange = jest.fn();
         const onChange = jest.fn();
         const onDateHover = jest.fn();
-        const referenceDate = moment();
+        const referenceDate = moment().toISOString();
         const displayWeekDayLocale = 'zh-TW';
         const testInstance = TestRenderer.create(
           <CalendarConfigProvider methods={CalendarMethodsMoment}>
@@ -135,7 +135,7 @@ describe('<Calendar />', () => {
         const isWeekInRange = jest.fn();
         const onChange = jest.fn();
         const onWeekHover = jest.fn();
-        const referenceDate = moment();
+        const referenceDate = moment().toISOString();
         const displayWeekDayLocale = 'zh-TW';
         const testInstance = TestRenderer.create(
           <CalendarConfigProvider methods={CalendarMethodsMoment}>
@@ -165,7 +165,7 @@ describe('<Calendar />', () => {
         const isMonthInRange = jest.fn();
         const onChange = jest.fn();
         const onMonthHover = jest.fn();
-        const referenceDate = moment();
+        const referenceDate = moment().toISOString();
         const testInstance = TestRenderer.create(
           <CalendarConfigProvider methods={CalendarMethodsMoment}>
             <Calendar
@@ -192,7 +192,7 @@ describe('<Calendar />', () => {
         const isYearInRange = jest.fn();
         const onChange = jest.fn();
         const onYearHover = jest.fn();
-        const referenceDate = moment();
+        const referenceDate = moment().toISOString();
         const testInstance = TestRenderer.create(
           <CalendarConfigProvider methods={CalendarMethodsMoment}>
             <Calendar
@@ -218,9 +218,11 @@ describe('<Calendar />', () => {
     describe('should have relevant control buttons', () => {
       (['day', 'week'] as CalendarMode[]).forEach((mode) => {
         it(`should have month and year button if mode="${mode}", and receiving event handlers`, () => {
-          const referenceDate = moment();
+          const referenceDate = moment().toISOString();
           const displayMonthLocale = 'en-US';
-          const displayMonthName = CalendarMethodsMoment.getMonthShortName(referenceDate.month(), displayMonthLocale);
+          const displayMonthName = CalendarMethodsMoment.getMonthShortName(
+            moment(referenceDate).month(), displayMonthLocale,
+          );
           const onMonthControlClick = jest.fn();
           const onYearControlClick = jest.fn();
           const { getByText } = render(
@@ -235,7 +237,7 @@ describe('<Calendar />', () => {
           );
 
           const monthControlButton = getByText(displayMonthName);
-          const yearControlButton = getByText(referenceDate.year());
+          const yearControlButton = getByText(moment(referenceDate).year());
 
           expect(monthControlButton).toBeInstanceOf(HTMLButtonElement);
           expect(yearControlButton).toBeInstanceOf(HTMLButtonElement);
@@ -249,7 +251,7 @@ describe('<Calendar />', () => {
       });
 
       it('should have year button if mode="month", and receiving event handlers', () => {
-        const referenceDate = moment();
+        const referenceDate = moment().toISOString();
         const onYearControlClick = jest.fn();
         const { getByText } = render(
           <CalendarConfigProvider methods={CalendarMethodsMoment}>
@@ -261,7 +263,7 @@ describe('<Calendar />', () => {
           </CalendarConfigProvider>,
         );
 
-        const yearControlButton = getByText(referenceDate.year());
+        const yearControlButton = getByText(moment(referenceDate).year());
 
         expect(yearControlButton).toBeInstanceOf(HTMLButtonElement);
 
@@ -270,8 +272,8 @@ describe('<Calendar />', () => {
       });
 
       it('should have a disabled year range button if mode="year"', () => {
-        const referenceDate = moment();
-        const [start, end] = getYearRange(referenceDate.year(), calendarYearModuler);
+        const referenceDate = moment().toISOString();
+        const [start, end] = getYearRange(moment(referenceDate).year(), calendarYearModuler);
         const displayYearRange = `${start} - ${end}`;
         const onYearControlClick = jest.fn();
         const { getByText } = render(
@@ -297,7 +299,7 @@ describe('<Calendar />', () => {
     it('CalendarControls should reveive undefined on onNext if prop not provided', () => {
       const testInstance = TestRenderer.create(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <Calendar referenceDate={moment()} />
+          <Calendar referenceDate={moment().toISOString()} />
         </CalendarConfigProvider>,
       );
 
@@ -310,7 +312,7 @@ describe('<Calendar />', () => {
       const onNext = jest.fn();
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <Calendar referenceDate={moment()} onNext={onNext} />
+          <Calendar referenceDate={moment().toISOString()} onNext={onNext} />
         </CalendarConfigProvider>,
       );
       const hostElement = getHostHTMLElement();
@@ -328,7 +330,7 @@ describe('<Calendar />', () => {
     it('CalendarControls should reveive undefined on onPrev if this prop not provided', () => {
       const testInstance = TestRenderer.create(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <Calendar referenceDate={moment()} />
+          <Calendar referenceDate={moment().toISOString()} />
         </CalendarConfigProvider>,
       );
 
@@ -341,7 +343,7 @@ describe('<Calendar />', () => {
       const onPrev = jest.fn();
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <Calendar referenceDate={moment()} onPrev={onPrev} />
+          <Calendar referenceDate={moment().toISOString()} onPrev={onPrev} />
         </CalendarConfigProvider>,
       );
       const hostElement = getHostHTMLElement();
@@ -357,14 +359,14 @@ describe('<Calendar />', () => {
 
   describe('prop: value', () => {
     it('should be casted to array and pass to calendars', () => {
-      const value = moment();
+      const value = moment().toISOString();
 
       modes.forEach((mode) => {
         const calendar = calendars[mode];
         const testInstance = TestRenderer.create(
           <CalendarConfigProvider methods={CalendarMethodsMoment}>
             <Calendar
-              referenceDate={moment()}
+              referenceDate={moment().toISOString()}
               mode={mode}
               value={value}
             />

--- a/packages/react/src/Calendar/Calendar.stories.tsx
+++ b/packages/react/src/Calendar/Calendar.stories.tsx
@@ -30,7 +30,7 @@ const InnerCalendarPlayground = ({
     month: 'YYYY-MM',
     year: 'YYYY',
   };
-  const initialReferenceDate = useMemo(() => moment(), []);
+  const initialReferenceDate = useMemo(() => moment().toISOString(), []);
   const [val, setVal] = useState<DateType>();
   const {
     currentMode,
@@ -56,7 +56,7 @@ const InnerCalendarPlayground = ({
   return (
     <>
       <Typography style={{ margin: '0 0 12px 0' }}>
-        {`current value: ${val?.format(formats[mode])}`}
+        {`current value: ${moment(val).format(formats[mode])}`}
       </Typography>
       <div style={{ width: '224px' }}>
         <Calendar
@@ -110,28 +110,28 @@ export const Calendars = () => {
     margin: '0 0 12px 0',
   };
 
-  const startDate = moment().date(17);
-  const endDate = moment().date(26);
-  const isDateInRange = (date: DateType) => date.isBetween(startDate, endDate);
+  const startDate = moment().date(17).toISOString();
+  const endDate = moment().date(26).toISOString();
+  const isDateInRange = (date: string) => moment(date).isBetween(startDate, endDate);
 
-  const startWeek = moment().date(7);
-  const endWeek = moment().date(21);
-  const isWeekInRange = (date: DateType) => date.isBetween(startWeek, endWeek, 'date', '[]');
+  const startWeek = moment().date(7).toISOString();
+  const endWeek = moment().date(21).toISOString();
+  const isWeekInRange = (date: string) => moment(date).isBetween(startWeek, endWeek, 'date', '[]');
 
-  const startMonth = moment().month(2);
-  const endMonth = moment().month(5);
-  const isMonthInRange = (date: DateType) => date.isBetween(startMonth, endMonth, 'month', '[]');
+  const startMonth = moment().month(2).toISOString();
+  const endMonth = moment().month(5).toISOString();
+  const isMonthInRange = (date: string) => moment(date).isBetween(startMonth, endMonth, 'month', '[]');
 
-  const startYear = moment().year(2021);
-  const endYear = moment().year(2025);
-  const isYearInRange = (date: DateType) => date.isBetween(startYear, endYear, 'year', '[]');
+  const startYear = moment().year(2021).toISOString();
+  const endYear = moment().year(2025).toISOString();
+  const isYearInRange = (date: string) => moment(date).isBetween(startYear, endYear, 'year', '[]');
 
   return (
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <Typography variant="h4" style={titleStyles}>Days Calendar</Typography>
       <div style={calendarStyles}>
         <CalendarDays
-          referenceDate={moment()}
+          referenceDate={moment().toISOString()}
           isDateInRange={isDateInRange}
           value={[startDate, endDate]}
         />

--- a/packages/react/src/Calendar/Calendar.stories.tsx
+++ b/packages/react/src/Calendar/Calendar.stories.tsx
@@ -112,19 +112,19 @@ export const Calendars = () => {
 
   const startDate = moment().date(17).toISOString();
   const endDate = moment().date(26).toISOString();
-  const isDateInRange = (date: string) => moment(date).isBetween(startDate, endDate);
+  const isDateInRange = (date: DateType) => moment(date).isBetween(startDate, endDate);
 
   const startWeek = moment().date(7).toISOString();
   const endWeek = moment().date(21).toISOString();
-  const isWeekInRange = (date: string) => moment(date).isBetween(startWeek, endWeek, 'date', '[]');
+  const isWeekInRange = (date: DateType) => moment(date).isBetween(startWeek, endWeek, 'date', '[]');
 
   const startMonth = moment().month(2).toISOString();
   const endMonth = moment().month(5).toISOString();
-  const isMonthInRange = (date: string) => moment(date).isBetween(startMonth, endMonth, 'month', '[]');
+  const isMonthInRange = (date: DateType) => moment(date).isBetween(startMonth, endMonth, 'month', '[]');
 
   const startYear = moment().year(2021).toISOString();
   const endYear = moment().year(2025).toISOString();
-  const isYearInRange = (date: string) => moment(date).isBetween(startYear, endYear, 'year', '[]');
+  const isYearInRange = (date: DateType) => moment(date).isBetween(startYear, endYear, 'year', '[]');
 
   return (
     <CalendarConfigProvider methods={CalendarMethodsMoment}>

--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -158,7 +158,7 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(pro
     ...restCalendarProps
   } = props;
 
-  const value = valueProp && castArray(valueProp);
+  const value = valueProp ? castArray(valueProp) : undefined;
 
   /** Compute which calendar to use */
   let displayCalendar;

--- a/packages/react/src/Calendar/CalendarContext.tsx
+++ b/packages/react/src/Calendar/CalendarContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, useContext } from 'react';
-import { CalendarMethods, DateType } from '@mezzanine-ui/core/calendar';
+import { CalendarMethods } from '@mezzanine-ui/core/calendar';
 
-export interface CalendarConfigs extends CalendarMethods<DateType> {
+export interface CalendarConfigs extends CalendarMethods {
   defaultDateFormat: string;
   defaultTimeFormat: string;
   displayMonthLocale: string;
@@ -15,7 +15,7 @@ export type CalendarConfigProviderProps = {
   defaultTimeFormat?: string;
   displayMonthLocale?: string;
   displayWeekDayLocale?: string;
-  methods: CalendarMethods<DateType>;
+  methods: CalendarMethods;
   valueLocale?: string;
 };
 

--- a/packages/react/src/Calendar/CalendarDays.spec.tsx
+++ b/packages/react/src/Calendar/CalendarDays.spec.tsx
@@ -64,7 +64,7 @@ describe('<CalendarDays />', () => {
     it('should disable Date when matching the condition', () => {
       const testDate = 15;
       const today = moment().date(testDate);
-      const isDateDisabled: CalendarDaysProps['isDateDisabled'] = (date) => date.isSame(today, 'date');
+      const isDateDisabled: CalendarDaysProps['isDateDisabled'] = (date) => moment(date).isSame(today, 'date');
 
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
@@ -89,7 +89,7 @@ describe('<CalendarDays />', () => {
       const rangeStart = moment().date(testRangeStart);
       const rangeEnd = moment().date(testRangeEnd);
       const isDateInRange: CalendarDaysProps['isDateInRange'] = (date) => (
-        date.isBetween(rangeStart, rangeEnd, undefined, '[]')
+        moment(date).isBetween(rangeStart, rangeEnd, undefined, '[]')
       );
 
       const { getByText } = render(

--- a/packages/react/src/Calendar/CalendarDays.spec.tsx
+++ b/packages/react/src/Calendar/CalendarDays.spec.tsx
@@ -24,7 +24,7 @@ describe('<CalendarDays />', () => {
     (className) => render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
         <CalendarDays
-          referenceDate={moment()}
+          referenceDate={moment().format('YYYY-MM-DD')}
           className={className}
         />
       </CalendarConfigProvider>,
@@ -34,7 +34,7 @@ describe('<CalendarDays />', () => {
   it('should bind host class', () => {
     const { getHostHTMLElement } = render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
-        <CalendarDays referenceDate={moment()} />
+        <CalendarDays referenceDate={moment().format('YYYY-MM-DD')} />
       </CalendarConfigProvider>,
     );
     const element = getHostHTMLElement();
@@ -47,7 +47,7 @@ describe('<CalendarDays />', () => {
       const testInstance = TestRenderer.create(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarDays
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             displayWeekDayLocale="zh-TW"
           />
           ,
@@ -69,7 +69,7 @@ describe('<CalendarDays />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarDays
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isDateDisabled={isDateDisabled}
           />
         </CalendarConfigProvider>,
@@ -95,7 +95,7 @@ describe('<CalendarDays />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarDays
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isDateInRange={isDateInRange}
           />
         </CalendarConfigProvider>,
@@ -111,7 +111,7 @@ describe('<CalendarDays />', () => {
     it('should have no click handler if onClick is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarDays referenceDate={moment()} />
+          <CalendarDays referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -127,7 +127,7 @@ describe('<CalendarDays />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarDays
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onClick={onClick}
           />
         </CalendarConfigProvider>,
@@ -149,7 +149,7 @@ describe('<CalendarDays />', () => {
     it('should have no mouseenter handler if onDateHover is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarDays referenceDate={moment()} />
+          <CalendarDays referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -165,7 +165,7 @@ describe('<CalendarDays />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarDays
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onDateHover={onDateHover}
           />
         </CalendarConfigProvider>,
@@ -185,7 +185,7 @@ describe('<CalendarDays />', () => {
 
   describe('prop: referenceDate', () => {
     it('should pass to getCalendarGrid method', () => {
-      const referenceDate = moment();
+      const referenceDate = moment().format('YYYY-MM-DD');
       const getCalendarGridSpy = jest.spyOn(CalendarMethodsMoment, 'getCalendarGrid');
 
       render(
@@ -201,12 +201,12 @@ describe('<CalendarDays />', () => {
   describe('prop: value', () => {
     it('should have the date matches the value have active class', () => {
       const testDate = 15;
-      const value = [moment().date(testDate)];
+      const value = [moment().date(testDate).format('YYYY-MM-DD')];
 
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarDays
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             value={value}
           />
         </CalendarConfigProvider>,

--- a/packages/react/src/Calendar/CalendarMonths.spec.tsx
+++ b/packages/react/src/Calendar/CalendarMonths.spec.tsx
@@ -63,7 +63,8 @@ describe('<CalendarMonths />', () => {
       const testMonth = 9;
       const testMonthName = monthNames[testMonth];
       const disableMonth = moment().month(testMonth);
-      const isMonthDisabled: CalendarMonthsProps['isMonthDisabled'] = (date) => date.isSame(disableMonth, 'month');
+      const isMonthDisabled: CalendarMonthsProps['isMonthDisabled'] = (date) => (
+        moment(date).isSame(disableMonth, 'month'));
 
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
@@ -90,7 +91,7 @@ describe('<CalendarMonths />', () => {
       const rangeStart = moment().month(testRangeStart);
       const rangeEnd = moment().month(testRangeEnd);
       const isMonthInRange: CalendarMonthsProps['isMonthInRange'] = (date) => (
-        date.isBetween(rangeStart, rangeEnd, undefined, '[]')
+        moment(date).isBetween(rangeStart, rangeEnd, undefined, '[]')
       );
 
       const { getByText } = render(

--- a/packages/react/src/Calendar/CalendarMonths.spec.tsx
+++ b/packages/react/src/Calendar/CalendarMonths.spec.tsx
@@ -22,7 +22,7 @@ describe('<CalendarMonths />', () => {
     (className) => render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
         <CalendarMonths
-          referenceDate={moment()}
+          referenceDate={moment().format('YYYY-MM-DD')}
           className={className}
         />
       </CalendarConfigProvider>,
@@ -32,7 +32,7 @@ describe('<CalendarMonths />', () => {
   it('should bind host class', () => {
     const { getHostHTMLElement } = render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
-        <CalendarMonths referenceDate={moment()} />
+        <CalendarMonths referenceDate={moment().format('YYYY-MM-DD')} />
       </CalendarConfigProvider>,
     );
     const element = getHostHTMLElement();
@@ -47,7 +47,7 @@ describe('<CalendarMonths />', () => {
       render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarMonths
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             displayMonthLocale="zh-TW"
           />
         </CalendarConfigProvider>,
@@ -69,7 +69,7 @@ describe('<CalendarMonths />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarMonths
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isMonthDisabled={isMonthDisabled}
           />
         </CalendarConfigProvider>,
@@ -97,7 +97,7 @@ describe('<CalendarMonths />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarMonths
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isMonthInRange={isMonthInRange}
           />
         </CalendarConfigProvider>,
@@ -113,7 +113,7 @@ describe('<CalendarMonths />', () => {
     it('should have no click handler if onClick is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarMonths referenceDate={moment()} />
+          <CalendarMonths referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -129,7 +129,7 @@ describe('<CalendarMonths />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarMonths
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onClick={onClick}
           />
         </CalendarConfigProvider>,
@@ -151,7 +151,7 @@ describe('<CalendarMonths />', () => {
     it('should have no mouseenter handler if onMonthHover is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarMonths referenceDate={moment()} />
+          <CalendarMonths referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -167,7 +167,7 @@ describe('<CalendarMonths />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarMonths
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onMonthHover={onMonthHover}
           />
         </CalendarConfigProvider>,
@@ -190,12 +190,12 @@ describe('<CalendarMonths />', () => {
       const monthNames = CalendarMethodsMoment.getMonthShortNames('en-US');
       const testMonth = 9;
       const testMonthName = monthNames[testMonth];
-      const value = [moment().month(testMonth)];
+      const value = [moment().month(testMonth).format('YYYY-MM-DD')];
 
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarMonths
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             value={value}
           />
         </CalendarConfigProvider>,

--- a/packages/react/src/Calendar/CalendarWeeks.spec.tsx
+++ b/packages/react/src/Calendar/CalendarWeeks.spec.tsx
@@ -64,7 +64,7 @@ describe('<CalendarWeeks />', () => {
     it('should disable week when matching the condition', () => {
       const testDate = 15;
       const today = moment().date(testDate);
-      const isWeekDisabled: CalendarWeeksProps['isWeekDisabled'] = (date) => date.isSame(today, 'week');
+      const isWeekDisabled: CalendarWeeksProps['isWeekDisabled'] = (date) => moment(date).isSame(today, 'week');
 
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
@@ -92,7 +92,7 @@ describe('<CalendarWeeks />', () => {
       const rangeStart = moment().date(testRangeStart);
       const rangeEnd = moment().date(testRangeEnd);
       const isWeekInRange: CalendarWeeksProps['isWeekInRange'] = (date) => (
-        date.isBetween(rangeStart, rangeEnd, undefined, '[]')
+        moment(date).isBetween(rangeStart, rangeEnd, undefined, '[]')
       );
 
       const { getByText } = render(

--- a/packages/react/src/Calendar/CalendarWeeks.spec.tsx
+++ b/packages/react/src/Calendar/CalendarWeeks.spec.tsx
@@ -24,7 +24,7 @@ describe('<CalendarWeeks />', () => {
     (className) => render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
         <CalendarWeeks
-          referenceDate={moment()}
+          referenceDate={moment().format('YYYY-MM-DD')}
           className={className}
         />
       </CalendarConfigProvider>,
@@ -34,7 +34,7 @@ describe('<CalendarWeeks />', () => {
   it('should bind host class', () => {
     const { getHostHTMLElement } = render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
-        <CalendarWeeks referenceDate={moment()} />
+        <CalendarWeeks referenceDate={moment().format('YYYY-MM-DD')} />
       </CalendarConfigProvider>,
     );
     const element = getHostHTMLElement();
@@ -47,7 +47,7 @@ describe('<CalendarWeeks />', () => {
       const testInstance = TestRenderer.create(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarWeeks
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             displayWeekDayLocale="zh-TW"
           />
           ,
@@ -69,7 +69,7 @@ describe('<CalendarWeeks />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarWeeks
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isWeekDisabled={isWeekDisabled}
           />
         </CalendarConfigProvider>,
@@ -98,7 +98,7 @@ describe('<CalendarWeeks />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarWeeks
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isWeekInRange={isWeekInRange}
           />
         </CalendarConfigProvider>,
@@ -114,7 +114,7 @@ describe('<CalendarWeeks />', () => {
     it('should have no click handler if onClick is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarWeeks referenceDate={moment()} />
+          <CalendarWeeks referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -130,7 +130,7 @@ describe('<CalendarWeeks />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarWeeks
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onClick={onClick}
           />
         </CalendarConfigProvider>,
@@ -152,7 +152,7 @@ describe('<CalendarWeeks />', () => {
     it('should have no mouseenter handler if onWeekHover is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarWeeks referenceDate={moment()} />
+          <CalendarWeeks referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -168,7 +168,7 @@ describe('<CalendarWeeks />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarWeeks
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onWeekHover={onWeekHover}
           />
         </CalendarConfigProvider>,
@@ -188,7 +188,7 @@ describe('<CalendarWeeks />', () => {
 
   describe('prop: referenceDate', () => {
     it('should pass to getCalendarGrid method', () => {
-      const referenceDate = moment();
+      const referenceDate = moment().format('YYYY-MM-DD');
       const getCalendarGridSpy = jest.spyOn(CalendarMethodsMoment, 'getCalendarGrid');
 
       render(
@@ -204,12 +204,12 @@ describe('<CalendarWeeks />', () => {
   describe('prop: value', () => {
     it('should have the date matches the value have active class', () => {
       const testDate = 15;
-      const value = [moment().date(testDate)];
+      const value = [moment().date(testDate).format('YYYY-MM-DD')];
 
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarWeeks
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             value={value}
           />
         </CalendarConfigProvider>,

--- a/packages/react/src/Calendar/CalendarYears.spec.tsx
+++ b/packages/react/src/Calendar/CalendarYears.spec.tsx
@@ -22,7 +22,7 @@ describe('<CalendarYears />', () => {
     (className) => render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
         <CalendarYears
-          referenceDate={moment()}
+          referenceDate={moment().format('YYYY-MM-DD')}
           className={className}
         />
       </CalendarConfigProvider>,
@@ -32,7 +32,7 @@ describe('<CalendarYears />', () => {
   it('should bind host class', () => {
     const { getHostHTMLElement } = render(
       <CalendarConfigProvider methods={CalendarMethodsMoment}>
-        <CalendarYears referenceDate={moment()} />
+        <CalendarYears referenceDate={moment().format('YYYY-MM-DD')} />
       </CalendarConfigProvider>,
     );
     const element = getHostHTMLElement();
@@ -48,7 +48,7 @@ describe('<CalendarYears />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarYears
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isYearDisabled={isYearDisabled}
           />
         </CalendarConfigProvider>,
@@ -73,7 +73,7 @@ describe('<CalendarYears />', () => {
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarYears
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             isYearInRange={isYearInRange}
           />
         </CalendarConfigProvider>,
@@ -89,7 +89,7 @@ describe('<CalendarYears />', () => {
     it('should have no click handler if onClick is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarYears referenceDate={moment()} />
+          <CalendarYears referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -105,7 +105,7 @@ describe('<CalendarYears />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarYears
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onClick={onClick}
           />
         </CalendarConfigProvider>,
@@ -127,7 +127,7 @@ describe('<CalendarYears />', () => {
     it('should have no mouseenter handler if onWeekHover is not provided', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
-          <CalendarYears referenceDate={moment()} />
+          <CalendarYears referenceDate={moment().format('YYYY-MM-DD')} />
         </CalendarConfigProvider>,
       );
       const element = getHostHTMLElement();
@@ -143,7 +143,7 @@ describe('<CalendarYears />', () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarYears
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             onYearHover={onYearHover}
           />
         </CalendarConfigProvider>,
@@ -163,17 +163,17 @@ describe('<CalendarYears />', () => {
 
   describe('prop: value', () => {
     it('should have the date matches the value have active class', () => {
-      const value = [moment()];
+      const value = [moment().format('YYYY-MM-DD')];
 
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <CalendarYears
-            referenceDate={moment()}
+            referenceDate={moment().format('YYYY-MM-DD')}
             value={value}
           />
         </CalendarConfigProvider>,
       );
-      const buttonElement = getByText(`${value[0].year()}`);
+      const buttonElement = getByText(`${moment(value[0]).year()}`);
 
       expect(buttonElement?.classList.contains('mzn-calendar-button--active')).toBe(true);
     });

--- a/packages/react/src/Calendar/CalendarYears.spec.tsx
+++ b/packages/react/src/Calendar/CalendarYears.spec.tsx
@@ -43,7 +43,7 @@ describe('<CalendarYears />', () => {
   describe('prop: isYearDisabled', () => {
     it('should disable year when matching the condition', () => {
       const today = moment();
-      const isYearDisabled: CalendarYearsProps['isYearDisabled'] = (date) => date.isSame(today, 'year');
+      const isYearDisabled: CalendarYearsProps['isYearDisabled'] = (date) => today.isSame(date, 'year');
 
       const { getByText } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
@@ -67,7 +67,7 @@ describe('<CalendarYears />', () => {
       const lastYear = moment().year(today.year() - 1);
       const nextYear = moment().year(today.year() + 1);
       const isYearInRange: CalendarYearsProps['isYearInRange'] = (date) => (
-        date.isBetween(lastYear, nextYear, undefined, '[]')
+        moment(date).isBetween(lastYear, nextYear, undefined, '[]')
       );
 
       const { getByText } = render(

--- a/packages/react/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/DatePicker/DatePicker.stories.tsx
@@ -12,9 +12,9 @@ export default {
   title: 'Data Entry/DatePicker',
 } as Meta;
 
-function usePickerChange<T = string>() {
-  const [val, setVal] = useState<T>();
-  const onChange = (v?: T) => { setVal(v); };
+function usePickerChange() {
+  const [val, setVal] = useState<DateType>();
+  const onChange = (v?: DateType) => { setVal(v); };
 
   return [val, onChange] as const;
 }

--- a/packages/react/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/DatePicker/DatePicker.stories.tsx
@@ -13,7 +13,7 @@ export default {
 } as Meta;
 
 function usePickerChange() {
-  const [val, setVal] = useState<DateType>();
+  const [val, setVal] = useState<DateType | undefined>('2022-01-05');
   const onChange = (v?: DateType) => { setVal(v); };
 
   return [val, onChange] as const;
@@ -99,7 +99,7 @@ Playground.args = {
 export const Basic = () => {
   const containerStyle = { margin: '0 0 24px 0' };
   const typoStyle = { margin: '0 0 12px 0' };
-  const [val, setVal] = useState<DateType>();
+  const [val, setVal] = useState<DateType | undefined>('2022-01-05');
   const onChange = (v?: DateType) => { setVal(v); };
 
   return (

--- a/packages/react/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,7 @@
 import { Story, Meta } from '@storybook/react';
-import { CalendarMethodsMoment, DateType, getDefaultModeFormat } from '@mezzanine-ui/core/calendar';
+import {
+  DateType, getDefaultModeFormat, CalendarMethodsMoment,
+} from '@mezzanine-ui/core/calendar';
 import { useState } from 'react';
 import moment from 'moment';
 import DatePicker, { DatePickerProps } from './DatePicker';
@@ -10,9 +12,9 @@ export default {
   title: 'Data Entry/DatePicker',
 } as Meta;
 
-function usePickerChange() {
-  const [val, setVal] = useState<DateType>();
-  const onChange = (v?: DateType) => { setVal(v); };
+function usePickerChange<T = string>() {
+  const [val, setVal] = useState<T>();
+  const onChange = (v?: T) => { setVal(v); };
 
   return [val, onChange] as const;
 }
@@ -33,11 +35,14 @@ export const Playground: Story<PlaygroundArgs> = ({
   const typoStyle = { margin: '0 0 12px 0' };
   const [val, onChange] = usePickerChange();
 
+  // const formatString = CalendarMethodsMomentIsoString.formatToString('', val ?? '', format ?? 'YYYY-MM-DD');
+
   return (
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <Typography variant="h5" style={typoStyle}>
-        {`current value: ${val?.format(format)}`}
+        {/* {`current value: ${formatString}`} */}
       </Typography>
+      <Typography>{val}</Typography>
       <DatePicker
         value={val}
         onChange={onChange}
@@ -109,19 +114,19 @@ export const Basic = () => {
         <Typography variant="h5" style={typoStyle}>
           Disabled
         </Typography>
-        <DatePicker value={moment()} disabled />
+        <DatePicker value={new Date().toISOString()} disabled />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Error
         </Typography>
-        <DatePicker value={moment()} error />
+        <DatePicker value={new Date().toISOString()} error />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Read only
         </Typography>
-        <DatePicker value={moment()} readOnly />
+        <DatePicker value={new Date().toISOString()} readOnly />
       </div>
     </CalendarConfigProvider>
   );
@@ -173,7 +178,7 @@ export const Modes = () => {
           Day
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${valD?.format(getDefaultModeFormat('day'))}`}
+          {`current value: ${moment(valD).format(getDefaultModeFormat('day'))}`}
         </Typography>
         <DatePicker
           value={valD}
@@ -188,7 +193,7 @@ export const Modes = () => {
           Week
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${valW?.format(getDefaultModeFormat('week'))}`}
+          {`current value: ${moment(valW).format(getDefaultModeFormat('week'))}`}
         </Typography>
         <DatePicker
           value={valW}
@@ -203,7 +208,7 @@ export const Modes = () => {
           Month
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${valM?.format(getDefaultModeFormat('month'))}`}
+          {`current value: ${moment(valM).format(getDefaultModeFormat('month'))}`}
         </Typography>
         <DatePicker
           value={valM}
@@ -218,7 +223,7 @@ export const Modes = () => {
           Year
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${valY?.format(getDefaultModeFormat('year'))}`}
+          {`current value: ${moment(valY).format(getDefaultModeFormat('year'))}`}
         </Typography>
         <DatePicker
           value={valY}
@@ -248,7 +253,7 @@ export const CustomDisable = () => {
   const disabledYearsEnd = moment().year(moment().year() + 2);
 
   const isDateDisabled = (target: DateType) => (
-    target.isBetween(
+    moment(target).isBetween(
       disabledDatesStart,
       disabledDatesEnd,
       'day',
@@ -257,7 +262,7 @@ export const CustomDisable = () => {
   );
 
   const isMonthDisabled = (target: DateType) => (
-    target.isBetween(
+    moment(target).isBetween(
       disabledMonthsStart,
       disabledMonthsEnd,
       'month',
@@ -266,7 +271,7 @@ export const CustomDisable = () => {
   );
 
   const isYearDisabled = (target: DateType) => (
-    target.isBetween(
+    moment(target).isBetween(
       disabledYearsStart,
       disabledYearsEnd,
       'year',

--- a/packages/react/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -49,8 +49,8 @@ export const Playground: Story<PlaygroundArgs> = ({
       </Typography>
       <Typography variant="body1" style={typoStyle}>
         {`current value: [
-            ${val?.[0]?.format(getDefaultModeFormat(mode || 'day'))},
-            ${val?.[1]?.format(getDefaultModeFormat(mode || 'day'))}
+            ${moment(val?.[0]).format(getDefaultModeFormat(mode || 'day'))},
+            ${moment(val?.[1]).format(getDefaultModeFormat(mode || 'day'))}
           ]`}
       </Typography>
       <DateRangePicker
@@ -124,19 +124,19 @@ export const Basic = () => {
         <Typography variant="h5" style={typoStyle}>
           Disabled
         </Typography>
-        <DateRangePicker value={[moment(), moment()]} disabled />
+        <DateRangePicker value={[moment().toISOString(), moment().toISOString()]} disabled />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Error
         </Typography>
-        <DateRangePicker value={[moment(), moment()]} error />
+        <DateRangePicker value={[moment().toISOString(), moment().toISOString()]} error />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Read only
         </Typography>
-        <DateRangePicker value={[moment(), moment()]} readOnly />
+        <DateRangePicker value={[moment().toISOString(), moment().toISOString()]} readOnly />
       </div>
     </CalendarConfigProvider>
   );
@@ -189,8 +189,8 @@ export const Modes = () => {
         </Typography>
         <Typography variant="body1" style={typoStyle}>
           {`current value: [
-            ${valD?.[0]?.format(getDefaultModeFormat('day'))},
-            ${valD?.[1]?.format(getDefaultModeFormat('day'))}
+            ${moment(valD?.[0]).format(getDefaultModeFormat('day'))},
+            ${moment(valD?.[1]).format(getDefaultModeFormat('day'))}
           ]`}
         </Typography>
         <DateRangePicker
@@ -208,8 +208,8 @@ export const Modes = () => {
         </Typography>
         <Typography variant="body1" style={typoStyle}>
           {`current value: [
-            ${valW?.[0]?.format(getDefaultModeFormat('week'))},
-            ${valW?.[1]?.format(getDefaultModeFormat('week'))}
+            ${moment(valW?.[0]).format(getDefaultModeFormat('week'))},
+            ${moment(valW?.[1]).format(getDefaultModeFormat('week'))}
           ]`}
         </Typography>
         <DateRangePicker
@@ -227,8 +227,8 @@ export const Modes = () => {
         </Typography>
         <Typography variant="body1" style={typoStyle}>
           {`current value: [
-            ${valM?.[0]?.format(getDefaultModeFormat('month'))},
-            ${valM?.[1]?.format(getDefaultModeFormat('month'))}
+            ${moment(valM?.[0]).format(getDefaultModeFormat('month'))},
+            ${moment(valM?.[1]).format(getDefaultModeFormat('month'))}
           ]`}
         </Typography>
         <DateRangePicker
@@ -246,8 +246,8 @@ export const Modes = () => {
         </Typography>
         <Typography variant="body1" style={typoStyle}>
           {`current value: [
-            ${valY?.[0]?.format(getDefaultModeFormat('year'))},
-            ${valY?.[1]?.format(getDefaultModeFormat('year'))}
+            ${moment(valY?.[0]).format(getDefaultModeFormat('year'))},
+            ${moment(valY?.[1]).format(getDefaultModeFormat('year'))}
           ]`}
         </Typography>
         <DateRangePicker
@@ -279,7 +279,7 @@ export const CustomDisable = () => {
   const disabledYearsEnd = moment().year(moment().year() + 2);
 
   const isDateDisabled = (target: DateType) => (
-    target.isBetween(
+    moment(target).isBetween(
       disabledDatesStart,
       disabledDatesEnd,
       'day',
@@ -288,7 +288,7 @@ export const CustomDisable = () => {
   );
 
   const isMonthDisabled = (target: DateType) => (
-    target.isBetween(
+    moment(target).isBetween(
       disabledMonthsStart,
       disabledMonthsEnd,
       'month',
@@ -297,7 +297,7 @@ export const CustomDisable = () => {
   );
 
   const isYearDisabled = (target: DateType) => (
-    target.isBetween(
+    moment(target).isBetween(
       disabledYearsStart,
       disabledYearsEnd,
       'year',

--- a/packages/react/src/DateTimePicker/DateTimePicker.stories.tsx
+++ b/packages/react/src/DateTimePicker/DateTimePicker.stories.tsx
@@ -44,7 +44,7 @@ export const Playground: Story<PlaygroundArgs> = ({
   return (
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <Typography variant="h5" style={typoStyle}>
-        {`current value: ${val?.format(format)}`}
+        {`current value: ${moment(val).format(format)}`}
       </Typography>
       <DateTimePicker
         value={val}
@@ -122,19 +122,19 @@ export const Basic = () => {
         <Typography variant="h5" style={typoStyle}>
           Disabled
         </Typography>
-        <DateTimePicker value={moment()} disabled />
+        <DateTimePicker value={moment().toISOString()} disabled />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Error
         </Typography>
-        <DateTimePicker value={moment()} error />
+        <DateTimePicker value={moment().toISOString()} error />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Read only
         </Typography>
-        <DateTimePicker value={moment()} readOnly />
+        <DateTimePicker value={moment().toISOString()} readOnly />
       </div>
     </CalendarConfigProvider>
   );
@@ -188,7 +188,7 @@ export const DisplayColumn = () => {
           Hours, minutes, seconds
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${val1?.format(fullFormat)}`}
+          {`current value: ${moment(val1).format(fullFormat)}`}
         </Typography>
         <DateTimePicker
           value={val1}
@@ -202,7 +202,7 @@ export const DisplayColumn = () => {
           Hours, minutes
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${val2?.format(withoutSecondFormat)}`}
+          {`current value: ${moment(val2).format(withoutSecondFormat)}`}
         </Typography>
         <DateTimePicker
           value={val2}
@@ -217,7 +217,7 @@ export const DisplayColumn = () => {
           Hours
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${val3?.format(onlyHourFormat)}`}
+          {`current value: ${moment(val3).format(onlyHourFormat)}`}
         </Typography>
         <DateTimePicker
           value={val3}
@@ -243,7 +243,7 @@ export const CustomDisable = () => {
   const format = 'YYYY-MM-DD HH:mm:ss';
 
   const isDateDisabled = (target: DateType) => (
-    target.isBetween(
+    moment(target).isBetween(
       disabledDatesStart,
       disabledDatesEnd,
       'day',

--- a/packages/react/src/Picker/useRangePickerValue.spec.tsx
+++ b/packages/react/src/Picker/useRangePickerValue.spec.tsx
@@ -24,8 +24,8 @@ describe('useRangePickerValue', () => {
 
   describe('onChange', () => {
     it('case: valid value should be returned', () => {
-      const from = moment('2021-10-20');
-      const to = moment('2021-10-21');
+      const from = '2021-10-20';
+      const to = '2021-10-21';
       const inputFromRef = {
         current: document.createElement('input'),
       };
@@ -45,14 +45,14 @@ describe('useRangePickerValue', () => {
       TestRenderer.act(() => {
         const sortedValue = result.current.onChange([from, to]);
 
-        expect(sortedValue?.[0]?.isSame(from, 'day'));
-        expect(sortedValue?.[1]?.isSame(to, 'day'));
+        expect(sortedValue?.[0] ? moment(sortedValue[0]).isSame(from, 'day') : false);
+        expect(sortedValue?.[1] ? moment(sortedValue[1]).isSame(to, 'day') : false);
       });
     });
 
     it('case: wrong ordered value should be sorted in returned value', () => {
-      const from = moment('2021-10-21');
-      const to = moment('2021-10-20');
+      const from = '2021-10-21';
+      const to = '2021-10-20';
       const inputFromRef = {
         current: document.createElement('input'),
       };
@@ -72,13 +72,13 @@ describe('useRangePickerValue', () => {
       TestRenderer.act(() => {
         const sortedValue = result.current.onChange([from, to]);
 
-        expect(sortedValue?.[0]?.isSame(to, 'day'));
-        expect(sortedValue?.[1]?.isSame(from, 'day'));
+        expect(sortedValue?.[0] ? moment(sortedValue[0]).isSame(from, 'day') : false);
+        expect(sortedValue?.[1] ? moment(sortedValue[1]).isSame(to, 'day') : false);
       });
     });
 
     it('case: value with only from should be returned with [from, undefind]', () => {
-      const from = moment('2021-10-20');
+      const from = '2021-10-20';
       const inputFromRef = {
         current: document.createElement('input'),
       };
@@ -99,13 +99,13 @@ describe('useRangePickerValue', () => {
         const sortedValue = result.current.onChange([from, undefined]);
 
         expect(sortedValue).toBeInstanceOf(Array);
-        expect(sortedValue?.[0]?.isSame(from, 'day'));
+        expect(sortedValue?.[0] ? moment(sortedValue[0]).isSame(from, 'day') : false);
         expect(sortedValue?.[1]).toBe(undefined);
       });
     });
 
     it('case: value with only to should be returned with [undefined, to]', () => {
-      const to = moment('2021-10-20');
+      const to = '2021-10-20';
       const inputFromRef = {
         current: document.createElement('input'),
       };
@@ -127,7 +127,7 @@ describe('useRangePickerValue', () => {
 
         expect(sortedValue).toBeInstanceOf(Array);
         expect(sortedValue?.[0]).toBe(undefined);
-        expect(sortedValue?.[1]?.isSame(to, 'day'));
+        expect(sortedValue?.[1] ? moment(sortedValue[1]).isSame(to, 'day') : false);
       });
     });
 

--- a/packages/react/src/Picker/useRangePickerValue.spec.tsx
+++ b/packages/react/src/Picker/useRangePickerValue.spec.tsx
@@ -204,13 +204,13 @@ describe('useRangePickerValue', () => {
         result.current.onInputFromChange({ target: { value: '2021-10-20' } } as ChangeEvent<HTMLInputElement>);
       });
 
-      expect(result.current.value[0]?.format('YYYY-MM-DD')).toBe('2021-10-20');
+      expect(moment(result.current.value[0]).format('YYYY-MM-DD')).toBe('2021-10-20');
 
       TestRenderer.act(() => {
         result.current.onInputToChange({ target: { value: '2021-10-17' } } as ChangeEvent<HTMLInputElement>);
       });
 
-      expect(result.current.value[1]?.format('YYYY-MM-DD')).toBe('2021-10-17');
+      expect(moment(result.current.value[1]).format('YYYY-MM-DD')).toBe('2021-10-17');
       expect(result.current.value[0]).toBe(undefined);
     });
 
@@ -235,13 +235,13 @@ describe('useRangePickerValue', () => {
         result.current.onInputToChange({ target: { value: '2021-10-20' } } as ChangeEvent<HTMLInputElement>);
       });
 
-      expect(result.current.value[1]?.format('YYYY-MM-DD')).toBe('2021-10-20');
+      expect(moment(result.current.value[1]).format('YYYY-MM-DD')).toBe('2021-10-20');
 
       TestRenderer.act(() => {
         result.current.onInputFromChange({ target: { value: '2021-10-21' } } as ChangeEvent<HTMLInputElement>);
       });
 
-      expect(result.current.value[0]?.format('YYYY-MM-DD')).toBe('2021-10-21');
+      expect(moment(result.current.value[0]).format('YYYY-MM-DD')).toBe('2021-10-21');
       expect(result.current.value[1]).toBe(undefined);
     });
   });

--- a/packages/react/src/TimePanel/TimePanel.spec.tsx
+++ b/packages/react/src/TimePanel/TimePanel.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import { CalendarMethodsMoment, DateType } from '@mezzanine-ui/core/calendar';
-import moment, { Moment } from 'moment';
+import moment from 'moment';
 import { getUnitLabel } from '@mezzanine-ui/core/time-panel';
 import {
   cleanup,
@@ -147,7 +147,7 @@ describe('<TimePanel />', () => {
     describe('column controls', () => {
       // eslint-disable-next-line max-len
       it('controls should fire onChange with `DateType` that indicates start of day as its argument if no value', () => {
-        function isStartOfDay(val: Moment) {
+        function isStartOfDay(val: string) {
           const valTimeString = moment(val).format('HH:mm:ss');
 
           return valTimeString === moment().startOf('day').format('HH:mm:ss');
@@ -186,14 +186,14 @@ describe('<TimePanel />', () => {
 
         for (let i = 0; i < 24; i += 1) {
           it(`prev control at ${getUnitLabel(i, 2)}:00:00`, () => {
-            const displayHour = moment().startOf('day').hour(i);
+            const displayHour = moment().startOf('day').hour(i).format('YYYY-MM-DD HH:mm:ss');
             const prevHour = (i - 1 >= 0 ? i - 1 : 24 + i - 1) % 24;
-            const expectHour = moment().startOf('day').hour(prevHour);
+            const expectHour = moment().startOf('day').hour(prevHour).format('YYYY-MM-DD HH:mm:ss');
 
-            function isSameTime(val: Moment) {
-              const valTimeString = moment(val).format('HH:mm:ss');
+            function isSameTime(val: string) {
+              const valTimeString = moment(val).format('YYYY-MM-DD HH:mm:ss');
 
-              return valTimeString === expectHour.format('HH:mm:ss');
+              return valTimeString === expectHour;
             }
 
             const onChange = jest.fn(isSameTime);
@@ -211,14 +211,14 @@ describe('<TimePanel />', () => {
           });
 
           it(`next control at ${getUnitLabel(i, 2)}:00:00`, () => {
-            const displayHour = moment().startOf('day').hour(i);
+            const displayHour = moment().startOf('day').hour(i).format('YYYY-MM-DD HH:mm:ss');
             const nextHour = (i + 1 >= 0 ? i + 1 : 24 + i + 1) % 24;
-            const expectHour = moment().startOf('day').hour(nextHour);
+            const expectHour = moment().startOf('day').hour(nextHour).format('YYYY-MM-DD HH:mm:ss');
 
-            function isSameTime(val: Moment) {
-              const valTimeString = moment(val).format('HH:mm:ss');
+            function isSameTime(val: string) {
+              const valTimeString = moment(val).format('YYYY-MM-DD HH:mm:ss');
 
-              return valTimeString === expectHour.format('HH:mm:ss');
+              return valTimeString === expectHour;
             }
 
             const onChange = jest.fn(isSameTime);
@@ -262,7 +262,7 @@ describe('<TimePanel />', () => {
         const expectHour = moment().startOf('day').hour(i);
 
         it(`should get ${getUnitLabel(i, 2)}:00:00`, () => {
-          function isSameTime(val: Moment) {
+          function isSameTime(val: string) {
             const valTimeString = moment(val).format('HH:mm:ss');
 
             return valTimeString === expectHour.format('HH:mm:ss');

--- a/packages/react/src/TimePanel/TimePanel.spec.tsx
+++ b/packages/react/src/TimePanel/TimePanel.spec.tsx
@@ -148,7 +148,7 @@ describe('<TimePanel />', () => {
       // eslint-disable-next-line max-len
       it('controls should fire onChange with `DateType` that indicates start of day as its argument if no value', () => {
         function isStartOfDay(val: Moment) {
-          const valTimeString = val.format('HH:mm:ss');
+          const valTimeString = moment(val).format('HH:mm:ss');
 
           return valTimeString === moment().startOf('day').format('HH:mm:ss');
         }
@@ -191,7 +191,7 @@ describe('<TimePanel />', () => {
             const expectHour = moment().startOf('day').hour(prevHour);
 
             function isSameTime(val: Moment) {
-              const valTimeString = val.format('HH:mm:ss');
+              const valTimeString = moment(val).format('HH:mm:ss');
 
               return valTimeString === expectHour.format('HH:mm:ss');
             }
@@ -216,7 +216,7 @@ describe('<TimePanel />', () => {
             const expectHour = moment().startOf('day').hour(nextHour);
 
             function isSameTime(val: Moment) {
-              const valTimeString = val.format('HH:mm:ss');
+              const valTimeString = moment(val).format('HH:mm:ss');
 
               return valTimeString === expectHour.format('HH:mm:ss');
             }
@@ -263,7 +263,7 @@ describe('<TimePanel />', () => {
 
         it(`should get ${getUnitLabel(i, 2)}:00:00`, () => {
           function isSameTime(val: Moment) {
-            const valTimeString = val.format('HH:mm:ss');
+            const valTimeString = moment(val).format('HH:mm:ss');
 
             return valTimeString === expectHour.format('HH:mm:ss');
           }

--- a/packages/react/src/TimePicker/TimePicker.stories.tsx
+++ b/packages/react/src/TimePicker/TimePicker.stories.tsx
@@ -10,9 +10,9 @@ export default {
   title: 'Data Entry/TimePicker',
 } as Meta;
 
-function usePickerChange() {
-  const [val, setVal] = useState<DateType>();
-  const onChange = (v?: DateType) => { setVal(v); };
+function usePickerChange<T = DateType>() {
+  const [val, setVal] = useState<T>();
+  const onChange = (v?: T) => { setVal(v); };
 
   return [val, onChange] as const;
 }
@@ -45,7 +45,7 @@ export const Playground: Story<PlaygroundArgs> = ({
   return (
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <Typography variant="h5" style={typoStyle}>
-        {`current value: ${val?.format(format)}`}
+        {`current value: ${moment(val).format(format)}`}
       </Typography>
       <TimePicker
         value={val}
@@ -125,19 +125,19 @@ export const Basic = () => {
         <Typography variant="h5" style={typoStyle}>
           Disabled
         </Typography>
-        <TimePicker value={moment()} disabled />
+        <TimePicker value={moment().toISOString()} disabled />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Error
         </Typography>
-        <TimePicker value={moment()} error />
+        <TimePicker value={moment().toISOString()} error />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
           Read only
         </Typography>
-        <TimePicker value={moment()} readOnly />
+        <TimePicker value={moment().toISOString()} readOnly />
       </div>
     </CalendarConfigProvider>
   );
@@ -188,7 +188,7 @@ export const DisplayColumn = () => {
           Hours, minutes, seconds
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${val1?.format('HH:mm:ss')}`}
+          {`current value: ${moment(val1).format('HH:mm:ss')}`}
         </Typography>
         <TimePicker
           value={val1}
@@ -202,7 +202,7 @@ export const DisplayColumn = () => {
           Hours, minutes
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${val2?.format('HH:mm')}`}
+          {`current value: ${moment(val2).format('HH:mm')}`}
         </Typography>
         <TimePicker
           value={val2}
@@ -217,7 +217,7 @@ export const DisplayColumn = () => {
           Hours
         </Typography>
         <Typography variant="body1" style={typoStyle}>
-          {`current value: ${val3?.format('HH')}`}
+          {`current value: ${moment(val3).format('HH')}`}
         </Typography>
         <TimePicker
           value={val3}


### PR DESCRIPTION
- 修改 DateType 為 Iso8601 的 string (fix #155)
- 調整 calendar/presets/moment.ts 的 CalendarMethods 使其相容 Moment 與 string 輸入
- 修復所有日期相關的元件內, 有假設輸入資料的型別為 Moment 的測試

![image](https://user-images.githubusercontent.com/83571075/154466291-3e4611c7-b65a-4b0c-8191-18900ff52cc4.png)
![image](https://user-images.githubusercontent.com/83571075/154466408-cb5b983d-8dc4-4bc0-af79-a8d2163737f7.png)
