### PR TITLE
feat(react/table): bodyRowClassName props also can use '(source) => s…

### DIFF
--- a/packages/react/src/Table/Table.tsx
+++ b/packages/react/src/Table/Table.tsx
@@ -52,7 +52,7 @@ export interface TableBaseProps<T>
   /**
     * customized body row className
     */
-  bodyRowClassName?: string;
+  bodyRowClassName?: string | ((source: TableDataSource) => string);
   /**
     * Columns of table <br />
     * `column.render` allowed customizing the column body cell rendering. <br />
@@ -315,6 +315,18 @@ const Table = forwardRef<HTMLTableElement, TableProps<Record<string, unknown>>>(
 
   const tableRefs = useComposeRefs([ref, scrollBody.target]);
 
+  const rowClassName = useMemo(() => {
+    if (bodyRowClassName) {
+      if (typeof bodyRowClassName === 'string') {
+        return (() => bodyRowClassName);
+      }
+
+      return ((source: TableDataSource) => bodyRowClassName?.(source));
+    }
+
+    return undefined;
+  }, [bodyRowClassName]);
+
   return (
     <TableContext.Provider value={tableContextValue}>
       <TableDataContext.Provider value={tableDataContextValue}>
@@ -369,7 +381,7 @@ const Table = forwardRef<HTMLTableElement, TableProps<Record<string, unknown>>>(
                         <TableBody
                           ref={bodyRef}
                           className={bodyClassName}
-                          rowClassName={bodyRowClassName}
+                          rowClassName={rowClassName}
                         />
                         <tbody>
                           {provided.placeholder}

--- a/packages/react/src/Table/TableBody.tsx
+++ b/packages/react/src/Table/TableBody.tsx
@@ -17,7 +17,7 @@ export interface TableBodyProps extends NativeElementPropsWithoutKeyAndRef<'div'
   /**
    * customize row className
    */
-  rowClassName?: string;
+  rowClassName?: (source: TableDataSource) => string;
 }
 
 const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(function TableBody(props, ref) {
@@ -77,7 +77,7 @@ const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(function T
       {currentDataSource.length ? currentDataSource.map((rowData: TableDataSource, index: number) => (
         <TableBodyRow
           key={(rowData.key || rowData.id) as string}
-          className={rowClassName}
+          className={rowClassName?.(rowData)}
           rowData={rowData}
           rowIndex={index}
         />


### PR DESCRIPTION
type of bodyRowClassName is `string` or `(source) => string`