### PR TITLE
fix(autocomplete): fix inputPosition="inside" interactions, double-select, and outside mode UX bugs

### DIFF
--- a/packages/core/src/autocomplete/_autocomplete-styles.scss
+++ b/packages/core/src/autocomplete/_autocomplete-styles.scss
@@ -1,4 +1,5 @@
 @use '../select/select' as select;
+@use '../input/input' as input;
 @use '../text-field/text-field' as text-field;
 @use './autocomplete' as *;
 @use '@mezzanine-ui/system/spacing' as spacing;
@@ -28,6 +29,13 @@
 
   &--inside-closed {
     .#{select.$trigger-prefix} {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    // Inside trigger uses a plain Input instead of SelectTrigger in some cases.
+    // Hide it consistently so the host collapses when dropdown is closed.
+    .#{input.$prefix} {
       opacity: 0;
       pointer-events: none;
     }

--- a/packages/core/src/select/_select-styles.scss
+++ b/packages/core/src/select/_select-styles.scss
@@ -73,6 +73,8 @@
     min-width: 30%;
 
     input {
+      width: 100%;
+
       /* Hide native search clear button to avoid duplicate clear icon in trigger. */
       &[type='search']::-webkit-search-decoration,
       &[type='search']::-webkit-search-cancel-button,

--- a/packages/react/src/AutoComplete/AutoComplete.spec.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.spec.tsx
@@ -8,6 +8,7 @@ import {
   MouseEvent,
   RefObject,
   SetStateAction,
+  useState,
 } from 'react';
 import { AutoComplete } from '.';
 import {
@@ -633,6 +634,123 @@ describe('<AutoComplete />', () => {
       });
     });
 
+    it('should remove unselected created option on blur/close (outside)', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+
+      const onRemoveCreated = jest.fn();
+
+      const Wrapper = () => {
+        const [options, setOptions] = useState<SelectValue[]>(defaultOptions);
+        const [value, setValue] = useState<SelectValue[]>([]);
+        const handleRemoveCreated = (cleanedOptions: SelectValue[]) => {
+          onRemoveCreated(cleanedOptions);
+          setOptions(cleanedOptions);
+        };
+
+        return (
+          <AutoComplete
+            addable
+            createSeparators={[',']}
+            disabledOptionsFilter
+            mode="multiple"
+            onChange={setValue}
+            onInsert={(text, currentOptions) => {
+              const updated = [
+                ...currentOptions,
+                { id: `new-${text}`, name: text },
+              ];
+              setOptions(updated);
+              return updated;
+            }}
+            onRemoveCreated={handleRemoveCreated}
+            options={options}
+            stepByStepBulkCreate
+            trimOnCreate
+            value={value}
+          />
+        );
+      };
+
+      const { container } = render(<Wrapper />);
+      const input = container.querySelector('input') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+
+      await act(async () => {
+        await user.click(input!);
+      });
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      fireEvent.paste(input!, {
+        clipboardData: { getData: () => 'Grid chart, Griddle, Grid' },
+      });
+
+      const firstCreateButton = await screen.findByText(/建立.*Grid chart/i);
+      await act(async () => {
+        await user.click(firstCreateButton);
+      });
+
+      await waitFor(() => {
+        const listbox = getDropdownListbox();
+        expect(listbox).toBeInTheDocument();
+        const createdSelectedOption = listbox?.querySelector(
+          '[role="option"][aria-selected="true"]',
+        ) as HTMLElement | null;
+        expect(createdSelectedOption).toBeInTheDocument();
+      });
+
+      const listbox = getDropdownListbox() as HTMLElement;
+      const createdOption = Array.from(
+        listbox.querySelectorAll('[role="option"]'),
+      ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart'));
+      expect(createdOption).toBeTruthy();
+
+      // Click once to unselect the created option.
+      await act(async () => {
+        await user.click(createdOption as HTMLElement);
+      });
+
+      await waitFor(() => {
+        const currentListbox = getDropdownListbox() as HTMLElement | null;
+        expect(currentListbox).toBeInTheDocument();
+        const currentOption = Array.from(
+          currentListbox!.querySelectorAll('[role="option"]'),
+        ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart'));
+        expect(currentOption).toBeTruthy();
+        expect((currentOption as HTMLElement).getAttribute('aria-selected')).toBe(
+          'false',
+        );
+      });
+
+      await act(async () => {
+        await user.click(input!);
+        await user.keyboard('{Escape}');
+        jest.runOnlyPendingTimers();
+      });
+
+      await waitFor(() => {
+        expect(
+          (screen.queryByRole('listbox') as HTMLElement | null) ??
+            getDropdownListbox(),
+        ).not.toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(onRemoveCreated).toHaveBeenCalled();
+        const lastCallArg =
+          onRemoveCreated.mock.calls[onRemoveCreated.mock.calls.length - 1]?.[0];
+        expect(lastCallArg).toEqual(expect.any(Array));
+        expect(
+          (lastCallArg as SelectValue[]).some(
+            (opt) => opt.id === 'new-Grid chart',
+          ),
+        ).toBe(false);
+      });
+    });
+
     it('should update input to remaining and show next create after clicking create', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ delay: null });
