### PR TITLE
docs(react/filter-area): add JSDoc and Playground story

### DIFF
--- a/packages/react/src/FilterArea/Filter.tsx
+++ b/packages/react/src/FilterArea/Filter.tsx
@@ -44,6 +44,29 @@ export interface FilterProps
   span?: FilterSpan;
 }
 
+/**
+ * 單一篩選條件元件，用於在 FilterLine 中定義欄位的佔位寬度。
+ *
+ * 使用 12 欄 Grid，`span` 決定欄位佔用幾欄（1–6）；
+ * `grow` 設為 `true` 時欄位自動填滿整行。
+ * 從 FilterAreaContext 繼承 `size`，統一套用至內部的輸入元件。
+ *
+ * @example
+ * ```tsx
+ * import { Filter } from '@mezzanine-ui/react';
+ * import { FormField } from '@mezzanine-ui/react';
+ * import Input from '@mezzanine-ui/react/Input';
+ *
+ * <Filter span={2}>
+ *   <FormField label="名稱" name="name" layout="horizontal">
+ *     <Input placeholder="請輸入" />
+ *   </FormField>
+ * </Filter>
+ * ```
+ *
+ * @see {@link FilterLine} 包含 Filter 的行容器
+ * @see {@link FilterArea} 管理整個篩選器的容器
+ */
 const Filter = forwardRef<HTMLDivElement, FilterProps>(
   function Filter(props, ref) {
     const {

--- a/packages/react/src/FilterArea/Filter.tsx
+++ b/packages/react/src/FilterArea/Filter.tsx
@@ -28,7 +28,7 @@ export interface FilterProps
    */
   children: ReactElement<FormFieldProps> | ReactElement<FormFieldProps>[];
   /**
-   * Layout control - Whether the field should automatically expand to fill the entire row (equivalent to span={12}).
+   * Layout control - Whether the field should automatically expand to fill the entire row (equivalent to span={6}).
    * @default false
    */
   grow?: boolean;
@@ -37,7 +37,7 @@ export interface FilterProps
    */
   minWidth?: string | number;
   /**
-   * Layout control - Number of columns the field occupies in the Grid (1-12, Grid has 12 columns total).
+   * Layout control - Number of columns the field occupies in the Grid (1-6, Grid has 6 columns total).
    * This property is ignored when grow is true.
    * @default 2
    */
@@ -47,7 +47,7 @@ export interface FilterProps
 /**
  * 單一篩選條件元件，用於在 FilterLine 中定義欄位的佔位寬度。
  *
- * 使用 12 欄 Grid，`span` 決定欄位佔用幾欄（1–6）；
+ * 使用 6 欄 Grid，`span` 決定欄位佔用幾欄（1–6）；
  * `grow` 設為 `true` 時欄位自動填滿整行。
  * 從 FilterAreaContext 繼承 `size`，統一套用至內部的輸入元件。
  *

--- a/packages/react/src/FilterArea/FilterArea.mdx
+++ b/packages/react/src/FilterArea/FilterArea.mdx
@@ -1,0 +1,31 @@
+import { ArgTypes, Description, Meta } from '@storybook/addon-docs/blocks';
+import FilterArea from './FilterArea';
+import FilterLine from './FilterLine';
+import Filter from './Filter';
+import * as FilterAreaStories from './FilterArea.stories';
+
+<Meta of={FilterAreaStories} />
+
+# FilterArea
+
+<Description of={FilterArea} />
+
+[Source Code](https://github.com/Mezzanine-UI/mezzanine/blob/main/packages/react/src/FilterArea/FilterArea.tsx)
+
+<ArgTypes of={FilterArea} />
+
+# FilterLine
+
+<Description of={FilterLine} />
+
+[Source Code](https://github.com/Mezzanine-UI/mezzanine/blob/main/packages/react/src/FilterArea/FilterLine.tsx)
+
+<ArgTypes of={FilterLine} />
+
+# Filter
+
+<Description of={Filter} />
+
+[Source Code](https://github.com/Mezzanine-UI/mezzanine/blob/main/packages/react/src/FilterArea/Filter.tsx)
+
+<ArgTypes of={Filter} />

--- a/packages/react/src/FilterArea/FilterArea.stories.tsx
+++ b/packages/react/src/FilterArea/FilterArea.stories.tsx
@@ -1,4 +1,5 @@
 import { FormFieldDensity, FormFieldLayout } from '@mezzanine-ui/core/form';
+import { FilterAreaActionsAlign, FilterAreaRowAlign, FilterAreaSize } from '@mezzanine-ui/core/filter-area';
 import { Meta, StoryObj } from '@storybook/react-webpack5';
 
 import { Filter, FilterArea, FilterAreaProps, FilterLine } from '.';
@@ -12,7 +13,7 @@ import { SelectValue } from '../Select/typings';
 export default {
   title: 'Data Entry/FilterArea',
   component: FilterArea,
-} as Meta;
+} satisfies Meta<typeof FilterArea>;
 
 const autoCompleteOptions: SelectValue[] = [
   { id: 'alpha', name: 'alpha' },
@@ -21,6 +22,96 @@ const autoCompleteOptions: SelectValue[] = [
 ];
 
 type Story = StoryObj<FilterAreaProps>;
+
+export const Playground: Story = {
+  argTypes: {
+    actionsAlign: {
+      control: { type: 'select' },
+      options: ['start', 'center', 'end'] satisfies FilterAreaActionsAlign[],
+    },
+    isDirty: {
+      control: { type: 'boolean' },
+    },
+    resetText: {
+      control: { type: 'text' },
+    },
+    rowAlign: {
+      control: { type: 'select' },
+      options: ['start', 'center', 'end'] satisfies FilterAreaRowAlign[],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['main', 'sub'] satisfies FilterAreaSize[],
+    },
+    submitText: {
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    actionsAlign: 'end',
+    isDirty: true,
+    resetText: 'Reset',
+    rowAlign: 'center',
+    size: 'main',
+    submitText: 'Search',
+  },
+  render: function PlaygroundStory(args) {
+    const horizontal = {
+      density: FormFieldDensity.BASE,
+      layout: FormFieldLayout.HORIZONTAL,
+    };
+
+    return (
+      <CalendarConfigProviderDayjs locale="zh-TW">
+        <FilterArea {...args}>
+          <FilterLine>
+            <Filter span={2}>
+              <FormField
+                label="Label"
+                name="name"
+                density={horizontal.density}
+                layout={horizontal.layout}
+              >
+                <Select
+                  fullWidth
+                  options={autoCompleteOptions}
+                  placeholder="請選擇"
+                />
+              </FormField>
+            </Filter>
+            <Filter span={2}>
+              <FormField
+                label="Label"
+                name="remark"
+                density={horizontal.density}
+                layout={horizontal.layout}
+              >
+                <Input placeholder="Enter name" />
+              </FormField>
+            </Filter>
+          </FilterLine>
+          <FilterLine>
+            <Filter span={3}>
+              <FormField
+                label="Label"
+                name="advanced1"
+                density={horizontal.density}
+                layout={horizontal.layout}
+              >
+                <AutoComplete
+                  fullWidth
+                  menuMaxHeight={140}
+                  options={autoCompleteOptions}
+                  placeholder="請輸入"
+                />
+              </FormField>
+            </Filter>
+          </FilterLine>
+        </FilterArea>
+      </CalendarConfigProviderDayjs>
+    );
+  },
+};
 
 export const Basic: Story = {
   argTypes: {

--- a/packages/react/src/FilterArea/FilterArea.tsx
+++ b/packages/react/src/FilterArea/FilterArea.tsx
@@ -71,6 +71,39 @@ export interface FilterAreaProps
   submitButtonType?: ComponentPropsWithoutRef<'button'>['type'];
 }
 
+/**
+ * 篩選器容器元件，管理多個 FilterLine 的展示與收合。
+ *
+ * 預設僅顯示第一行（`FilterLine`），多行時自動出現展開／收合切換按鈕。
+ * 透過 `size` 統一控制內部所有表單欄位的尺寸；
+ * 透過 `actionsAlign` 調整「送出／重設」按鈕區塊的對齊；
+ * 透過 `isDirty` 控制重設按鈕的啟用狀態（`false` 時禁用）。
+ *
+ * @example
+ * ```tsx
+ * import { Filter, FilterArea, FilterLine } from '@mezzanine-ui/react';
+ * import { FormField } from '@mezzanine-ui/react';
+ * import Input from '@mezzanine-ui/react/Input';
+ *
+ * <FilterArea
+ *   submitText="搜尋"
+ *   resetText="重設"
+ *   onSubmit={handleSubmit}
+ *   onReset={handleReset}
+ * >
+ *   <FilterLine>
+ *     <Filter span={2}>
+ *       <FormField label="名稱" name="name" layout="horizontal">
+ *         <Input placeholder="請輸入" />
+ *       </FormField>
+ *     </Filter>
+ *   </FilterLine>
+ * </FilterArea>
+ * ```
+ *
+ * @see {@link FilterLine} 用於組成 FilterArea 的單行條件列
+ * @see {@link Filter} 包裝單一篩選欄位的元件
+ */
 const FilterArea = forwardRef<HTMLDivElement, FilterAreaProps>(
   function FilterArea(props, ref) {
     const {

--- a/packages/react/src/FilterArea/FilterArea.tsx
+++ b/packages/react/src/FilterArea/FilterArea.tsx
@@ -35,14 +35,14 @@ export interface FilterAreaProps
    */
   onReset?: () => void;
   /**
-   * Callback function triggered when the form is submitted.
+   * Callback function triggered when the submit button is clicked.
    * FilterArea itself does not manage form state; the parent component should collect
-   * filter values and handle submission logic. If using react-hook-form, values will be
-   * handled through FormProvider's handleSubmit.
+   * filter values and handle submission logic.
    */
   onSubmit?: () => void;
   /**
    * The text of the reset button.
+   * @default 'Reset'
    */
   resetText?: string;
   /**
@@ -52,6 +52,7 @@ export interface FilterAreaProps
   size?: FilterAreaSize;
   /**
    * The text of the submit button.
+   * @default 'Search'
    */
   submitText?: string;
   /**

--- a/packages/react/src/FilterArea/FilterLine.tsx
+++ b/packages/react/src/FilterArea/FilterLine.tsx
@@ -17,6 +17,25 @@ export interface FilterLineProps
   children: ReactElement<FilterProps> | ReactElement<FilterProps>[];
 }
 
+/**
+ * 篩選器中的單行條件列，包含一或多個 Filter 欄位。
+ *
+ * 透過 Grid 排版將 Filter 子元件橫向排列；
+ * 需作為 FilterArea 的直接子元件使用。
+ *
+ * @example
+ * ```tsx
+ * import { Filter, FilterLine } from '@mezzanine-ui/react';
+ *
+ * <FilterLine>
+ *   <Filter span={2}>...</Filter>
+ *   <Filter span={3}>...</Filter>
+ * </FilterLine>
+ * ```
+ *
+ * @see {@link FilterArea} 管理多個 FilterLine 的容器元件
+ * @see {@link Filter} 包裝單一篩選欄位的元件
+ */
 const FilterLine = forwardRef<HTMLDivElement, FilterLineProps>(
   function FilterLine(props, ref) {
     const { className, children, ...rest } = props;


### PR DESCRIPTION
## Summary
- Add JSDoc comments to `FilterArea`, `FilterLine`, and `Filter` components with usage examples and cross-references
- Add a `Playground` story to `FilterArea.stories.tsx` with interactive controls for all major props
- Fix incorrect grid column count in `Filter` JSDoc and prop descriptions (6 columns, not 12)
- Refine `onSubmit` and prop `@default` documentation in `FilterAreaProps`