### PR TITLE
fix(react/modal-actions): modal-actions loading priority, closed #190

### DIFF
--- a/packages/react/src/Modal/ModalActions.tsx
+++ b/packages/react/src/Modal/ModalActions.tsx
@@ -36,6 +36,10 @@ const ModalActions = forwardRef<HTMLDivElement, ModalActionsProps>(function Moda
     ...rest
   } = props;
   const {
+    loading: confirmButtonLoading,
+    ...restConfirmButtonProps
+  } = confirmButtonProps || {};
+  const {
     loading,
     severity,
   } = useContext(ModalControlContext);
@@ -51,12 +55,12 @@ const ModalActions = forwardRef<HTMLDivElement, ModalActionsProps>(function Moda
         cancelButtonProps={cancelButtonProps}
         cancelText={cancelText}
         className={classes.actions}
-        confirmButtonProps={confirmButtonProps}
+        confirmButtonProps={restConfirmButtonProps}
         confirmText={confirmText}
         danger={danger}
         hideCancelButton={hideCancelButton}
         hideConfirmButton={hideConfirmButton}
-        loading={loading}
+        loading={confirmButtonLoading ?? loading}
         onCancel={onCancel}
         onConfirm={onConfirm}
       />


### PR DESCRIPTION
Add the props from `confirmButtonProps={{ loading: loading }}` to `<ModalActions />`.
And adjust the priority to 

> **Higher.** `<ModalActions confirmButtonProps={{ loading: loading }} />`
> Lower. `<Modal loading={loading} />`