@@ -810,6 +928,370 @@ describe('<AutoComplete />', () => {
 
       await waitFor(() => {
         expect(onVisibilityChange).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+
+  describe('prop: inputPosition="inside"', () => {
+    it('should render single-like checked icon (without checkbox) in multiple mode', async () => {
+      const { container } = render(
+        <AutoComplete
+          inputPosition="inside"
+          mode="multiple"
+          open
+          options={defaultOptions}
+          value={[defaultOptions[0]]}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      const listbox = getDropdownListbox() as HTMLElement;
+      const checkboxes = listbox.querySelectorAll(
+        'input[type="checkbox"]',
+      ) as NodeListOf<HTMLInputElement>;
+
+      expect(checkboxes.length).toBe(0);
+
+      const selectedOption = listbox.querySelector(
+        '[role="option"][aria-selected="true"]',
+      ) as HTMLElement | null;
+      expect(selectedOption).toBeInTheDocument();
+      expect(
+        selectedOption?.querySelector('.mzn-dropdown-item-card-append-content .mzn-icon'),
+      ).toBeInTheDocument();
+
+      // Keep the input (trigger) and selection checkboxes separate:
+      // the inside trigger itself is the combobox input (not type=checkbox).
+      const triggerInputs = container.querySelectorAll(
+        'input[role="combobox"]',
+      );
+      expect(triggerInputs.length).toBeGreaterThan(0);
+    });
+
+    it('should show empty status when there are no options', async () => {
+      render(
+        <AutoComplete
+          inputPosition="inside"
+          mode="multiple"
+          open
+          options={[]}
+          emptyText="沒有符合的項目"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/沒有符合的項目/i)).toBeInTheDocument();
+      expect(screen.queryByText(/建立/i)).not.toBeInTheDocument();
+    });
+
+    it('should show create action when addable and no option matches', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+
+      const onInsert = jest.fn((text: string) => [
+        { id: text, name: text },
+      ]);
+
+      render(
+        <AutoComplete
+          addable
+          inputPosition="inside"
+          mode="multiple"
+          onInsert={onInsert}
+          open
+          options={[]}
+          emptyText="沒有符合的項目"
+        />,
+      );
+
+      const input = await waitFor(() => {
+        const el = document.querySelector(
+          'input[role="combobox"]',
+        ) as HTMLInputElement | null;
+        expect(el).not.toBeNull();
+        return el!;
+      });
+
+      await act(async () => {
+        await user.click(input);
+        await user.type(input, 'newitem');
+      });
+
+      const createButton = await screen.findByText(/建立.*newitem/i);
+      expect(createButton).toBeInTheDocument();
+
+      fireEvent.click(createButton);
+      expect(onInsert).toHaveBeenCalledWith(
+        'newitem',
+        expect.any(Array),
+      );
+    });
+
+    it('should keep New tag for created option in inside mode', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+
+      const InsideCreatable = () => {
+        const [options, setOptions] = useState<SelectValue[]>(defaultOptions);
+        const [value, setValue] = useState<SelectValue[]>([]);
+
+        return (
+          <AutoComplete
+            addable
+            disabledOptionsFilter
+            inputPosition="inside"
+            mode="multiple"
+            onChange={setValue}
+            onInsert={(text, currentOptions) => {
+              const updated = [...currentOptions, { id: `new-${text}`, name: text }];
+              setOptions(updated);
+              return updated;
+            }}
+            open
+            options={options}
+            value={value}
+          />
+        );
+      };
+
+      render(<InsideCreatable />);
+
+      const input = await waitFor(() => {
+        const el = document.querySelector(
+          'input[role="combobox"]',
+        ) as HTMLInputElement | null;
+        expect(el).not.toBeNull();
+        return el!;
+      });
+
+      await act(async () => {
+        await user.click(input);
+        await user.type(input, 'newitem');
+      });
+
+      const createButton = await screen.findByText(/建立.*newitem/i);
+      fireEvent.click(createButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('New')).toBeInTheDocument();
+      });
+    });
+
+    it('should support step-by-step bulk create in inside position', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+
+      const onInsert = jest.fn(
+        (text: string, currentOptions: SelectValue[]) => [
+          ...currentOptions,
+          { id: `new-${text}`, name: text },
+        ],
+      );
+
+      render(
+        <AutoComplete
+          addable
+          createSeparators={[',']}
+          inputPosition="inside"
+          mode="multiple"
+          onInsert={onInsert}
+          open
+          options={defaultOptions}
+          stepByStepBulkCreate
+          trimOnCreate
+        />,
+      );
+
+      const input = await waitFor(() => {
+        const el = document.querySelector(
+          'input[role="combobox"]',
+        ) as HTMLInputElement | null;
+        expect(el).not.toBeNull();
+        return el!;
+      });
+
+      await act(async () => {
+        await user.click(input);
+      });
+
+      fireEvent.paste(input, {
+        clipboardData: { getData: () => 'Grid chart, Griddle, Grid' },
+      });
+
+      await waitFor(() => {
+        expect(input.value).toBe('Grid chart, Griddle, Grid');
+      });
+
+      const firstCreateButton = screen.queryByText(
+        /建立.*Grid chart/i,
+      );
+      expect(firstCreateButton).toBeInTheDocument();
+
+      fireEvent.click(firstCreateButton!);
+
+      await waitFor(() => {
+        expect(input.value).toBe('Griddle, Grid');
+      });
+
+      await waitFor(() => {
+        const nextCreateButton = screen.queryByText(/建立.*Griddle/i);
+        expect(nextCreateButton).toBeInTheDocument();
+      });
+    });
+
+    it('should show loading status in inside position', async () => {
+      render(
+        <AutoComplete
+          inputPosition="inside"
+          loading
+          loadingPosition="full"
+          loadingText="載入中..."
+          mode="multiple"
+          open
+          options={[]}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/載入中|loading/i)).toBeInTheDocument();
+    });
+
+    it('should remove unselected created option on blur/close (inside, uncontrolled)', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({
+        advanceTimers: jest.advanceTimersByTime,
+        delay: null,
+      });
+
+      const onRemoveCreated = jest.fn();
+
+      const Wrapper = () => {
+        const [options, setOptions] = useState<SelectValue[]>(defaultOptions);
+        const [value, setValue] = useState<SelectValue[]>([]);
+        const handleRemoveCreated = (cleanedOptions: SelectValue[]) => {
+          onRemoveCreated(cleanedOptions);
+          setOptions(cleanedOptions);
+        };
+
+        return (
+          <AutoComplete
+            addable
+            createSeparators={[',']}
+            disabledOptionsFilter
+            inputPosition="inside"
+            mode="multiple"
+            onChange={setValue}
+            onInsert={(text, currentOptions) => {
+              const updated = [
+                ...currentOptions,
+                { id: `new-${text}`, name: text },
+              ];
+              setOptions(updated);
+              return updated;
+            }}
+            onRemoveCreated={handleRemoveCreated}
+            options={options}
+            stepByStepBulkCreate
+            trimOnCreate
+            value={value}
+          />
+        );
+      };
+
+      render(<Wrapper />);
+
+      const input = await waitFor(() => {
+        const el = document.querySelector(
+          'input[role="combobox"]',
+        ) as HTMLInputElement | null;
+        expect(el).not.toBeNull();
+        return el!;
+      });
+
+      await act(async () => {
+        await user.click(input);
+      });
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      fireEvent.paste(input, {
+        clipboardData: { getData: () => 'Grid chart, Griddle, Grid' },
+      });
+
+      const firstCreateButton = await screen.findByText(/建立.*Grid chart/i);
+      await act(async () => {
+        await user.click(firstCreateButton);
+      });
+
+      await waitFor(() => {
+        const listbox = getDropdownListbox();
+        expect(listbox).toBeInTheDocument();
+      });
+
+      // Unselect the created option by clicking the selected row.
+      const getCreatedSelectedOption = () => {
+        const currentListbox = getDropdownListbox() as HTMLElement | null;
+        if (!currentListbox) return null;
+        return Array.from(
+          currentListbox.querySelectorAll('[role="option"][aria-selected="true"]'),
+        ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart')) as
+          | HTMLElement
+          | null;
+      };
+
+      const createdSelectedOption = await waitFor(() => {
+        const el = getCreatedSelectedOption();
+        expect(el).toBeTruthy();
+        return el!;
+      });
+
+      await act(async () => {
+        await user.click(createdSelectedOption);
+      });
+
+      await waitFor(() => {
+        const currentListbox = getDropdownListbox() as HTMLElement | null;
+        expect(currentListbox).toBeInTheDocument();
+        const currentOption = Array.from(
+          currentListbox!.querySelectorAll('[role="option"]'),
+        ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart'));
+        expect(currentOption).toBeTruthy();
+        expect((currentOption as HTMLElement).getAttribute('aria-selected')).toBe(
+          'false',
+        );
+      });
+
+      await act(async () => {
+        // Close via click-away (Dropdown inside mode uses container click-away)
+        await user.click(document.body);
+        jest.runOnlyPendingTimers();
+      });
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).not.toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(onRemoveCreated).toHaveBeenCalled();
+        const lastCallArg =
+          onRemoveCreated.mock.calls[onRemoveCreated.mock.calls.length - 1]?.[0];
+        expect(lastCallArg).toEqual(expect.any(Array));
+        expect(
+          (lastCallArg as SelectValue[]).some(
+            (opt) => opt.id === 'new-Grid chart',
+          ),
+        ).toBe(false);
       });
     });
   });

