### PR TITLE
feat(react/select): allow generic on SelectValue id type

### DIFF
--- a/packages/react/src/Select/typings.ts
+++ b/packages/react/src/Select/typings.ts
@@ -1,14 +1,14 @@
-export interface SelectValue {
-  id: string;
+export interface SelectValue<T = string> {
+  id: T;
   name: string;
 }
 
-export interface TreeSelectOption extends SelectValue {
+export interface TreeSelectOption<T = string> extends SelectValue<T> {
   dynamicChildrenFetching?: boolean;
-  siblings?: TreeSelectOption[]
+  siblings?: TreeSelectOption<T>[]
 }
 
-export interface SelectControl {
-  value: SelectValue[] | SelectValue | null;
-  onChange: (v: SelectValue | null) => SelectValue[] | SelectValue | null;
+export interface SelectControl<T = string> {
+  value: SelectValue<T>[] | SelectValue<T> | null;
+  onChange: (v: SelectValue<T> | null) => SelectValue<T>[] | SelectValue<T> | null;
 }


### PR DESCRIPTION
Allow generic on SelectValue type

e.g.
```typescript
enum Status {
  NORMAL = 'NORMAL',
  ARCHIVED = 'ARCHIVED'
}

const options = [{
  id: Status.NORMAL,
  name: 'Normal',
}, {
  id: Status.ARCHIVED,
  name: 'Archived',
}] as SelectValue<Status>;
```