### PR TITLE
feat(react/checkbox): auto-check and auto-focus for withEditInput mode

### DIFF
--- a/packages/react/src/Checkbox/Checkbox.spec.tsx
+++ b/packages/react/src/Checkbox/Checkbox.spec.tsx
@@ -434,7 +434,7 @@ describe('<Checkbox />', () => {
       expect(input.disabled).toBe(false);
     });
 
-    it('should render editable input when checkbox is unchecked but disabled', () => {
+    it('should render editable input as enabled when checkbox is unchecked', () => {
       const { getHostHTMLElement } = render(
         <Checkbox
           checked={false}
@@ -449,10 +449,10 @@ describe('<Checkbox />', () => {
       );
       const input = editableInputContainer?.querySelector('input') as HTMLInputElement;
 
-      // Editable input should be rendered but disabled when unchecked
+      // Editable input should be rendered and enabled even when unchecked
       expect(editableInputContainer).toBeTruthy();
       expect(input).toBeTruthy();
-      expect(input.disabled).toBe(true);
+      expect(input.disabled).toBe(false);
     });
 
     it('should use default placeholder when editableInput is not provided', () => {
@@ -570,6 +570,71 @@ describe('<Checkbox />', () => {
       const description = element.querySelector('.mzn-checkbox__description');
 
       expect(description).toBeFalsy();
+    });
+
+    it('should focus the editable input when checkbox transitions from unchecked to checked', () => {
+      const { getHostHTMLElement } = render(
+        <Checkbox
+          defaultChecked={false}
+          withEditInput
+          label="Other"
+          name="test"
+        />,
+      );
+      const element = getHostHTMLElement();
+      const checkboxInput = element.querySelector('.mzn-checkbox__input') as HTMLInputElement;
+      const editableInputContainer = element.querySelector(
+        '.mzn-checkbox__editable-input-container',
+      ) as HTMLElement;
+      const editableInput = editableInputContainer.querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(checkboxInput);
+
+      expect(document.activeElement).toBe(editableInput);
+    });
+
+    it('should check the checkbox when mousedown fires on the editable input container while unchecked', () => {
+      const { getHostHTMLElement } = render(
+        <Checkbox
+          defaultChecked={false}
+          withEditInput
+          label="Other"
+          name="test"
+        />,
+      );
+      const element = getHostHTMLElement();
+      const checkboxInput = element.querySelector('.mzn-checkbox__input') as HTMLInputElement;
+      const editableInputContainer = element.querySelector(
+        '.mzn-checkbox__editable-input-container',
+      ) as HTMLElement;
+
+      expect(checkboxInput.checked).toBe(false);
+
+      fireEvent.mouseDown(editableInputContainer);
+
+      expect(checkboxInput.checked).toBe(true);
+    });
+
+    it('should not toggle the checkbox when mousedown fires on the editable input container while already checked', () => {
+      const { getHostHTMLElement } = render(
+        <Checkbox
+          defaultChecked
+          withEditInput
+          label="Other"
+          name="test"
+        />,
+      );
+      const element = getHostHTMLElement();
+      const checkboxInput = element.querySelector('.mzn-checkbox__input') as HTMLInputElement;
+      const editableInputContainer = element.querySelector(
+        '.mzn-checkbox__editable-input-container',
+      ) as HTMLElement;
+
+      expect(checkboxInput.checked).toBe(true);
+
+      fireEvent.mouseDown(editableInputContainer);
+
+      expect(checkboxInput.checked).toBe(true);
     });
 
     it('should generate default id and name for editable input', () => {

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -2,6 +2,7 @@
 
 import {
   ChangeEventHandler,
+  MouseEvent,
   Ref,
   forwardRef,
   useContext,
@@ -53,7 +54,7 @@ type CheckboxInputElementProps = Omit<
 
 export interface CheckboxProps
   extends Omit<NativeElementPropsWithoutKeyAndRef<'label'>, 'onChange'>,
-    CheckboxPropsBase {
+  CheckboxPropsBase {
   /**
    * Whether to show an editable input when checkbox is checked.
    * When `true`, an Input component will be displayed after the checkbox when checked.
@@ -248,7 +249,7 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       if (!checkboxGroup && !name && !nameFromInputProps && label) {
         console.warn(
           'Checkbox: The `name` prop is recommended when integrating with react-hook-form. ' +
-            `Checkbox with label "${label}" is missing the \`name\` prop.`,
+          `Checkbox with label "${label}" is missing the \`name\` prop.`,
         );
       }
     }, [checkboxGroup, name, nameFromInputProps, label]);
@@ -307,6 +308,21 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
     }, [withEditInput, editableInput, resolvedName, finalInputId]);
 
     const shouldShowEditableInput = withEditInput && defaultEditableInput;
+    const prevIsCheckedRef = useRef(isChecked);
+
+    useEffect(() => {
+      if (isChecked && !prevIsCheckedRef.current && shouldShowEditableInput && editableInputRef.current) {
+        editableInputRef.current.focus();
+      }
+      prevIsCheckedRef.current = isChecked;
+    }, [isChecked, shouldShowEditableInput]);
+
+    const handleEditableInputContainerMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+      if (!isChecked && !disabled && inputElementRef.current) {
+        event.preventDefault(); // 阻止原生 focus-on-mousedown，讓 useEffect 統一控制 focus 時機
+        inputElementRef.current.click();
+      }
+    };
 
     return (
       <div
@@ -393,11 +409,14 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
           defaultEditableInput &&
           mode !== 'chip' &&
           !indeterminate && (
-            <div className={classes.editableInputContainer}>
+            <div
+              className={classes.editableInputContainer}
+              onMouseDown={handleEditableInputContainerMouseDown}
+            >
               <Input
                 {...defaultEditableInput}
-                {...((!isChecked || disabled) &&
-                defaultEditableInput.disabled !== true
+                {...(disabled &&
+                  defaultEditableInput.disabled !== true
                   ? { disabled: true }
                   : {})}
                 inputRef={composeRefs([


### PR DESCRIPTION
When withEditInput is true, both Checkbox and Input are now always enabled. Interacting with either element activates both.

- Click Checkbox: transitions to checked, then useEffect auto-focuses the editable Input (cursor appears)
- MouseDown on Input container: calls click() on the checkbox input to check it (guarded by !isChecked to prevent toggling), then useEffect transfers focus to the Input
- event.preventDefault() on mousedown suppresses native  focus-on-mousedown so focus timing is controlled by the effect
- Remove !isChecked from the Input's disabled condition