--- a/packages/react/src/AutoComplete/AutoComplete.stories.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.stories.tsx
@@ -658,9 +658,9 @@ const CreatableMultipleComponent = () => {
       }}
     >
       <div>
-        <h3>多選模式 - 可新增選項</h3>
+        <h3>inside 多選模式 - 單選風格 checked icon</h3>
         <p style={{ fontSize: '12px', color: '#666', marginBottom: '8px' }}>
-          輸入文字後按 Enter 或點擊 + 號新增選項
+          下拉視覺採單選風格 checked icon，但行為仍可多選；建立項目維持 New 標記。
         </p>
         <AutoComplete
           addable
@@ -801,9 +801,9 @@ export const BulkCreate: StoryObj<typeof AutoComplete> = {
 };
 
 const InputPositionInsideComponent = () => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const [options, setOptions] = useState<SelectValue[]>(originOptions);
-  const [selections, setSelections] = useState<SelectValue[]>([]);
+  const [selections, setSelections] = useState<SelectValue[]>([originOptions[0]]);
   const nextIdRef = useRef(originOptions.length + 1);
 
   const handleInsert = useCallback(
@@ -897,6 +897,211 @@ const InputPositionInsideComponent = () => {
 
 export const InputPositionInside: StoryObj<typeof AutoComplete> = {
   render: () => <InputPositionInsideComponent />,
+};
+
+const InsideBulkCreateComponent = () => {
+  const [open, setOpen] = useState(true);
+  const [options, setOptions] = useState<SelectValue[]>(originOptions);
+  const [selections, setSelections] = useState<SelectValue[]>([]);
+  const nextIdRef = useRef(originOptions.length + 1);
+
+  const handleInsert = useCallback(
+    (text: string, currentOptions: SelectValue[]): SelectValue[] => {
+      const newOption: SelectValue = {
+        id: `new-${nextIdRef.current++}`,
+        name: text,
+      };
+
+      const updatedOptions = [...currentOptions, newOption];
+      setOptions(updatedOptions);
+      return updatedOptions;
+    },
+    [],
+  );
+
+  const handleRemoveCreated = useCallback((cleanedOptions: SelectValue[]) => {
+    setOptions(cleanedOptions);
+  }, []);
+
+  const closeDropdown = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        maxWidth: '620px',
+      }}
+    >
+      <div>
+        <h3>inside 多選模式 - 單選風格 checked icon + step-by-step bulk create</h3>
+        <p style={{ fontSize: '12px', color: '#666', marginBottom: '8px' }}>
+          貼上多個項目後，dropdown 只顯示第一個「建立」，點擊後再顯示下一個。
+        </p>
+        <p style={{ fontSize: '12px', color: '#666', marginBottom: '16px' }}>
+          試試貼上：<code>Grid chart, Griddle, Grid</code>
+        </p>
+
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '4px',
+            width: '100%',
+            marginBlock: '8px',
+          }}
+        >
+          {selections.map((selection) => (
+            <Tag
+              key={selection.id}
+              label={selection.name}
+              type="dismissable"
+              onClose={() =>
+                setSelections(selections.filter((s) => s.id !== selection.id))
+              }
+            />
+          ))}
+        </div>
+
+        <Tag
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            setOpen(!open);
+          }}
+          type="addable"
+          label={open ? '收起選單' : '展開選單'}
+        />
+
+        <AutoComplete
+          addable
+          createSeparators={[',', '+', '\n']}
+          fullWidth
+          inputPosition="inside"
+          mode="multiple"
+          onChange={setSelections}
+          onInsert={handleInsert}
+          onRemoveCreated={handleRemoveCreated}
+          onVisibilityChange={closeDropdown}
+          options={options}
+          open={open}
+          placeholder="試試貼上..."
+          stepByStepBulkCreate
+          trimOnCreate
+          value={selections}
+        />
+      </div>
+
+      <div>
+        <p>已選擇數量: {selections.length}</p>
+        <p>選項數量: {options.length}</p>
+      </div>
+    </div>
+  );
+};
+
+export const InsideBulkCreate: StoryObj<typeof AutoComplete> = {
+  render: () => <InsideBulkCreateComponent />,
+};
+
+const InsideEmptyComponent = () => {
+  const [open, setOpen] = useState(true);
+
+  const closeDropdown = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        maxWidth: '240px',
+      }}
+    >
+      <div>
+        <h3>inside 多選模式 - 單選風格 checked icon + empty</h3>
+        <Tag
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            setOpen(!open);
+          }}
+          type="addable"
+          label={open ? '收起選單' : '展開選單'}
+        />
+        <AutoComplete
+          emptyText="沒有符合的項目"
+          fullWidth
+          inputPosition="inside"
+          mode="multiple"
+          open={open}
+          onVisibilityChange={closeDropdown}
+          options={[]}
+          placeholder="沒有選項可選"
+          value={[]}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const InsideEmpty: StoryObj<typeof AutoComplete> = {
+  render: () => <InsideEmptyComponent />,
+};
+
+const InsideLoadingComponent = () => {
+  const [open, setOpen] = useState(true);
+
+  const closeDropdown = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        maxWidth: '240px',
+      }}
+    >
+      <div>
+        <h3>inside 多選模式 - 單選風格 checked icon + loading</h3>
+        <Tag
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            setOpen(!open);
+          }}
+          type="addable"
+          label={open ? '收起選單' : '展開選單'}
+        />
+        <AutoComplete
+          emptyText="沒有符合的項目"
+          fullWidth
+          inputPosition="inside"
+          loading
+          loadingPosition="full"
+          loadingText="載入中..."
+          mode="multiple"
+          open={open}
+          onVisibilityChange={closeDropdown}
+          options={[]}
+          placeholder="資料載入中..."
+          value={[]}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const InsideLoading: StoryObj<typeof AutoComplete> = {
+  render: () => <InsideLoadingComponent />,
 };
 
 const LoadMoreOnReachBottomComponent = () => {

--- a/packages/react/src/AutoComplete/AutoComplete.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.tsx
@@ -87,6 +87,8 @@ export interface AutoCompleteBaseProps
   asyncData?: boolean;
   /**
    * Whether to clear search text when leaving the textfield/dropdown scope.
+   * When `false`, typed text persists after blur. In `single` mode, a clearable
+   * icon will appear if the user has typed text without selecting an option.
    * @default true
    */
   clearSearchText?: boolean;
@@ -112,7 +114,10 @@ export interface AutoCompleteBaseProps
    */
   id?: string;
   /**
-   * The position of the input.
+   * The position of the search input relative to the dropdown.
+   * - `'outside'`: input is always visible above the dropdown (default trigger layout).
+   * - `'inside'`: input is rendered inside the dropdown panel; the trigger shows only
+   *   the selected value(s) and opens the dropdown on click.
    * @default 'outside'
    */
   inputPosition?: DropdownInputPosition;
@@ -159,10 +164,10 @@ export interface AutoCompleteBaseProps
    */
   name?: string;
   /**
-   * insert callback whenever insert icon is clicked
-   * receives the text to insert and current options, returns the updated options array
-   * should remove previously created but unselected options
-   * The returned options will be used to update the component's options prop
+   * Callback fired when the user confirms a new item creation.
+   * Receives the typed text and the current options array; must return the updated options array.
+   * Use this to append the new item to your options state.
+   * Required when `addable` is true; omitting it will disable the creation feature.
    */
   onInsert?(text: string, currentOptions: SelectValue[]): SelectValue[];
   /**
@@ -254,9 +259,10 @@ export interface AutoCompleteBaseProps
    */
   onLeaveBottom?: () => void;
   /**
-   * Called on blur when addable mode has unselected created items.
-   * Receives the cleaned options (unselected created items already removed).
-   * Use this to update your options state.
+   * Called when the dropdown closes (on blur or Escape) and `addable` mode has
+   * items that were created but never selected.
+   * Receives the cleaned options array with unselected created items already removed.
+   * Use this to sync your options state and strip the dangling created entries.
    * Only called when `addable` is true and there are unselected created items.
    */
   onRemoveCreated?(cleanedOptions: SelectValue[]): void;
@@ -348,7 +354,8 @@ function isSingleValue(
 /**
  * 自動完成輸入元件，在使用者輸入時即時顯示符合的下拉選項。
  *
- * 支援 `single`（單選）與 `multiple`（多選標籤）兩種模式；設定 `addable` 與 `onInsert`
+ * 支援 `single`（單選）與 `multiple`（多選標籤）兩種模式；`inputPosition` 控制搜尋輸入框
+ * 位於下拉選單外（`'outside'`，預設）或內（`'inside'`）。設定 `addable` 與 `onInsert`
  * 可讓使用者動態建立不在選項清單中的項目。`asyncData` 搭配 `onSearch` 可實現非同步搜尋，
  * 輸入時觸發 debounce 查詢並顯示 loading 狀態。若僅需從固定選項中搜尋，請改用 `Select` 元件。
  *
@@ -368,6 +375,15 @@ function isSingleValue(
  * // 多選模式
  * <AutoComplete
  *   mode="multiple"
+ *   options={options}
+ *   value={selectedList}
+ *   onChange={setSelectedList}
+ * />
+ *
+ * // 搜尋框置於下拉選單內（inside 模式）
+ * <AutoComplete
+ *   mode="multiple"
+ *   inputPosition="inside"
  *   options={options}
  *   value={selectedList}
  *   onChange={setSelectedList}

--- a/packages/react/src/AutoComplete/AutoComplete.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.tsx
@@ -53,6 +53,7 @@ import {
 import { useAutoCompleteKeyboard } from './useAutoCompleteKeyboard';
 import { useAutoCompleteSearch } from './useAutoCompleteSearch';
 import { useCreationTracker } from './useCreationTracker';
+import AutoCompleteInsideTrigger from './AutoCompleteInside';
 
 export interface AutoCompleteBaseProps
   extends Omit<
@@ -705,7 +706,10 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     );
 
     useEffect(() => {
-      if (!isMultiple) return;
+      // Multiple mode bridge only applies to SelectTrigger (tags) rendering.
+      // In `inputPosition="inside"` we render a plain Input trigger, so the hidden
+      // SelectTrigger input bridge is not needed.
+      if (!isMultiple || inputPosition === 'inside') return;
 
       const hiddenTriggerInput =
         nodeRef.current?.querySelector<HTMLInputElement>(
@@ -721,7 +725,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
 
       hiddenTriggerInput.value = bridgeValue;
       hiddenTriggerInput.dispatchEvent(new Event('change', { bubbles: true }));
-    }, [isMultiple, searchText, value]);
+    }, [inputPosition, isMultiple, searchText, value]);
 
     // In single mode, show searchText when focused, otherwise show selected value
     // In multiple mode, always return empty string to avoid displaying "0"
@@ -736,6 +740,30 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
         return () => '';
       }
       return undefined;
+    }, [
+      focused,
+      isMultiple,
+      isSingle,
+      searchText,
+      shouldClearSearchTextOnBlur,
+      value,
+    ]);
+
+    const insideInputValue = useMemo(() => {
+      // Inside trigger is a plain Input, so we must decide what to display.
+      // - multiple: always show current search text
+      // - single: show search text when focused (or when clear-on-blur is disabled)
+      if (isMultiple) return searchText;
+
+      if (
+        isSingle &&
+        (focused || (!shouldClearSearchTextOnBlur && !value && searchText))
+      ) {
+        return searchText;
+      }
+
+      if (isSingleValue(value)) return value.name;
+      return '';
     }, [
       focused,
       isMultiple,
@@ -781,8 +809,8 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
       }
 
       // Only open if not already open to avoid flickering
-      // When inputPosition is inside, Dropdown will handle opening via inlineTriggerElement
-      if (inputPosition !== 'inside' && !open) {
+      // Ensure inside/uncontrolled can open from the native input focus.
+      if (!open) {
         toggleOpen(true);
       }
       onFocus(true);
@@ -888,11 +916,13 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
           name: option.name,
         };
 
-        // Set checkSite based on mode
-        // Multiple mode: show checkbox at prepend
-        // Single mode: show checked icon at append when selected
+        // Set checkSite based on mode and input position.
+        // - inside + multiple: keep multiple behavior, but render single-like checked icon
+        //   at suffix to match product visual expectation.
+        // - outside + multiple: render checkbox at prefix.
+        // - single: render checked icon at suffix.
         if (mode === 'multiple') {
-          result.checkSite = 'prefix';
+          result.checkSite = inputPosition === 'inside' ? 'suffix' : 'prefix';
         } else {
           result.checkSite = 'suffix';
         }
@@ -904,7 +934,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
 
         return result;
       });
-    }, [isCreated, mode, options]);
+    }, [inputPosition, isCreated, mode, options]);
 
     // Get selected value for dropdown
     const dropdownValue = useMemo(() => {
@@ -1047,6 +1077,10 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
             setKeyboardActiveIndex(null);
             setListboxHasVisualFocus(false);
             onFocus(false);
+            if (isMultiple && shouldClearSearchTextOnBlur) {
+              resetSearchInputsAndOptions();
+              cleanupUnselectedCreated();
+            }
             inputElementRef.current?.blur();
             inputProps?.onKeyDown?.(e);
             return;
@@ -1055,12 +1089,16 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
           handleInputKeyDown(e);
         },
         [
+          cleanupUnselectedCreated,
           handleInputKeyDown,
           inputProps,
+          isMultiple,
           onFocus,
+          resetSearchInputsAndOptions,
           setActiveIndex,
           setKeyboardActiveIndex,
           setListboxHasVisualFocus,
+          shouldClearSearchTextOnBlur,
           toggleOpen,
         ],
       );
@@ -1188,6 +1226,9 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
             showDropdownActions={shouldShowCreateAction}
             showActionShowTopBar={shouldShowCreateAction}
             status={dropdownStatus}
+            toggleCheckedOnClick={
+              inputPosition === 'inside' && mode === 'multiple' ? false : undefined
+            }
             type="default"
             value={dropdownValue}
             zIndex={dropdownZIndex}
@@ -1195,6 +1236,27 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
             onReachBottom={onReachBottom}
             onLeaveBottom={onLeaveBottom}
           >
+          {inputPosition === 'inside' ? (
+            <AutoCompleteInsideTrigger
+              active={open}
+              className={className}
+              clearable={shouldForceClearable}
+              disabled={isInputDisabled}
+              error={error}
+              fullWidth={fullWidth}
+              inputRef={composedInputRef}
+              onClear={handleClear}
+              placeholder={getPlaceholder()}
+              resolvedInputProps={{
+                ...resolvedInputProps,
+                onClick: (e: ReactMouseEvent<HTMLInputElement>) => {
+                  resolvedInputProps.onClick?.(e);
+                },
+              }}
+              size={size}
+              value={insideInputValue}
+            />
+          ) : (
             <SelectTrigger
               ref={composedRef}
               active={open}
@@ -1220,9 +1282,8 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
                 onClick: (e: ReactMouseEvent<HTMLInputElement>) => {
                   // When inputPosition is inside, let Dropdown handle the click event
                   // Otherwise, stop propagation to prevent conflicts
-                  if (inputPosition !== 'inside') {
-                    e.stopPropagation();
-                  }
+                  // This branch is only rendered when `inputPosition !== 'inside'`.
+                  e.stopPropagation();
                   resolvedInputProps.onClick?.(e);
                 },
               }}
@@ -1239,6 +1300,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
               }
               {...(mode === 'single' && renderValue ? { renderValue } : {})}
             />
+          )}
           </Dropdown>
         </div>
       </SelectControlContext.Provider>

--- a/packages/react/src/AutoComplete/AutoComplete.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.tsx
@@ -955,7 +955,8 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     const shouldForceClearable = isMultiple
       ? (isMultipleValue(value) && value.length > 0) ||
         searchText.trim().length > 0
-      : isSingleValue(value);
+      : isSingleValue(value) ||
+        (!shouldClearSearchTextOnBlur && searchText.trim().length > 0);
 
     // Handle dropdown option selection
     const handleDropdownSelect = useCallback(

--- a/packages/react/src/AutoComplete/AutoCompleteInside.tsx
+++ b/packages/react/src/AutoComplete/AutoCompleteInside.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { type MouseEventHandler, type Ref } from 'react';
+
+import Input from '../Input';
+import type { InputProps } from '../Input';
+import type { SelectTriggerInputProps } from '../Select/typings';
+
+export interface AutoCompleteInsideTriggerProps {
+  /**
+   * Disabled state for the input.
+   */
+  disabled: boolean;
+  /**
+   * Error state for the input.
+   */
+  error: boolean;
+  /**
+   * Whether the trigger should render as active (focused/open).
+   */
+  active: boolean;
+  /**
+   * Input display value (usually the current search text).
+   */
+  value: string;
+  /**
+   * Input placeholder text.
+   */
+  placeholder?: string;
+  /**
+   * Input variant sizing.
+   */
+  size?: InputProps['size'];
+  /**
+   * Whether the input should occupy full width.
+   */
+  fullWidth?: boolean;
+  /**
+   * Additional class name for the trigger.
+   */
+  className?: string;
+  /**
+   * Input ref (points to the underlying <input/> element).
+   */
+  inputRef?: Ref<HTMLInputElement>;
+  /**
+   * Props forwarded to the underlying input element.
+   */
+  resolvedInputProps: SelectTriggerInputProps;
+  /**
+   * Input clear handler.
+   */
+  clearable: boolean;
+  onClear?: MouseEventHandler;
+}
+
+function extractIdAndName(props: SelectTriggerInputProps) {
+  const { id, name, readOnly, onChange, ...rest } = props;
+  return { id, name, onChange, rest };
+}
+
+export default function AutoCompleteInsideTrigger(props: AutoCompleteInsideTriggerProps) {
+  const {
+    active,
+    className,
+    clearable,
+    disabled,
+    error,
+    fullWidth,
+    inputRef,
+    onClear,
+    placeholder,
+    resolvedInputProps,
+    size,
+    value,
+  } = props;
+
+  const { id, name, onChange, rest } = extractIdAndName(resolvedInputProps);
+
+  return (
+    <Input
+      active={active}
+      className={className}
+      {...(disabled ? { disabled: true as const } : {})}
+      error={error}
+      fullWidth={fullWidth}
+      id={id}
+      name={name}
+      placeholder={placeholder}
+      onChange={onChange}
+      size={size}
+      value={value}
+      clearable={clearable}
+      onClear={onClear}
+      // keep clear icon visibility behavior consistent with SelectTrigger
+      forceShowClearable={clearable}
+      inputRef={inputRef}
+      inputProps={rest}
+    />
+  );
+}
+

--- a/packages/react/src/AutoComplete/AutoCompleteInside.tsx
+++ b/packages/react/src/AutoComplete/AutoCompleteInside.tsx
@@ -2,8 +2,8 @@
 
 import { type MouseEventHandler, type Ref } from 'react';
 
-import Input from '../Input';
 import type { InputProps } from '../Input';
+import Input from '../Input';
 import type { SelectTriggerInputProps } from '../Select/typings';
 
 export interface AutoCompleteInsideTriggerProps {
@@ -48,9 +48,12 @@ export interface AutoCompleteInsideTriggerProps {
    */
   resolvedInputProps: SelectTriggerInputProps;
   /**
-   * Input clear handler.
+   * Whether to show the clear icon.
    */
   clearable: boolean;
+  /**
+   * Input clear handler.
+   */
   onClear?: MouseEventHandler;
 }
 

--- a/packages/react/src/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/Dropdown/DropdownItem.tsx
@@ -627,7 +627,12 @@ export default function DropdownItem<
               // In `tree` + `multiple` mode, `DropdownItemCard` already triggers selection via
               // `onCheckedChange` when row is clicked (it toggles checked first, then calls `onClick`),
               // so calling `onSelect` here would cause it to fire twice for leaf nodes.
-              if (!(type === 'tree' && mode === 'multiple')) {
+              // In `multiple` mode, row click also triggers `onCheckedChange` when
+              // `toggleCheckedOnClick` is enabled, so avoid firing `onSelect` twice.
+              if (
+                !(type === 'tree' && mode === 'multiple') &&
+                !(mode === 'multiple' && resolvedToggleCheckedOnClick)
+              ) {
                 onSelect?.(option);
               }
             }


### PR DESCRIPTION
 ## Summary

- **Inside mode — dropdown open on focus**: `inputPosition="inside"` now correctly opens the dropdown when the native input receives focus; previously only `outside` mode worked
- **Inside mode — Escape cleanup**: pressing Escape in `multiple` mode now calls `onRemoveCreated` and clears search text, consistent with blur behavior
- **Double onSelect prevention**: added `toggleCheckedOnClick={false}` for `inside` + `multiple` and a guard in `DropdownItem` to prevent `onSelect` firing twice per click
- **Outside mode — clearable with persisted text**: in `single` mode with `clearSearchText={false}`, the ✕ icon now appears when the user has typed text but not selected an option
- **Outside mode — input overflow**: the search input in `multiple` mode no longer overflows the trigger container when a long string is typed (`width: 100%` added to `__tags-input input`)
- **Core**: hides the plain `Input` trigger visually when the dropdown is closed in inside mode
