### PR TITLE
Bug fixing for Calendar components and some new features

### DIFF
--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -167,6 +167,8 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(pro
     displayCalendar = (
       <CalendarDays
         {...calendarDaysProps}
+        isYearDisabled={isYearDisabled}
+        isMonthDisabled={isMonthDisabled}
         isDateDisabled={isDateDisabled}
         isDateInRange={isDateInRange}
         onClick={onChange}
@@ -180,6 +182,8 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(pro
     displayCalendar = (
       <CalendarWeeks
         {...calendarWeeksProps}
+        isYearDisabled={isYearDisabled}
+        isMonthDisabled={isMonthDisabled}
         isWeekDisabled={isWeekDisabled}
         isWeekInRange={isWeekInRange}
         onClick={onChange}
@@ -193,6 +197,7 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(pro
     displayCalendar = (
       <CalendarMonths
         {...calendarMonthsProps}
+        isYearDisabled={isYearDisabled}
         isMonthDisabled={isMonthDisabled}
         isMonthInRange={isMonthInRange}
         onClick={onChange}

--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -75,6 +75,16 @@ export interface CalendarProps
   | 'isYearInRange'
   | 'onYearHover'>;
   /**
+   * Disabled `Month` calendar button click
+   * @default false
+   */
+  disabledMonthSwitch?: boolean;
+  /**
+   * Disabled `Year` calendar button click
+   * @default false
+   */
+  disabledYearSwitch?: boolean;
+  /**
    * Use this prop to switch calendars.
    * @default 'day'
    */
@@ -131,8 +141,10 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(pro
     calendarWeeksProps,
     calendarYearsProps,
     className,
+    disabledMonthSwitch,
     disableOnNext,
     disableOnPrev,
+    disabledYearSwitch,
     displayMonthLocale = displayMonthLocaleFromConfig,
     displayWeekDayLocale,
     isDateDisabled,
@@ -230,14 +242,26 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(pro
       <>
         <button
           type="button"
-          className={cx(classes.button, classes.controlsButton)}
+          className={cx(
+            classes.button,
+            classes.controlsButton,
+            disabledMonthSwitch && classes.buttonDisabled,
+          )}
+          disabled={disabledMonthSwitch}
+          aria-disabled={disabledMonthSwitch}
           onClick={onMonthControlClick}
         >
           {getMonthShortName(getMonth(referenceDate), displayMonthLocale)}
         </button>
         <button
           type="button"
-          className={cx(classes.button, classes.controlsButton)}
+          className={cx(
+            classes.button,
+            classes.controlsButton,
+            disabledYearSwitch && classes.buttonDisabled,
+          )}
+          disabled={disabledYearSwitch}
+          aria-disabled={disabledYearSwitch}
           onClick={onYearControlClick}
         >
           {getYear(referenceDate)}
@@ -248,7 +272,13 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(pro
     controls = (
       <button
         type="button"
-        className={cx(classes.button, classes.controlsButton)}
+        className={cx(
+          classes.button,
+          classes.controlsButton,
+          disabledYearSwitch && classes.buttonDisabled,
+        )}
+        disabled={disabledYearSwitch}
+        aria-disabled={disabledYearSwitch}
         onClick={onYearControlClick}
       >
         {getYear(referenceDate)}

--- a/packages/react/src/Calendar/CalendarDays.tsx
+++ b/packages/react/src/Calendar/CalendarDays.tsx
@@ -8,10 +8,14 @@ import { NativeElementPropsWithoutKeyAndRef } from '../utils/jsx-types';
 import { cx } from '../utils/cx';
 import CalendarDayOfWeek, { CalendarDayOfWeekProps } from './CalendarDayOfWeek';
 import { useCalendarContext } from './CalendarContext';
+import type { CalendarYearsProps } from './CalendarYears';
+import type { CalendarMonthsProps } from './CalendarMonths';
 
 export interface CalendarDaysProps
   extends
   Pick<CalendarDayOfWeekProps, 'displayWeekDayLocale'>,
+  Pick<CalendarYearsProps, 'isYearDisabled'>,
+  Pick<CalendarMonthsProps, 'isMonthDisabled'>,
   Omit<NativeElementPropsWithoutKeyAndRef<'div'>, 'onClick' | 'children'> {
   /**
    * Provide if you have a custom disabling logic. The method takes the date object as its parameter.
@@ -60,6 +64,8 @@ function CalendarDays(props: CalendarDaysProps) {
   const {
     className,
     displayWeekDayLocale = displayWeekDayLocaleFromConfig,
+    isYearDisabled,
+    isMonthDisabled,
     isDateDisabled,
     isDateInRange,
     onClick: onClickProp,
@@ -98,7 +104,7 @@ function CalendarDays(props: CalendarDaysProps) {
                   ? thisMonth + 1
                   : thisMonth;
               const date = setDate(setMonth(referenceDate, month), dateNum);
-              const disabled = isDateDisabled && isDateDisabled(date);
+              const disabled = (isYearDisabled?.(date) || isMonthDisabled?.(date) || isDateDisabled?.(date)) || false;
               const inactive = !disabled && (isPrevMonth || isNextMonth);
               const inRange = !inactive && isDateInRange && isDateInRange(date);
               const active = !disabled && !inactive && value && isDateIncluded(date, value);

--- a/packages/react/src/Calendar/CalendarMonths.tsx
+++ b/packages/react/src/Calendar/CalendarMonths.tsx
@@ -3,13 +3,15 @@ import {
   DateType,
   calendarMonths,
 } from '@mezzanine-ui/core/calendar';
+import type { CalendarYearsProps } from './CalendarYears';
 import { cx } from '../utils/cx';
 import { NativeElementPropsWithoutKeyAndRef } from '../utils/jsx-types';
 import { useCalendarContext } from './CalendarContext';
 
 export interface CalendarMonthsProps
   extends
-  Omit<NativeElementPropsWithoutKeyAndRef<'div'>, 'onClick' | 'children'> {
+  Omit<NativeElementPropsWithoutKeyAndRef<'div'>, 'onClick' | 'children'>,
+  Pick<CalendarYearsProps, 'isYearDisabled'> {
   /**
    * The locale you want to use when rendering the names of month.
    * If none provided, it will use the `displayMonthLocale` from calendar context.
@@ -59,6 +61,7 @@ function CalendarMonths(props: CalendarMonthsProps) {
     displayMonthLocale = displayMonthLocaleFromConfig,
     isMonthDisabled,
     isMonthInRange,
+    isYearDisabled,
     onClick: onClickProp,
     onMonthHover,
     referenceDate,
@@ -80,7 +83,8 @@ function CalendarMonths(props: CalendarMonthsProps) {
         {calendarMonths.map((month) => {
           const monthDateType = setMonth(referenceDate, month);
           const active = value && isMonthIncluded(monthDateType, value);
-          const disabled = isMonthDisabled && isMonthDisabled(monthDateType);
+          /** @NOTE Current month should be disabled when current year is disabled */
+          const disabled = (isYearDisabled?.(monthDateType) || isMonthDisabled?.(monthDateType)) || false;
           const inRange = isMonthInRange && isMonthInRange(monthDateType);
 
           const onClick = onClickProp ? () => { onClickProp(monthDateType); } : undefined;

--- a/packages/react/src/Calendar/CalendarWeeks.tsx
+++ b/packages/react/src/Calendar/CalendarWeeks.tsx
@@ -8,10 +8,14 @@ import { NativeElementPropsWithoutKeyAndRef } from '../utils/jsx-types';
 import { cx } from '../utils/cx';
 import CalendarDayOfWeek, { CalendarDayOfWeekProps } from './CalendarDayOfWeek';
 import { useCalendarContext } from './CalendarContext';
+import type { CalendarYearsProps } from './CalendarYears';
+import type { CalendarMonthsProps } from './CalendarMonths';
 
 export interface CalendarWeeksProps
   extends
   Pick<CalendarDayOfWeekProps, 'displayWeekDayLocale'>,
+  Pick<CalendarYearsProps, 'isYearDisabled'>,
+  Pick<CalendarMonthsProps, 'isMonthDisabled'>,
   Omit<NativeElementPropsWithoutKeyAndRef<'div'>, 'onClick' | 'children'> {
   /**
    * Provide if you have a custom disabling logic.
@@ -64,6 +68,8 @@ function CalendarWeeks(props: CalendarWeeksProps) {
   const {
     className,
     displayWeekDayLocale = displayWeekDayLocaleFromConfig,
+    isYearDisabled,
+    isMonthDisabled,
     isWeekDisabled,
     isWeekInRange,
     onClick: onClickProp,
@@ -105,7 +111,7 @@ function CalendarWeeks(props: CalendarWeeksProps) {
             dates.push(date);
           });
 
-          const disabled = isWeekDisabled && isWeekDisabled(dates[0]);
+          const disabled = (isYearDisabled?.(dates[0]) || isMonthDisabled?.(dates[0]) || isWeekDisabled?.(dates[0])) || false;
           const inactive = !disabled && (weekStartInPrevMonth || weekStartInNextMonth);
           const active = !disabled && !inactive && value && isWeekIncluded(dates[0], value);
           const inRange = !disabled && !inactive && isWeekInRange && isWeekInRange(dates[0]);

--- a/packages/react/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/DatePicker/DatePicker.stories.tsx
@@ -6,7 +6,7 @@ import {
 import CalendarMethodsDayjs from '@mezzanine-ui/core/calendarMethodsDayjs';
 import CalendarMethodsMoment from '@mezzanine-ui/core/calendarMethodsMoment';
 import CalendarMethodsLuxon from '@mezzanine-ui/core/calendarMethodsLuxon';
-import { useState } from 'react';
+import { CSSProperties, useState } from 'react';
 import moment from 'moment';
 import DatePicker, { DatePickerProps } from './DatePicker';
 import Typography from '../Typography';
@@ -18,7 +18,7 @@ export default {
 } as Meta;
 
 function usePickerChange() {
-  const [val, setVal] = useState<DateType | undefined>('2022-01-05');
+  const [val, setVal] = useState<DateType | undefined>(new Date().toISOString());
   const onChange = (v?: DateType) => { setVal(v); };
 
   return [val, onChange] as const;
@@ -135,7 +135,7 @@ export const Basic = () => {
 export const Method = () => {
   const containerStyle = { margin: '0 0 24px 0' };
   const typoStyle = { margin: '0 0 12px 0' };
-  const [val, setVal] = useState<DateType>(new Date());
+  const [val, setVal] = useState<DateType | undefined>(new Date().toISOString());
   const onChange = (v?: DateType) => { setVal(v); };
 
   return (
@@ -277,24 +277,36 @@ export const Modes = () => {
 
 export const CustomDisable = () => {
   const containerStyle = { margin: '0 0 24px 0' };
-  const typoStyle = { margin: '0 0 12px 0' };
+  const typoStyle = { margin: '0 0 12px 0', whiteSpace: 'pre-line' } as CSSProperties;
   const [valD, onChangeD] = usePickerChange();
+  const [valW, onChangeW] = usePickerChange();
   const [valM, onChangeM] = usePickerChange();
   const [valY, onChangeY] = usePickerChange();
 
   // We use moment.date  instead of moment.add is because storybook currently has internal conflict with the method.
-  const disabledDatesStart = moment().date(moment().date() - 7);
+  const disabledDatesStart = moment().date(moment().date() + 3);
   const disabledDatesEnd = moment().date(moment().date() + 7);
-  const disabledMonthsStart = moment().month(moment().month() - 2);
-  const disabledMonthsEnd = moment().month(moment().month() + 2);
-  const disabledYearsStart = moment().year(moment().year() - 2);
-  const disabledYearsEnd = moment().year(moment().year() + 2);
+  const disabledWeeksStart = moment().week(moment().week() - 5);
+  const disabledWeeksEnd = moment().week(moment().week() - 2);
+  const disabledMonthsStart = moment().month(moment().month() - 5);
+  const disabledMonthsEnd = moment().month(moment().month() - 1);
+  const disabledYearsStart = moment().year(moment().year() - 20);
+  const disabledYearsEnd = moment().year(moment().year() - 1);
 
   const isDateDisabled = (target: DateType) => (
     moment(target).isBetween(
       disabledDatesStart,
       disabledDatesEnd,
       'day',
+      '[]',
+    )
+  );
+
+  const isWeekDisabled = (target: DateType) => (
+    moment(target).isBetween(
+      disabledWeeksStart,
+      disabledWeeksEnd,
+      'week',
       '[]',
     )
   );
@@ -321,7 +333,11 @@ export const CustomDisable = () => {
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
-          {`Disabled Dates: ${disabledDatesStart.format('YYYY-MM-DD')} ~ ${disabledDatesEnd.format('YYYY-MM-DD')}`}
+          {`(mode='day') Disabled
+            Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
+            Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}
+            Dates: ${disabledDatesStart.format('YYYY-MM-DD')} ~ ${disabledDatesEnd.format('YYYY-MM-DD')}
+          `}
         </Typography>
         <DatePicker
           value={valD}
@@ -330,33 +346,67 @@ export const CustomDisable = () => {
           format="YYYY-MM-DD"
           placeholder="YYYY-MM-DD"
           isDateDisabled={isDateDisabled}
+          isMonthDisabled={isMonthDisabled}
+          isYearDisabled={isYearDisabled}
         />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
-          {`Disabled Months:
-          ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}`}
+          {`(mode='week') Disabled
+          Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
+          Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}
+          Weeks: ${disabledWeeksStart.format(getDefaultModeFormat('week'))} ~ ${disabledWeeksEnd.format(getDefaultModeFormat('week'))}`}
+        </Typography>
+        <DatePicker
+          value={valW}
+          onChange={onChangeW}
+          mode="week"
+          format={getDefaultModeFormat('week')}
+          placeholder={getDefaultModeFormat('week')}
+          isYearDisabled={isYearDisabled}
+          isMonthDisabled={isMonthDisabled}
+          isWeekDisabled={isWeekDisabled}
+        />
+      </div>
+      <div style={containerStyle}>
+        <Typography variant="h5" style={typoStyle}>
+          {`(mode='day') Disabled Dates:
+          ${disabledDatesStart.format(getDefaultModeFormat('day'))} ~ ${disabledDatesEnd.format(getDefaultModeFormat('day'))}`}
+        </Typography>
+        <DatePicker
+          value={valD}
+          onChange={onChangeD}
+          mode="day"
+          format={getDefaultModeFormat('day')}
+          placeholder={getDefaultModeFormat('day')}
+          isDateDisabled={isDateDisabled}
+        />
+      </div>
+      <div style={containerStyle}>
+        <Typography variant="h5" style={typoStyle}>
+          {`(mode='month') Disabled Months:
+          ${disabledMonthsStart.format(getDefaultModeFormat('month'))} ~ ${disabledMonthsEnd.format(getDefaultModeFormat('month'))}`}
         </Typography>
         <DatePicker
           value={valM}
           onChange={onChangeM}
           mode="month"
-          format="YYYY-MM"
-          placeholder="YYYY-MM"
+          format={getDefaultModeFormat('month')}
+          placeholder={getDefaultModeFormat('month')}
           isMonthDisabled={isMonthDisabled}
         />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
-          {`Disabled Years:
-          ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}`}
+          {`(mode='year') Disabled Years:
+          ${disabledYearsStart.format(getDefaultModeFormat('year'))} ~ ${disabledYearsEnd.format(getDefaultModeFormat('year'))}`}
         </Typography>
         <DatePicker
           value={valY}
           onChange={onChangeY}
           mode="year"
-          format="YYYY"
-          placeholder="YYYY"
+          format={getDefaultModeFormat('year')}
+          placeholder={getDefaultModeFormat('year')}
           isYearDisabled={isYearDisabled}
         />
       </div>

--- a/packages/react/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/DatePicker/DatePicker.stories.tsx
@@ -333,6 +333,26 @@ export const CustomDisable = () => {
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
+          {`(mode='day')
+          disabledMonthSwitch = true
+          disabledYearSwitch = true
+          disableOnNext = true
+          disableOnPrev = true`}
+        </Typography>
+        <DatePicker
+          value={valD}
+          onChange={onChangeD}
+          mode="day"
+          format="YYYY-MM-DD"
+          placeholder="YYYY-MM-DD"
+          disabledMonthSwitch
+          disabledYearSwitch
+          disableOnNext
+          disableOnPrev
+        />
+      </div>
+      <div style={containerStyle}>
+        <Typography variant="h5" style={typoStyle}>
           {`(mode='day') Disabled
             Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
             Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -104,6 +104,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       inputProps,
       isDateDisabled,
       isMonthDisabled,
+      isWeekDisabled,
       isYearDisabled,
       mode = 'day',
       onCalendarToggle: onCalendarToggleProp,
@@ -305,6 +306,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           fadeProps={fadeProps}
           isDateDisabled={isDateDisabled}
           isMonthDisabled={isMonthDisabled}
+          isWeekDisabled={isWeekDisabled}
           isYearDisabled={isYearDisabled}
           mode={mode}
           onChange={onCalendarChange}

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -93,8 +93,10 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       className,
       clearable = true,
       defaultValue,
+      disabledMonthSwitch = false,
       disableOnNext,
       disableOnPrev,
+      disabledYearSwitch = false,
       disabled = disabledFromFormControl || false,
       displayMonthLocale,
       error = severity === 'error' || false,
@@ -300,8 +302,10 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           ref={calendarRef}
           anchor={anchorRef}
           calendarProps={calendarProps}
+          disabledMonthSwitch={disabledMonthSwitch}
           disableOnNext={disableOnNext}
           disableOnPrev={disableOnPrev}
+          disabledYearSwitch={disabledYearSwitch}
           displayMonthLocale={displayMonthLocale}
           fadeProps={fadeProps}
           isDateDisabled={isDateDisabled}

--- a/packages/react/src/DatePicker/DatePickerCalendar.tsx
+++ b/packages/react/src/DatePicker/DatePickerCalendar.tsx
@@ -20,6 +20,7 @@ export interface DatePickerCalendarProps
   | 'displayMonthLocale'
   | 'isDateDisabled'
   | 'isMonthDisabled'
+  | 'isWeekDisabled'
   | 'isYearDisabled'
   | 'onChange'
   | 'referenceDate'> {
@@ -89,6 +90,7 @@ const DatePickerCalendar = forwardRef<HTMLDivElement, DatePickerCalendarProps>(
       fadeProps,
       isDateDisabled,
       isMonthDisabled,
+      isWeekDisabled,
       isYearDisabled,
       mode = 'day',
       onChange: onChangeProp,
@@ -182,6 +184,7 @@ const DatePickerCalendar = forwardRef<HTMLDivElement, DatePickerCalendarProps>(
           displayMonthLocale={displayMonthLocale}
           isDateDisabled={isDateDisabled}
           isMonthDisabled={isMonthDisabled}
+          isWeekDisabled={isWeekDisabled}
           isYearDisabled={isYearDisabled}
           mode={currentMode}
           onChange={onChange}

--- a/packages/react/src/DatePicker/DatePickerCalendar.tsx
+++ b/packages/react/src/DatePicker/DatePickerCalendar.tsx
@@ -15,8 +15,10 @@ export interface DatePickerCalendarProps
   | 'open'
   >,
   Pick<CalendarProps,
+  | 'disabledMonthSwitch'
   | 'disableOnNext'
   | 'disableOnPrev'
+  | 'disabledYearSwitch'
   | 'displayMonthLocale'
   | 'isDateDisabled'
   | 'isMonthDisabled'
@@ -33,6 +35,7 @@ export interface DatePickerCalendarProps
   | 'displayMonthLocale'
   | 'isDateDisabled'
   | 'isMonthDisabled'
+  | 'isWeekDisabled'
   | 'isYearDisabled'
   | 'locale'
   | 'mode'
@@ -84,8 +87,10 @@ const DatePickerCalendar = forwardRef<HTMLDivElement, DatePickerCalendarProps>(
       anchor,
       calendarProps,
       calendarRef,
+      disabledMonthSwitch,
       disableOnNext,
       disableOnPrev,
+      disabledYearSwitch,
       displayMonthLocale = displayMonthLocaleFromConfig,
       fadeProps,
       isDateDisabled,
@@ -179,8 +184,10 @@ const DatePickerCalendar = forwardRef<HTMLDivElement, DatePickerCalendarProps>(
           {...restCalendarProps}
           ref={calendarRef}
           className={calendarClassName}
+          disabledMonthSwitch={disabledMonthSwitch}
           disableOnNext={disableOnNext}
           disableOnPrev={disableOnPrev}
+          disabledYearSwitch={disabledYearSwitch}
           displayMonthLocale={displayMonthLocale}
           isDateDisabled={isDateDisabled}
           isMonthDisabled={isMonthDisabled}

--- a/packages/react/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -353,6 +353,27 @@ export const CustomDisable = () => {
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
+          {`(mode='day')
+          disabledMonthSwitch = true
+          disabledYearSwitch = true
+          disableOnNext = true
+          disableOnPrev = true`}
+        </Typography>
+        <DateRangePicker
+          value={valD}
+          onChange={onChangeD}
+          mode="day"
+          format="YYYY-MM-DD"
+          inputFromPlaceholder="Start Date"
+          inputToPlaceholder="End Date"
+          disabledMonthSwitch
+          disabledYearSwitch
+          disableOnNext
+          disableOnPrev
+        />
+      </div>
+      <div style={containerStyle}>
+        <Typography variant="h5" style={typoStyle}>
           {`(mode='day') Disabled
             Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
             Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}

--- a/packages/react/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from '@mezzanine-ui/core/calendar';
 import CalendarMethodsDayjs from '@mezzanine-ui/core/calendarMethodsDayjs';
 import CalendarMethodsMoment from '@mezzanine-ui/core/calendarMethodsMoment';
-import { useState } from 'react';
+import { CSSProperties, useState } from 'react';
 import moment from 'moment';
 import { RangePickerValue } from '@mezzanine-ui/core/picker';
 import DateRangePicker from '.';
@@ -296,24 +296,37 @@ export const Modes = () => {
 
 export const CustomDisable = () => {
   const containerStyle = { margin: '0 0 36px 0' };
-  const typoStyle = { margin: '0 0 8px 0' };
+  const typoStyle = { margin: '0 0 8px 0', whiteSpace: 'pre-line' } as CSSProperties;
+  const [valMix, onChangeMix] = usePickerChange();
   const [valD, onChangeD] = usePickerChange();
+  const [valW, onChangeW] = usePickerChange();
   const [valM, onChangeM] = usePickerChange();
   const [valY, onChangeY] = usePickerChange();
 
   // We use moment.date  instead of moment.add is because storybook currently has internal conflict with the method.
-  const disabledDatesStart = moment().date(moment().date() - 7);
+  const disabledDatesStart = moment().date(moment().date() + 3);
   const disabledDatesEnd = moment().date(moment().date() + 7);
-  const disabledMonthsStart = moment().month(moment().month() - 2);
-  const disabledMonthsEnd = moment().month(moment().month() + 2);
-  const disabledYearsStart = moment().year(moment().year() - 2);
-  const disabledYearsEnd = moment().year(moment().year() + 2);
+  const disabledWeeksStart = moment().week(moment().week() - 5);
+  const disabledWeeksEnd = moment().week(moment().week() - 2);
+  const disabledMonthsStart = moment().month(moment().month() - 5);
+  const disabledMonthsEnd = moment().month(moment().month() - 1);
+  const disabledYearsStart = moment().year(moment().year() - 20);
+  const disabledYearsEnd = moment().year(moment().year() - 1);
 
   const isDateDisabled = (target: DateType) => (
     moment(target).isBetween(
       disabledDatesStart,
       disabledDatesEnd,
       'day',
+      '[]',
+    )
+  );
+
+  const isWeekDisabled = (target: DateType) => (
+    moment(target).isBetween(
+      disabledWeeksStart,
+      disabledWeeksEnd,
+      'week',
       '[]',
     )
   );
@@ -340,13 +353,53 @@ export const CustomDisable = () => {
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
-          {`Disabled Dates: ${disabledDatesStart.format('YYYY-MM-DD')} ~ ${disabledDatesEnd.format('YYYY-MM-DD')}`}
+          {`(mode='day') Disabled
+            Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
+            Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}
+            Dates: ${disabledDatesStart.format('YYYY-MM-DD')} ~ ${disabledDatesEnd.format('YYYY-MM-DD')}
+          `}
+        </Typography>
+        <DateRangePicker
+          value={valMix}
+          onChange={onChangeMix}
+          mode="day"
+          format="YYYY-MM-DD"
+          inputFromPlaceholder="Start Date"
+          inputToPlaceholder="End Date"
+          isDateDisabled={isDateDisabled}
+          isMonthDisabled={isMonthDisabled}
+          isYearDisabled={isYearDisabled}
+        />
+      </div>
+      <div style={containerStyle}>
+        <Typography variant="h5" style={typoStyle}>
+          {`(mode='week') Disabled
+          Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
+          Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}
+          Weeks: ${disabledWeeksStart.format(getDefaultModeFormat('week'))} ~ ${disabledWeeksEnd.format(getDefaultModeFormat('week'))}`}
+        </Typography>
+        <DateRangePicker
+          value={valW}
+          onChange={onChangeW}
+          mode="week"
+          format={getDefaultModeFormat('week')}
+          inputFromPlaceholder="Start Week"
+          inputToPlaceholder="End Week"
+          isYearDisabled={isYearDisabled}
+          isMonthDisabled={isMonthDisabled}
+          isWeekDisabled={isWeekDisabled}
+        />
+      </div>
+      <div style={containerStyle}>
+        <Typography variant="h5" style={typoStyle}>
+          {`(mode='day') Disabled Dates:
+          ${disabledDatesStart.format(getDefaultModeFormat('day'))} ~ ${disabledDatesEnd.format(getDefaultModeFormat('day'))}`}
         </Typography>
         <DateRangePicker
           value={valD}
           onChange={onChangeD}
           mode="day"
-          format="YYYY-MM-DD"
+          format={getDefaultModeFormat('day')}
           inputFromPlaceholder="Start Date"
           inputToPlaceholder="End Date"
           isDateDisabled={isDateDisabled}
@@ -354,31 +407,31 @@ export const CustomDisable = () => {
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
-          {`Disabled Months:
-          ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}`}
+          {`(mode='month') Disabled Months:
+          ${disabledMonthsStart.format(getDefaultModeFormat('month'))} ~ ${disabledMonthsEnd.format(getDefaultModeFormat('month'))}`}
         </Typography>
         <DateRangePicker
           value={valM}
           onChange={onChangeM}
           mode="month"
-          format="YYYY-MM"
-          inputFromPlaceholder="Start Date"
-          inputToPlaceholder="End Date"
+          format={getDefaultModeFormat('month')}
+          inputFromPlaceholder="Start Month"
+          inputToPlaceholder="End Month"
           isMonthDisabled={isMonthDisabled}
         />
       </div>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
-          {`Disabled Years:
-          ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}`}
+          {`(mode='year') Disabled Years:
+          ${disabledYearsStart.format(getDefaultModeFormat('year'))} ~ ${disabledYearsEnd.format(getDefaultModeFormat('year'))}`}
         </Typography>
         <DateRangePicker
           value={valY}
           onChange={onChangeY}
           mode="year"
-          format="YYYY"
-          inputFromPlaceholder="Start Date"
-          inputToPlaceholder="End Date"
+          format={getDefaultModeFormat('year')}
+          inputFromPlaceholder="Start Year"
+          inputToPlaceholder="End Year"
           isYearDisabled={isYearDisabled}
         />
       </div>

--- a/packages/react/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePicker.tsx
@@ -31,6 +31,7 @@ export interface DateRangePickerProps
   | 'mode'
   | 'popperProps'
   | 'isDateDisabled'
+  | 'isWeekDisabled'
   | 'isMonthDisabled'
   | 'isYearDisabled'
   >,
@@ -109,6 +110,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
       inputToPlaceholder,
       inputToProps,
       isDateDisabled,
+      isWeekDisabled,
       isMonthDisabled,
       isYearDisabled,
       mode = 'day',
@@ -403,6 +405,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
           isDateInRange={getIsInRangeHandler('date')}
           isMonthDisabled={isMonthDisabled}
           isMonthInRange={getIsInRangeHandler('month')}
+          isWeekDisabled={isWeekDisabled}
           isWeekInRange={getIsInRangeHandler('week')}
           isYearDisabled={isYearDisabled}
           isYearInRange={getIsInRangeHandler('year')}

--- a/packages/react/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePicker.tsx
@@ -26,6 +26,10 @@ export interface DateRangePickerProps
   extends
   Pick<DateRangePickerCalendarProps,
   | 'calendarProps'
+  | 'disabledMonthSwitch'
+  | 'disableOnNext'
+  | 'disableOnPrev'
+  | 'disabledYearSwitch'
   | 'displayMonthLocale'
   | 'fadeProps'
   | 'mode'
@@ -99,6 +103,10 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
       className,
       clearable = true,
       defaultValue,
+      disabledMonthSwitch = false,
+      disableOnNext,
+      disableOnPrev,
+      disabledYearSwitch = false,
       disabled = disabledFromFormControl || false,
       displayMonthLocale,
       error = severity === 'error' || false,
@@ -399,6 +407,10 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
           open={open}
           anchor={anchorRef}
           calendarProps={calendarProps}
+          disabledMonthSwitch={disabledMonthSwitch}
+          disableOnNext={disableOnNext}
+          disableOnPrev={disableOnPrev}
+          disabledYearSwitch={disabledYearSwitch}
           displayMonthLocale={displayMonthLocale}
           fadeProps={fadeProps}
           isDateDisabled={isDateDisabled}

--- a/packages/react/src/DateRangePicker/DateRangePickerCalendar.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePickerCalendar.tsx
@@ -21,6 +21,10 @@ export interface DateRangePickerCalendarProps
   Pick<CalendarProps,
   | 'value'
   | 'onChange'
+  | 'disabledMonthSwitch'
+  | 'disabledYearSwitch'
+  | 'disableOnNext'
+  | 'disableOnPrev'
   | 'displayMonthLocale'
   | 'mode'
   | 'isDateInRange'
@@ -75,6 +79,10 @@ const DateRangePickerCalendar = forwardRef<HTMLDivElement, DateRangePickerCalend
     const {
       anchor,
       calendarProps,
+      disabledMonthSwitch,
+      disableOnNext,
+      disableOnPrev,
+      disabledYearSwitch,
       displayMonthLocale = displayMonthLocaleFromConfig,
       fadeProps,
       firstCalendarRef,
@@ -225,6 +233,10 @@ const DateRangePickerCalendar = forwardRef<HTMLDivElement, DateRangePickerCalend
               },
               className,
             )}
+            disabledMonthSwitch={disabledMonthSwitch}
+            disableOnNext={disableOnNext}
+            disableOnPrev={disableOnPrev}
+            disabledYearSwitch={disabledYearSwitch}
             displayMonthLocale={displayMonthLocale}
             isDateDisabled={isDateDisabled}
             isDateInRange={isDateInRange}
@@ -257,6 +269,10 @@ const DateRangePickerCalendar = forwardRef<HTMLDivElement, DateRangePickerCalend
               },
               className,
             )}
+            disabledMonthSwitch={disabledMonthSwitch}
+            disableOnNext={disableOnNext}
+            disableOnPrev={disableOnPrev}
+            disabledYearSwitch={disabledYearSwitch}
             displayMonthLocale={displayMonthLocale}
             isDateDisabled={isDateDisabled}
             isDateInRange={isDateInRange}

--- a/packages/react/src/DateRangePicker/DateRangePickerCalendar.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePickerCalendar.tsx
@@ -27,6 +27,7 @@ export interface DateRangePickerCalendarProps
   | 'isDateDisabled'
   | 'isMonthDisabled'
   | 'isMonthInRange'
+  | 'isWeekDisabled'
   | 'isWeekInRange'
   | 'isYearDisabled'
   | 'isYearInRange'
@@ -81,6 +82,7 @@ const DateRangePickerCalendar = forwardRef<HTMLDivElement, DateRangePickerCalend
       isDateInRange,
       isMonthDisabled,
       isMonthInRange,
+      isWeekDisabled,
       isWeekInRange,
       isYearDisabled,
       isYearInRange,
@@ -228,6 +230,7 @@ const DateRangePickerCalendar = forwardRef<HTMLDivElement, DateRangePickerCalend
             isDateInRange={isDateInRange}
             isMonthDisabled={isMonthDisabled}
             isMonthInRange={isMonthInRange}
+            isWeekDisabled={isWeekDisabled}
             isWeekInRange={isWeekInRange}
             isYearDisabled={isYearDisabled}
             isYearInRange={isYearInRange}
@@ -259,6 +262,7 @@ const DateRangePickerCalendar = forwardRef<HTMLDivElement, DateRangePickerCalend
             isDateInRange={isDateInRange}
             isMonthDisabled={isMonthDisabled}
             isMonthInRange={isMonthInRange}
+            isWeekDisabled={isWeekDisabled}
             isWeekInRange={isWeekInRange}
             isYearDisabled={isYearDisabled}
             isYearInRange={isYearInRange}

--- a/packages/react/src/DateTimePicker/DateTimePicker.stories.tsx
+++ b/packages/react/src/DateTimePicker/DateTimePicker.stories.tsx
@@ -4,7 +4,7 @@ import {
 } from '@mezzanine-ui/core/calendar';
 import CalendarMethodsDayjs from '@mezzanine-ui/core/calendarMethodsDayjs';
 import CalendarMethodsMoment from '@mezzanine-ui/core/calendarMethodsMoment';
-import { useState } from 'react';
+import { CSSProperties, useState } from 'react';
 import moment from 'moment';
 import { CalendarConfigProvider } from '../Calendar';
 import DateTimePicker, { DateTimePickerProps } from './DateTimePicker';
@@ -269,12 +269,16 @@ export const DisplayColumn = () => {
 
 export const CustomDisable = () => {
   const containerStyle = { margin: '0 0 24px 0' };
-  const typoStyle = { margin: '0 0 12px 0' };
+  const typoStyle = { margin: '0 0 12px 0', whiteSpace: 'pre-line' } as CSSProperties;
   const [valD, onChangeD] = usePickerChange();
 
   // We use moment.date  instead of moment.add is because storybook currently has internal conflict with the method.
-  const disabledDatesStart = moment().date(moment().date() - 7);
+  const disabledDatesStart = moment().date(moment().date() + 3);
   const disabledDatesEnd = moment().date(moment().date() + 7);
+  const disabledMonthsStart = moment().month(moment().month() - 5);
+  const disabledMonthsEnd = moment().month(moment().month() - 1);
+  const disabledYearsStart = moment().year(moment().year() - 20);
+  const disabledYearsEnd = moment().year(moment().year() - 1);
   const format = 'YYYY-MM-DD HH:mm:ss';
 
   const isDateDisabled = (target: DateType) => (
@@ -286,17 +290,41 @@ export const CustomDisable = () => {
     )
   );
 
+  const isMonthDisabled = (target: DateType) => (
+    moment(target).isBetween(
+      disabledMonthsStart,
+      disabledMonthsEnd,
+      'month',
+      '[]',
+    )
+  );
+
+  const isYearDisabled = (target: DateType) => (
+    moment(target).isBetween(
+      disabledYearsStart,
+      disabledYearsEnd,
+      'year',
+      '[]',
+    )
+  );
+
   return (
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
-          {`Disabled Dates: ${disabledDatesStart.format(format)} ~ ${disabledDatesEnd.format(format)}`}
+          {`(mode='day') Disabled
+            Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
+            Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}
+            Dates: ${disabledDatesStart.format(format)} ~ ${disabledDatesEnd.format(format)}
+          `}
         </Typography>
         <DateTimePicker
           value={valD}
           onChange={onChangeD}
           format={format}
           placeholder={format}
+          isYearDisabled={isYearDisabled}
+          isMonthDisabled={isMonthDisabled}
           isDateDisabled={isDateDisabled}
         />
       </div>

--- a/packages/react/src/DateTimePicker/DateTimePicker.stories.tsx
+++ b/packages/react/src/DateTimePicker/DateTimePicker.stories.tsx
@@ -312,6 +312,25 @@ export const CustomDisable = () => {
     <CalendarConfigProvider methods={CalendarMethodsMoment}>
       <div style={containerStyle}>
         <Typography variant="h5" style={typoStyle}>
+          {`(mode='day')
+          disabledMonthSwitch = true
+          disabledYearSwitch = true
+          disableOnNext = true
+          disableOnPrev = true`}
+        </Typography>
+        <DateTimePicker
+          value={valD}
+          onChange={onChangeD}
+          format={format}
+          placeholder={format}
+          disabledMonthSwitch
+          disabledYearSwitch
+          disableOnNext
+          disableOnPrev
+        />
+      </div>
+      <div style={containerStyle}>
+        <Typography variant="h5" style={typoStyle}>
           {`(mode='day') Disabled
             Years: ${disabledYearsStart.format('YYYY')} ~ ${disabledYearsEnd.format('YYYY')}
             Months: ${disabledMonthsStart.format('YYYY-MM')} ~ ${disabledMonthsEnd.format('YYYY-MM')}

--- a/packages/react/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/react/src/DateTimePicker/DateTimePicker.tsx
@@ -86,8 +86,10 @@ const DateTimePicker = forwardRef<HTMLDivElement, DateTimePickerProps>(
       clearable = true,
       confirmText,
       defaultValue,
+      disabledMonthSwitch = false,
       disableOnNext,
       disableOnPrev,
+      disabledYearSwitch = false,
       disabled = disabledFromFormControl,
       displayMonthLocale,
       error = severity === 'error' || false,
@@ -291,8 +293,10 @@ const DateTimePicker = forwardRef<HTMLDivElement, DateTimePickerProps>(
           anchor={anchorRef}
           calendarProps={calendarProps}
           confirmText={confirmText}
+          disabledMonthSwitch={disabledMonthSwitch}
           disableOnNext={disableOnNext}
           disableOnPrev={disableOnPrev}
+          disabledYearSwitch={disabledYearSwitch}
           displayMonthLocale={displayMonthLocale}
           fadeProps={fadeProps}
           hideHour={hideHour}

--- a/packages/react/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/react/src/DateTimePicker/DateTimePicker.tsx
@@ -102,6 +102,7 @@ const DateTimePicker = forwardRef<HTMLDivElement, DateTimePickerProps>(
       inputProps,
       isDateDisabled,
       isMonthDisabled,
+      isWeekDisabled,
       isYearDisabled,
       minutePrefix,
       minuteStep,
@@ -301,6 +302,7 @@ const DateTimePicker = forwardRef<HTMLDivElement, DateTimePickerProps>(
           hourStep={hourStep}
           isDateDisabled={isDateDisabled}
           isMonthDisabled={isMonthDisabled}
+          isWeekDisabled={isWeekDisabled}
           isYearDisabled={isYearDisabled}
           minutePrefix={minutePrefix}
           minuteStep={minuteStep}

--- a/packages/react/src/DateTimePicker/DateTimePickerPanel.tsx
+++ b/packages/react/src/DateTimePicker/DateTimePickerPanel.tsx
@@ -22,8 +22,10 @@ export interface DateTimePickerPanelProps
   | 'open'
   >,
   Pick<CalendarProps,
+  | 'disabledMonthSwitch'
   | 'disableOnNext'
   | 'disableOnPrev'
+  | 'disabledYearSwitch'
   | 'displayMonthLocale'
   | 'isDateDisabled'
   | 'isMonthDisabled'
@@ -36,8 +38,10 @@ export interface DateTimePickerPanelProps
    * Other calendar props you may provide to `Calendar`.
    */
   calendarProps?: Omit<CalendarProps,
+  | 'disabledMonthSwitch'
   | 'disableOnNext'
   | 'disableOnPrev'
+  | 'disabledYearSwitch'
   | 'displayMonthLocale'
   | 'isDateDisabled'
   | 'isMonthDisabled'
@@ -94,8 +98,10 @@ const DateTimePickerPanel = forwardRef<HTMLDivElement, DateTimePickerPanelProps>
       calendarProps,
       className,
       confirmText,
+      disabledMonthSwitch,
       disableOnNext,
       disableOnPrev,
+      disabledYearSwitch,
       displayMonthLocale = displayMonthLocaleFromConfig,
       fadeProps,
       hideHour,
@@ -196,8 +202,10 @@ const DateTimePickerPanel = forwardRef<HTMLDivElement, DateTimePickerPanelProps>
           <div className={classes.panelSelectors}>
             <Calendar
               {...calendarProps}
+              disabledMonthSwitch={disabledMonthSwitch}
               disableOnNext={disableOnNext}
               disableOnPrev={disableOnPrev}
+              disabledYearSwitch={disabledYearSwitch}
               displayMonthLocale={displayMonthLocale}
               isDateDisabled={isDateDisabled}
               isMonthDisabled={isMonthDisabled}

--- a/packages/react/src/DateTimePicker/DateTimePickerPanel.tsx
+++ b/packages/react/src/DateTimePicker/DateTimePickerPanel.tsx
@@ -27,6 +27,7 @@ export interface DateTimePickerPanelProps
   | 'displayMonthLocale'
   | 'isDateDisabled'
   | 'isMonthDisabled'
+  | 'isWeekDisabled'
   | 'isYearDisabled'
   | 'onChange'
   | 'referenceDate'
@@ -104,6 +105,7 @@ const DateTimePickerPanel = forwardRef<HTMLDivElement, DateTimePickerPanelProps>
       hourStep,
       isDateDisabled,
       isMonthDisabled,
+      isWeekDisabled,
       isYearDisabled,
       minutePrefix,
       minuteStep,
@@ -199,6 +201,7 @@ const DateTimePickerPanel = forwardRef<HTMLDivElement, DateTimePickerPanelProps>
               displayMonthLocale={displayMonthLocale}
               isDateDisabled={isDateDisabled}
               isMonthDisabled={isMonthDisabled}
+              isWeekDisabled={isWeekDisabled}
               isYearDisabled={isYearDisabled}
               mode={currentMode}
               onChange={onCalendarChange}


### PR DESCRIPTION
影響範圍：使用到 Calendar 的元件（DatePicker, DateTimePicker, DateRangePicker）

- 增加 `disabledMonthSwitch`, `disabledYearSwitch`，現在可以控制要不要將`月份/年份`按鈕 disabled
- 修正 `isWeekDisabled` 沒有正確傳入的 bug 及其 typings
- 現在傳入 isYearDisabled, isMonthDisabled 會同步套用到他的子集，修正 issue #213
  - 在 mode="month" 下，會同步受到 isYearDisabled 影響
  - 在 mode="week" 下，會同步受到 isYearDisabled, isMonthDisabled 影響
  - 在 mode="day" 下，會同步受到 isYearDisabled, isMonthDisabled 影響
- 修正 storybook examples