### PR TITLE
feat(drawer&notification-center): expose filterBarOnSelect and align Drawer filterArea API

### DIFF
--- a/packages/core/src/drawer/_drawer-styles.scss
+++ b/packages/core/src/drawer/_drawer-styles.scss
@@ -70,7 +70,7 @@ $drawer-size-config: (
     }
   }
 
-  &__control-bar {
+  &__filter-area {
     align-items: center;
     border-block-end: 1px solid palette.semantic-variable(separator, neutral-faint);
     display: flex;

--- a/packages/core/src/drawer/drawer.ts
+++ b/packages/core/src/drawer/drawer.ts
@@ -23,6 +23,6 @@ export const drawerClasses = {
   bottom__actions: `${drawerPrefix}__bottom__actions`,
   size: (size: DrawerSize) => `${drawerPrefix}--${size}`,
   content: `${drawerPrefix}__content`,
-  controlBar: `${drawerPrefix}__control-bar`,
-  controlBarButtonOnly: `${drawerPrefix}__control-bar--button-only`,
+  filterArea: `${drawerPrefix}__filter-area`,
+  filterAreaButtonOnly: `${drawerPrefix}__filter-area--button-only`,
 } as const;

--- a/packages/react/src/Drawer/Drawer.spec.tsx
+++ b/packages/react/src/Drawer/Drawer.spec.tsx
@@ -4,7 +4,8 @@ import {
   drawerClasses as classes,
 } from '@mezzanine-ui/core/drawer';
 import { CloseIcon } from '@mezzanine-ui/icons';
-import { cleanup, cleanupHook, fireEvent, render } from '../../__test-utils__';
+import userEvent from '@testing-library/user-event';
+import { cleanup, cleanupHook, fireEvent, render, screen, waitFor } from '../../__test-utils__';
 import { describeForwardRefToHTMLElement } from '../../__test-utils__/common';
 import Drawer from '.';
 
@@ -691,41 +692,41 @@ describe('<Drawer />', () => {
     });
   });
 
-  describe('prop: controlBar (default)', () => {
-    it('should not render control bar by default when controlBarShow is false', () => {
+  describe('prop: filterArea (default)', () => {
+    it('should not render filter area by default when filterAreaShow is false', () => {
       render(<Drawer open>Content</Drawer>);
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
 
-      expect(controlBarElement).toBe(null);
+      expect(filterAreaElement).toBe(null);
     });
 
-    it('should render control bar when controlBarShow is true', () => {
+    it('should render filter area when filterAreaShow is true', () => {
       render(
-        <Drawer controlBarAllRadioLabel="All" controlBarShow open>
+        <Drawer filterAreaAllRadioLabel="All" filterAreaShow open>
           Content
         </Drawer>,
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
 
-      expect(controlBarElement).toBeInstanceOf(Node);
+      expect(filterAreaElement).toBeInstanceOf(Node);
     });
 
     it('should render RadioGroup with correct labels', () => {
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarReadRadioLabel="Read"
-          controlBarShow
-          controlBarShowUnreadButton
-          controlBarUnreadRadioLabel="Unread"
+          filterAreaAllRadioLabel="All"
+          filterAreaReadRadioLabel="Read"
+          filterAreaShow
+          filterAreaShowUnreadButton
+          filterAreaUnreadRadioLabel="Unread"
           open
         >
           Content
@@ -733,14 +734,14 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const radios = controlBarElement?.querySelectorAll('input[type="radio"]');
+      const radios = filterAreaElement?.querySelectorAll('input[type="radio"]');
 
       expect(radios?.length).toBe(3);
 
-      const labels = controlBarElement?.querySelectorAll('label');
+      const labels = filterAreaElement?.querySelectorAll('label');
       const labelTexts = Array.from(labels || []).map(
         (label) => label.textContent,
       );
@@ -750,14 +751,14 @@ describe('<Drawer />', () => {
       expect(labelTexts).toContain('Unread');
     });
 
-    it('should render only 2 radios when controlBarShowUnreadButton is false', () => {
+    it('should render only 2 radios when filterAreaShowUnreadButton is false', () => {
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarReadRadioLabel="Read"
-          controlBarShow
-          controlBarShowUnreadButton={false}
-          controlBarUnreadRadioLabel="Unread"
+          filterAreaAllRadioLabel="All"
+          filterAreaReadRadioLabel="Read"
+          filterAreaShow
+          filterAreaShowUnreadButton={false}
+          filterAreaUnreadRadioLabel="Unread"
           open
         >
           Content
@@ -765,10 +766,10 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const radios = controlBarElement?.querySelectorAll('input[type="radio"]');
+      const radios = filterAreaElement?.querySelectorAll('input[type="radio"]');
 
       expect(radios?.length).toBe(2);
     });
@@ -776,10 +777,10 @@ describe('<Drawer />', () => {
     it('should render custom button with correct label', () => {
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarCustomButtonLabel="Clear All"
-          controlBarOnCustomButtonClick={jest.fn()}
-          controlBarShow
+          filterAreaAllRadioLabel="All"
+          filterAreaCustomButtonLabel="Clear All"
+          filterAreaOnCustomButtonClick={jest.fn()}
+          filterAreaShow
           open
         >
           Content
@@ -787,23 +788,23 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const button = controlBarElement?.querySelector('button');
+      const button = filterAreaElement?.querySelector('button');
 
       expect(button).toBeInstanceOf(HTMLButtonElement);
       expect(button?.textContent).toBe('Clear All');
       expect(button?.classList.contains('mzn-button--base-ghost')).toBeTruthy();
     });
 
-    it('should disable custom button when controlBarIsEmpty is true', () => {
+    it('should disable custom button when filterAreaIsEmpty is true', () => {
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarIsEmpty
-          controlBarOnCustomButtonClick={jest.fn()}
-          controlBarShow
+          filterAreaAllRadioLabel="All"
+          filterAreaIsEmpty
+          filterAreaOnCustomButtonClick={jest.fn()}
+          filterAreaShow
           open
         >
           Content
@@ -811,23 +812,23 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const button = controlBarElement?.querySelector(
+      const button = filterAreaElement?.querySelector(
         'button',
       ) as HTMLButtonElement;
 
       expect(button?.disabled).toBe(true);
     });
 
-    it('should enable custom button when controlBarIsEmpty is false', () => {
+    it('should enable custom button when filterAreaIsEmpty is false', () => {
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarIsEmpty={false}
-          controlBarOnCustomButtonClick={jest.fn()}
-          controlBarShow
+          filterAreaAllRadioLabel="All"
+          filterAreaIsEmpty={false}
+          filterAreaOnCustomButtonClick={jest.fn()}
+          filterAreaShow
           open
         >
           Content
@@ -835,24 +836,24 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const button = controlBarElement?.querySelector(
+      const button = filterAreaElement?.querySelector(
         'button',
       ) as HTMLButtonElement;
 
       expect(button?.disabled).toBe(false);
     });
 
-    it('should call controlBarOnCustomButtonClick when custom button clicked', () => {
+    it('should call filterAreaOnCustomButtonClick when custom button clicked', () => {
       const onCustomButtonClick = jest.fn();
 
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarOnCustomButtonClick={onCustomButtonClick}
-          controlBarShow
+          filterAreaAllRadioLabel="All"
+          filterAreaOnCustomButtonClick={onCustomButtonClick}
+          filterAreaShow
           open
         >
           Content
@@ -860,10 +861,10 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const button = controlBarElement?.querySelector(
+      const button = filterAreaElement?.querySelector(
         'button',
       ) as HTMLButtonElement;
 
@@ -872,15 +873,15 @@ describe('<Drawer />', () => {
       expect(onCustomButtonClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should call controlBarOnRadioChange when radio selection changes', () => {
+    it('should call filterAreaOnRadioChange when radio selection changes', () => {
       const onRadioChange = jest.fn();
 
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarOnRadioChange={onRadioChange}
-          controlBarReadRadioLabel="Read"
-          controlBarShow
+          filterAreaAllRadioLabel="All"
+          filterAreaOnRadioChange={onRadioChange}
+          filterAreaReadRadioLabel="Read"
+          filterAreaShow
           open
         >
           Content
@@ -888,10 +889,10 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const radios = controlBarElement?.querySelectorAll(
+      const radios = filterAreaElement?.querySelectorAll(
         'input[type="radio"]',
       ) as NodeListOf<HTMLInputElement>;
 
@@ -903,10 +904,10 @@ describe('<Drawer />', () => {
     it('should set default value for RadioGroup', () => {
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarDefaultValue="read"
-          controlBarReadRadioLabel="Read"
-          controlBarShow
+          filterAreaAllRadioLabel="All"
+          filterAreaDefaultValue="read"
+          filterAreaReadRadioLabel="Read"
+          filterAreaShow
           open
         >
           Content
@@ -914,10 +915,10 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const radios = controlBarElement?.querySelectorAll(
+      const radios = filterAreaElement?.querySelectorAll(
         'input[type="radio"]',
       ) as NodeListOf<HTMLInputElement>;
       const checkedRadio = Array.from(radios).find((radio) => radio.checked);
@@ -928,10 +929,10 @@ describe('<Drawer />', () => {
     it('should control RadioGroup value', () => {
       const { rerender } = render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarReadRadioLabel="Read"
-          controlBarShow
-          controlBarValue="all"
+          filterAreaAllRadioLabel="All"
+          filterAreaReadRadioLabel="Read"
+          filterAreaShow
+          filterAreaValue="all"
           open
         >
           Content
@@ -939,10 +940,10 @@ describe('<Drawer />', () => {
       );
 
       let drawerElement = getDrawerElement()!;
-      let controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      let filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      let radios = controlBarElement?.querySelectorAll(
+      let radios = filterAreaElement?.querySelectorAll(
         'input[type="radio"]',
       ) as NodeListOf<HTMLInputElement>;
       let checkedRadio = Array.from(radios).find((radio) => radio.checked);
@@ -951,10 +952,10 @@ describe('<Drawer />', () => {
 
       rerender(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarReadRadioLabel="Read"
-          controlBarShow
-          controlBarValue="read"
+          filterAreaAllRadioLabel="All"
+          filterAreaReadRadioLabel="Read"
+          filterAreaShow
+          filterAreaValue="read"
           open
         >
           Content
@@ -962,8 +963,8 @@ describe('<Drawer />', () => {
       );
 
       drawerElement = getDrawerElement()!;
-      controlBarElement = drawerElement.querySelector(`.${classes.controlBar}`);
-      radios = controlBarElement?.querySelectorAll(
+      filterAreaElement = drawerElement.querySelector(`.${classes.filterArea}`);
+      radios = filterAreaElement?.querySelectorAll(
         'input[type="radio"]',
       ) as NodeListOf<HTMLInputElement>;
       checkedRadio = Array.from(radios).find((radio) => radio.checked);
@@ -973,17 +974,17 @@ describe('<Drawer />', () => {
 
     it('should not render control bar when no radio labels and no button callback are provided', () => {
       render(
-        <Drawer controlBarShow open>
+        <Drawer filterAreaShow open>
           Content
         </Drawer>,
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
 
-      expect(controlBarElement).toBe(null);
+      expect(filterAreaElement).toBe(null);
     });
 
     it('should render control bar with only button when no radio labels provided but button callback exists', () => {
@@ -991,9 +992,9 @@ describe('<Drawer />', () => {
 
       render(
         <Drawer
-          controlBarCustomButtonLabel="Action"
-          controlBarOnCustomButtonClick={onCustomButtonClick}
-          controlBarShow
+          filterAreaCustomButtonLabel="Action"
+          filterAreaOnCustomButtonClick={onCustomButtonClick}
+          filterAreaShow
           open
         >
           Content
@@ -1001,15 +1002,15 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const radioGroup = controlBarElement?.querySelector('.mzn-radio-group');
-      const button = controlBarElement?.querySelector('button');
+      const radioGroup = filterAreaElement?.querySelector('.mzn-radio-group');
+      const button = filterAreaElement?.querySelector('button');
 
-      expect(controlBarElement).toBeInstanceOf(Node);
+      expect(filterAreaElement).toBeInstanceOf(Node);
       expect(
-        controlBarElement?.classList.contains(classes.controlBarButtonOnly),
+        filterAreaElement?.classList.contains(classes.filterAreaButtonOnly),
       ).toBeTruthy();
       expect(radioGroup).toBe(null);
       expect(button).toBeInstanceOf(HTMLButtonElement);
@@ -1021,8 +1022,8 @@ describe('<Drawer />', () => {
 
       render(
         <Drawer
-          controlBarOnCustomButtonClick={onCustomButtonClick}
-          controlBarShow
+          filterAreaOnCustomButtonClick={onCustomButtonClick}
+          filterAreaShow
           open
         >
           Content
@@ -1030,10 +1031,10 @@ describe('<Drawer />', () => {
       );
 
       const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const filterAreaElement = drawerElement.querySelector(
+        `.${classes.filterArea}`,
       );
-      const button = controlBarElement?.querySelector(
+      const button = filterAreaElement?.querySelector(
         'button',
       ) as HTMLButtonElement;
 
@@ -1043,114 +1044,79 @@ describe('<Drawer />', () => {
     });
   });
 
-  describe('prop: renderControlBar', () => {
-    it('should not render control bar by default', () => {
-      render(<Drawer open>Content</Drawer>);
-
-      const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        '[data-testid="control-bar"]',
-      );
-
-      expect(controlBarElement).toBe(null);
-    });
-
-    it('should render custom control bar when renderControlBar provided', () => {
-      const renderControlBar = () => (
-        <div data-testid="control-bar">Custom Control Bar</div>
-      );
-
-      render(
-        <Drawer open renderControlBar={renderControlBar}>
-          Content
-        </Drawer>,
-      );
-
-      const drawerElement = getDrawerElement()!;
-      const controlBarElement = drawerElement.querySelector(
-        '[data-testid="control-bar"]',
-      );
-
-      expect(controlBarElement).toBeInstanceOf(Node);
-      expect(controlBarElement?.textContent).toBe('Custom Control Bar');
-    });
-
-    it('should render control bar between header and content', () => {
-      const renderControlBar = () => (
-        <div data-testid="control-bar">Control Bar</div>
-      );
-
+  describe('prop: filterAreaOptions', () => {
+    it('should render icon button when filterAreaOptions is non-empty', () => {
       render(
         <Drawer
-          headerTitle="Header"
-          isHeaderDisplay
+          filterAreaShow
+          filterAreaOptions={[{ id: 'a', name: 'A' }]}
           open
-          renderControlBar={renderControlBar}
         >
           Content
         </Drawer>,
       );
 
-      const drawerElement = getDrawerElement()!;
-      const headerElement = drawerElement.querySelector(`.${classes.header}`);
-      const controlBarElement = drawerElement.querySelector(
-        '[data-testid="control-bar"]',
+      const filterAreaElement = getDrawerElement()!.querySelector(
+        `.${classes.filterArea}`,
       );
-      const contentElement = drawerElement.querySelector(`.${classes.content}`);
+      const iconButton = filterAreaElement?.querySelector('button');
 
-      // Check all elements exist
-      expect(headerElement).toBeInstanceOf(Node);
-      expect(controlBarElement).toBeInstanceOf(Node);
-      expect(contentElement).toBeInstanceOf(Node);
-
-      // Check order: header should come before control bar, control bar before content
-      const childNodes = Array.from(drawerElement.children);
-      const headerIndex = childNodes.indexOf(headerElement as Element);
-      const controlBarIndex = childNodes.indexOf(controlBarElement as Element);
-      const contentIndex = childNodes.indexOf(contentElement as Element);
-
-      expect(headerIndex).toBeLessThan(controlBarIndex);
-      expect(controlBarIndex).toBeLessThan(contentIndex);
+      expect(iconButton).toBeInstanceOf(Node);
+      expect(iconButton?.querySelector('i[data-icon-name]')).toBeInstanceOf(Node);
     });
 
-    it('should call renderControlBar function', () => {
-      const renderControlBar = jest.fn(() => <div>Control Bar</div>);
-
-      render(
-        <Drawer open renderControlBar={renderControlBar}>
-          Content
-        </Drawer>,
-      );
-
-      expect(renderControlBar).toHaveBeenCalled();
-    });
-
-    it('should use renderControlBar over default control bar when both provided', () => {
-      const renderControlBar = () => (
-        <div data-testid="custom-control-bar">Custom Control Bar</div>
-      );
-
+    it('should render plain text button when filterAreaOptions is empty', () => {
       render(
         <Drawer
-          controlBarAllRadioLabel="All"
-          controlBarShow
+          filterAreaCustomButtonLabel="Clear"
+          filterAreaOnCustomButtonClick={jest.fn()}
+          filterAreaShow
+          filterAreaOptions={[]}
           open
-          renderControlBar={renderControlBar}
         >
           Content
         </Drawer>,
       );
 
-      const drawerElement = getDrawerElement()!;
-      const customControlBar = drawerElement.querySelector(
-        '[data-testid="custom-control-bar"]',
+      const filterAreaElement = getDrawerElement()!.querySelector(
+        `.${classes.filterArea}`,
       );
-      const defaultControlBar = drawerElement.querySelector(
-        `.${classes.controlBar}`,
+      const button = filterAreaElement?.querySelector('button');
+
+      expect(button?.textContent).toBe('Clear');
+    });
+
+    it('should call filterAreaOnSelect when a dropdown option is selected', async () => {
+      const user = userEvent.setup();
+      const onSelect = jest.fn();
+
+      render(
+        <Drawer
+          filterAreaShow
+          filterAreaOnSelect={onSelect}
+          filterAreaOptions={[{ id: 'a', name: 'Option A' }]}
+          open
+        >
+          Content
+        </Drawer>,
       );
 
-      expect(customControlBar).toBeInstanceOf(Node);
-      expect(defaultControlBar).toBe(null);
+      const filterAreaElement = getDrawerElement()!.querySelector(
+        `.${classes.filterArea}`,
+      );
+      const iconButton = filterAreaElement?.querySelector('button') as HTMLButtonElement;
+
+      await user.click(iconButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Option A')).toBeTruthy();
+      });
+
+      await user.click(screen.getByText('Option A'));
+
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'a' }),
+      );
     });
   });
 
@@ -1420,20 +1386,18 @@ describe('<Drawer />', () => {
     it('should render complete drawer with header, control bar, content, and bottom actions', () => {
       const onClose = jest.fn();
       const onPrimaryActionClick = jest.fn();
-      const renderControlBar = () => (
-        <div data-testid="control-bar">Filter Control Bar</div>
-      );
 
       render(
         <Drawer
           bottomOnPrimaryActionClick={onPrimaryActionClick}
           bottomPrimaryActionText="Submit"
+          filterAreaAllRadioLabel="All"
+          filterAreaShow
           headerTitle="Complete Drawer"
           isBottomDisplay
           isHeaderDisplay
           onClose={onClose}
           open
-          renderControlBar={renderControlBar}
           size="wide"
         >
           <div>Main Content</div>
@@ -1442,19 +1406,16 @@ describe('<Drawer />', () => {
 
       const drawerElement = getDrawerElement()!;
       const headerElement = drawerElement.querySelector(`.${classes.header}`);
-      const controlBarElement = drawerElement.querySelector(
-        '[data-testid="control-bar"]',
-      );
+      const filterAreaElement = drawerElement.querySelector(`.${classes.filterArea}`);
       const contentElement = drawerElement.querySelector(`.${classes.content}`);
       const bottomElement = drawerElement.querySelector(`.${classes.bottom}`);
 
       expect(headerElement).toBeInstanceOf(Node);
-      expect(controlBarElement).toBeInstanceOf(Node);
+      expect(filterAreaElement).toBeInstanceOf(Node);
       expect(contentElement).toBeInstanceOf(Node);
       expect(bottomElement).toBeInstanceOf(Node);
 
       expect(headerElement?.textContent).toContain('Complete Drawer');
-      expect(controlBarElement?.textContent).toBe('Filter Control Bar');
       expect(contentElement?.textContent).toBe('Main Content');
     });
   });

--- a/packages/react/src/Drawer/Drawer.stories.tsx
+++ b/packages/react/src/Drawer/Drawer.stories.tsx
@@ -1,12 +1,16 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { StoryObj } from '@storybook/react-webpack5';
+import { DropdownOption } from '@mezzanine-ui/core/dropdown/dropdown';
 import {
   CheckedFilledIcon,
   ChevronLeftIcon,
+  ClockIcon,
   CloseIcon,
+  DownloadIcon,
   InfoOutlineIcon,
   PlusIcon,
+  UploadIcon
 } from '@mezzanine-ui/icons';
+import { StoryObj } from '@storybook/react-webpack5';
+import React, { useCallback, useEffect, useState } from 'react';
 import Drawer, { DrawerProps } from '.';
 import { Button, Modal, Typography } from '../index';
 
@@ -314,16 +318,16 @@ export const WithControlBar: StoryObj<DrawerProps> = {
         </Button>
 
         <Drawer
-          controlBarAllRadioLabel="全部"
-          controlBarCustomButtonLabel="清除"
-          controlBarDefaultValue="all"
-          controlBarOnCustomButtonClick={() => alert('清除篩選')}
-          controlBarOnRadioChange={(e) => setFilter(e.target.value)}
-          controlBarReadRadioLabel="進行中"
-          controlBarShow
-          controlBarShowUnreadButton
-          controlBarUnreadRadioLabel="已完成"
-          controlBarValue={filter}
+          filterAreaAllRadioLabel="全部"
+          filterAreaCustomButtonLabel="清除"
+          filterAreaDefaultValue="all"
+          filterAreaOnCustomButtonClick={() => alert('清除篩選')}
+          filterAreaOnRadioChange={(e) => setFilter(e.target.value)}
+          filterAreaReadRadioLabel="進行中"
+          filterAreaShow
+          filterAreaShowUnreadButton
+          filterAreaUnreadRadioLabel="已完成"
+          filterAreaValue={filter}
           headerTitle="內容篩選器"
           isHeaderDisplay
           onClose={handleClose}
@@ -362,9 +366,9 @@ export const WithControlBarButtonOnly: StoryObj<DrawerProps> = {
         </Button>
 
         <Drawer
-          controlBarCustomButtonLabel="重置全部"
-          controlBarOnCustomButtonClick={() => alert('重置')}
-          controlBarShow
+          filterAreaCustomButtonLabel="重置全部"
+          filterAreaOnCustomButtonClick={() => alert('重置')}
+          filterAreaShow
           headerTitle="設定"
           isHeaderDisplay
           onClose={handleClose}
@@ -375,71 +379,6 @@ export const WithControlBarButtonOnly: StoryObj<DrawerProps> = {
             <Typography variant="body">
               這個 Drawer 的控制列只有按鈕，沒有 Radio Group
             </Typography>
-          </div>
-        </Drawer>
-      </>
-    );
-  },
-};
-
-export const WithCustomControlBar: StoryObj<DrawerProps> = {
-  render: function Render() {
-    const [open, setOpen] = useState(false);
-
-    const handleClose = useCallback(() => setOpen(false), []);
-
-    return (
-      <>
-        <Button onClick={() => setOpen(true)} variant="base-text-link">
-          開啟 Drawer (自訂控制列)
-        </Button>
-
-        <Drawer
-          headerTitle="設定"
-          isHeaderDisplay
-          onClose={handleClose}
-          open={open}
-          renderControlBar={() => (
-            <div
-              style={{
-                backgroundColor: '#f5f5f5',
-                borderBottom: '2px solid #1976d2',
-                padding: '12px 16px',
-              }}
-            >
-              <div
-                style={{
-                  alignItems: 'center',
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                }}
-              >
-                <Typography variant="text-link-body">快速操作</Typography>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                  <Button
-                    onClick={() => alert('重置')}
-                    size="minor"
-                    type="button"
-                    variant="base-secondary"
-                  >
-                    重置
-                  </Button>
-                  <Button
-                    onClick={() => alert('套用')}
-                    size="minor"
-                    type="button"
-                    variant="base-primary"
-                  >
-                    套用
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
-          size="medium"
-        >
-          <div style={{ padding: '16px' }}>
-            <Typography variant="body">這是 Drawer 的內容區域</Typography>
           </div>
         </Drawer>
       </>
@@ -613,6 +552,74 @@ export const WithModalWhileDrawerOpen: StoryObj<DrawerProps> = {
             測試 z-index 和背景遮罩是否正常運作。
           </Typography>
         </Modal>
+      </>
+    );
+  },
+};
+
+export const WithFilterBarDropdown: StoryObj<DrawerProps> = {
+  render: function Render() {
+    const [open, setOpen] = useState(false);
+    const [selected, setSelected] = useState('');
+    const handleClose = useCallback(() => setOpen(false), []);
+
+    const filterOptions: DropdownOption[] = [
+      { id: 'import', name: '匯入', icon: DownloadIcon },
+      { id: 'export', name: '匯出', icon: UploadIcon, showUnderline: true },
+      { id: 'past-version', name: '過去版本', icon: ClockIcon },
+    ];
+
+    return (
+      <>
+        <Button onClick={() => setOpen(true)} variant="base-text-link">
+          開啟 Drawer (篩選 Dropdown)
+        </Button>
+
+        <Drawer
+          filterAreaAllRadioLabel="今日"
+          filterAreaReadRadioLabel="本月"
+          filterAreaShow
+          filterAreaOnSelect={(opt) => setSelected(opt.id)}
+          filterAreaOptions={filterOptions}
+          headerTitle="篩選器 Dropdown 示範"
+          isHeaderDisplay
+          onClose={handleClose}
+          open={open}
+          size="narrow"
+        >
+          <div style={{ padding: '16px' }}>
+            <Typography variant="body">
+              已選擇篩選：{selected || '（尚未選擇）'}
+            </Typography>
+          </div>
+        </Drawer>
+      </>
+    );
+  },
+};
+
+export const WithFilterAreaOnCustomButton: StoryObj<DrawerProps> = {
+  render: function Render() {
+    const [open, setOpen] = useState(false);
+    const handleClose = useCallback(() => setOpen(false), []);
+
+    return (
+      <>
+        <Button onClick={() => setOpen(true)} variant="base-text-link">
+          開啟 Drawer (篩選 Dropdown)
+        </Button>
+
+        <Drawer
+          filterAreaAllRadioLabel="今日"
+          filterAreaReadRadioLabel="本月"
+          filterAreaShow
+          filterAreaOnCustomButtonClick={() => alert('清除篩選')}
+          headerTitle="篩選器 Dropdown 示範"
+          isHeaderDisplay
+          onClose={handleClose}
+          open={open}
+          size="narrow"
+        />
       </>
     );
   },

--- a/packages/react/src/Drawer/Drawer.tsx
+++ b/packages/react/src/Drawer/Drawer.tsx
@@ -1,43 +1,46 @@
-import React, {
+import {
+  ButtonIconType,
+  ButtonSize,
+  ButtonVariant,
+} from '@mezzanine-ui/core/button';
+import {
+  drawerClasses as classes,
+  DrawerSize,
+} from '@mezzanine-ui/core/drawer';
+import type { DropdownOption } from '@mezzanine-ui/core/dropdown';
+import { DotHorizontalIcon, IconDefinition } from '@mezzanine-ui/icons';
+import { MOTION_DURATION, MOTION_EASING } from '@mezzanine-ui/system/motion';
+import {
   forwardRef,
   useEffect,
   useMemo,
   useState,
   type ChangeEventHandler,
 } from 'react';
-import {
-  drawerClasses as classes,
-  DrawerSize,
-} from '@mezzanine-ui/core/drawer';
-import { IconDefinition } from '@mezzanine-ui/icons';
-import {
-  ButtonIconType,
-  ButtonSize,
-  ButtonVariant,
-} from '@mezzanine-ui/core/button';
-import { cx } from '../utils/cx';
-import { NativeElementPropsWithoutKeyAndRef } from '../utils/jsx-types';
 import Backdrop, { BackdropProps } from '../Backdrop';
+import Button from '../Button';
+import ClearActions from '../ClearActions';
+import Dropdown from '../Dropdown';
+import Radio from '../Radio/Radio';
+import RadioGroup from '../Radio/RadioGroup';
 import { Slide } from '../Transition';
 import { useDocumentEscapeKeyDown } from '../hooks/useDocumentEscapeKeyDown';
 import useTopStack from '../hooks/useTopStack';
-import ClearActions from '../ClearActions';
-import Button from '../Button';
-import Radio from '../Radio/Radio';
-import RadioGroup from '../Radio/RadioGroup';
-import { MOTION_DURATION, MOTION_EASING } from '@mezzanine-ui/system/motion';
+import { cx } from '../utils/cx';
+import { NativeElementPropsWithoutKeyAndRef } from '../utils/jsx-types';
+
 
 export interface DrawerProps
   extends NativeElementPropsWithoutKeyAndRef<'div'>,
-    Pick<
-      BackdropProps,
-      | 'container'
-      | 'disableCloseOnBackdropClick'
-      | 'disablePortal'
-      | 'onBackdropClick'
-      | 'onClose'
-      | 'open'
-    > {
+  Pick<
+    BackdropProps,
+    | 'container'
+    | 'disableCloseOnBackdropClick'
+    | 'disablePortal'
+    | 'onBackdropClick'
+    | 'onClose'
+    | 'open'
+  > {
   /**
    * Key prop for forcing content remount when data changes.
    * Use this to prevent DOM residue when list items decrease (e.g., records.length).
@@ -149,51 +152,62 @@ export interface DrawerProps
    */
   bottomSecondaryActionVariant?: ButtonVariant;
   /**
-   * The label of the all radio in control bar.
+   * The label of the all radio in filter area.
    */
-  controlBarAllRadioLabel?: string;
+  filterAreaAllRadioLabel?: string;
   /**
-   * The label of the custom button in control bar.
+   * The label of the custom button in filter area.
    */
-  controlBarCustomButtonLabel?: string;
+  filterAreaCustomButtonLabel?: string;
   /**
-   * The default value of the radio group in control bar.
+   * The default value of the radio group in filter area.
    */
-  controlBarDefaultValue?: string;
+  filterAreaDefaultValue?: string;
   /**
-   * Whether the control bar content is empty (for disabling custom button).
+   * Whether the filter area content is empty (for disabling custom button).
    */
-  controlBarIsEmpty?: boolean;
+  filterAreaIsEmpty?: boolean;
   /**
-   * The callback function when the custom button is clicked in control bar.
+   * The callback function when the custom button is clicked in filter area.
    */
-  controlBarOnCustomButtonClick?: VoidFunction;
+  filterAreaOnCustomButtonClick?: VoidFunction;
   /**
-   * The callback function when the radio group value changes in control bar.
+   * The callback function when the radio group value changes in filter area.
    */
-  controlBarOnRadioChange?: ChangeEventHandler<HTMLInputElement>;
+  filterAreaOnRadioChange?: ChangeEventHandler<HTMLInputElement>;
   /**
-   * The label of the read radio in control bar.
+   * The label of the read radio in filter area.
    */
-  controlBarReadRadioLabel?: string;
+  filterAreaReadRadioLabel?: string;
   /**
-   * Controls whether to display the control bar.
+   * Controls whether to display the filter area.
    * @default false
    */
-  controlBarShow?: boolean;
+  filterAreaShow?: boolean;
   /**
-   * Controls whether to display the unread button in control bar.
+   * Controls whether to display the unread button in filter area.
    * @default false
    */
-  controlBarShowUnreadButton?: boolean;
+  filterAreaShowUnreadButton?: boolean;
   /**
-   * The label of the unread radio in control bar.
+   * The label of the unread radio in filter area.
    */
-  controlBarUnreadRadioLabel?: string;
+  filterAreaUnreadRadioLabel?: string;
   /**
-   * The value of the radio group in control bar.
+   * The value of the radio group in filter area.
    */
-  controlBarValue?: string;
+  filterAreaValue?: string;
+  /**
+   * Options for the filter bar dropdown.
+   * When non-empty, the right-side filter area button is replaced by a Dropdown
+   * triggered by a `DotHorizontalIcon` icon button.
+   */
+  filterAreaOptions?: DropdownOption[];
+  /**
+   * Callback fired when a filter bar dropdown option is selected.
+   * Only used when `filterAreaOptions` is non-empty.
+   */
+  filterAreaOnSelect?: (option: DropdownOption) => void;
   /**
    * Controls whether to disable closing drawer while escape key down.
    * @default false
@@ -212,13 +226,6 @@ export interface DrawerProps
    */
   isHeaderDisplay?: boolean;
   /**
-   * Custom render function for the control bar area.
-   * The control bar will be rendered between the header and content areas.
-   * If provided, this will override the default control bar rendering and control bar-related props.
-   * @returns ReactNode - The custom control bar element
-   */
-  renderControlBar?: () => React.ReactNode;
-  /**
    * Controls the width of the drawer.
    * @default 'medium'
    */
@@ -229,7 +236,7 @@ export interface DrawerProps
  * 從螢幕右側滑入的抽屜面板元件。
  *
  * 使用 `Backdrop` 作為遮罩層，並以 `Slide` 動畫過渡效果呈現開關狀態。
- * 支援標題列、自訂控制列（含分頁 Radio）、底部操作按鈕區域，以及按下 Escape 鍵關閉。
+ * 支援標題列、篩選區域（含分頁 Radio）、底部操作按鈕區域，以及按下 Escape 鍵關閉。
  * 當多個 Drawer 同時開啟時，Escape 鍵只會關閉最上層的 Drawer。
  *
  * @example
@@ -291,21 +298,23 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
     bottomSecondaryActionSize,
     bottomSecondaryActionText,
     bottomSecondaryActionVariant = 'base-secondary',
+    filterAreaOnSelect,
+    filterAreaOptions = [],
     children,
     className,
     container,
     contentKey,
-    controlBarAllRadioLabel,
-    controlBarCustomButtonLabel = '全部已讀',
-    controlBarDefaultValue,
-    controlBarIsEmpty = false,
-    controlBarOnCustomButtonClick,
-    controlBarOnRadioChange,
-    controlBarReadRadioLabel,
-    controlBarShow = false,
-    controlBarShowUnreadButton = false,
-    controlBarUnreadRadioLabel,
-    controlBarValue,
+    filterAreaAllRadioLabel,
+    filterAreaCustomButtonLabel = '全部已讀',
+    filterAreaDefaultValue,
+    filterAreaIsEmpty = false,
+    filterAreaOnCustomButtonClick,
+    filterAreaOnRadioChange,
+    filterAreaReadRadioLabel,
+    filterAreaShow = false,
+    filterAreaShowUnreadButton = false,
+    filterAreaUnreadRadioLabel,
+    filterAreaValue,
     disableCloseOnBackdropClick = false,
     disableCloseOnEscapeKeyDown = false,
     disablePortal,
@@ -315,7 +324,6 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
     onBackdropClick,
     onClose,
     open,
-    renderControlBar: customRenderControlBar,
     size = 'medium',
     ...rest
   } = props;
@@ -336,46 +344,41 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
    */
   const checkIsOnTheTop = useTopStack(open);
 
-  const renderControlBar = useMemo(() => {
-    // If custom renderControlBar is provided, use it
-    if (customRenderControlBar) {
-      return customRenderControlBar;
-    }
-
-    // Default control bar implementation
-    if (!controlBarShow) {
+  const renderFilterArea = useMemo(() => {
+    if (!filterAreaShow) {
       return undefined;
     }
 
     return () => {
       const radios = [];
 
-      if (controlBarAllRadioLabel) {
+      if (filterAreaAllRadioLabel) {
         radios.push(
           <Radio key="all" type="segment" value="all">
-            {controlBarAllRadioLabel}
+            {filterAreaAllRadioLabel}
           </Radio>,
         );
       }
 
-      if (controlBarReadRadioLabel) {
+      if (filterAreaReadRadioLabel) {
         radios.push(
           <Radio key="read" type="segment" value="read">
-            {controlBarReadRadioLabel}
+            {filterAreaReadRadioLabel}
           </Radio>,
         );
       }
 
-      if (controlBarUnreadRadioLabel && controlBarShowUnreadButton) {
+      if (filterAreaUnreadRadioLabel && filterAreaShowUnreadButton) {
         radios.push(
           <Radio key="unread" type="segment" value="unread">
-            {controlBarUnreadRadioLabel}
+            {filterAreaUnreadRadioLabel}
           </Radio>,
         );
       }
 
       const hasRadios = radios.length > 0;
-      const hasButton = controlBarOnCustomButtonClick !== undefined;
+      const hasButton =
+        filterAreaOptions.length > 0 || filterAreaOnCustomButtonClick !== undefined;
 
       // Don't render if neither radios nor button are provided
       if (!hasRadios && !hasButton) {
@@ -385,48 +388,65 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
       return (
         <div
           className={cx(
-            classes.controlBar,
-            !hasRadios && hasButton && classes.controlBarButtonOnly,
+            classes.filterArea,
+            !hasRadios && hasButton && classes.filterAreaButtonOnly,
           )}
         >
           {hasRadios && (
             <RadioGroup
-              defaultValue={controlBarDefaultValue ?? 'all'}
-              onChange={controlBarOnRadioChange}
+              defaultValue={filterAreaDefaultValue ?? 'all'}
+              onChange={filterAreaOnRadioChange}
               size="minor"
               type="segment"
-              value={controlBarValue}
+              value={filterAreaValue}
             >
               {radios}
             </RadioGroup>
           )}
           {hasButton && (
-            <Button
-              disabled={controlBarIsEmpty}
-              onClick={controlBarOnCustomButtonClick}
-              size="minor"
-              type="button"
-              variant="base-ghost"
-            >
-              {controlBarCustomButtonLabel}
-            </Button>
+            filterAreaOptions.length > 0 ? (
+              <Dropdown
+                onSelect={filterAreaOnSelect}
+                options={filterAreaOptions}
+                placement="bottom-end"
+              >
+                <Button
+                  icon={DotHorizontalIcon}
+                  iconType="icon-only"
+                  size="minor"
+                  type="button"
+                  variant="base-ghost"
+                />
+              </Dropdown>
+            ) : (
+              <Button
+                disabled={filterAreaIsEmpty}
+                onClick={filterAreaOnCustomButtonClick}
+                size="minor"
+                type="button"
+                variant="base-ghost"
+              >
+                {filterAreaCustomButtonLabel}
+              </Button>
+            )
           )}
         </div>
       );
     };
   }, [
-    controlBarAllRadioLabel,
-    controlBarCustomButtonLabel,
-    controlBarDefaultValue,
-    controlBarIsEmpty,
-    controlBarOnCustomButtonClick,
-    controlBarOnRadioChange,
-    controlBarReadRadioLabel,
-    controlBarShow,
-    controlBarShowUnreadButton,
-    controlBarUnreadRadioLabel,
-    controlBarValue,
-    customRenderControlBar,
+    filterAreaAllRadioLabel,
+    filterAreaCustomButtonLabel,
+    filterAreaDefaultValue,
+    filterAreaIsEmpty,
+    filterAreaOnCustomButtonClick,
+    filterAreaOnRadioChange,
+    filterAreaReadRadioLabel,
+    filterAreaShow,
+    filterAreaShowUnreadButton,
+    filterAreaUnreadRadioLabel,
+    filterAreaValue,
+    filterAreaOnSelect,
+    filterAreaOptions,
   ]);
 
   useDocumentEscapeKeyDown(() => {
@@ -488,7 +508,7 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
             </div>
           )}
 
-          {renderControlBar?.()}
+          {renderFilterArea?.()}
 
           <div
             key={contentKey !== undefined ? contentKey : openCount}

--- a/packages/react/src/NotificationCenter/NotificationCenter.stories.tsx
+++ b/packages/react/src/NotificationCenter/NotificationCenter.stories.tsx
@@ -70,8 +70,8 @@ export const Playground: Story = {
     function PlaygroundNotification() {
       const reference = useMemo(() => `notification-playground`, []);
 
-      const onConfirm = () => {};
-      const onCancel = () => {};
+      const onConfirm = () => { };
+      const onCancel = () => { };
 
       return (
         <NotificationCenter
@@ -130,7 +130,7 @@ function AddMethodExample() {
     NotificationDataForDrawer[]
   >([]);
 
-  const handleBadgeSelect = (_: DropdownOption) => {};
+  const handleBadgeSelect = (_: DropdownOption) => { };
   const handleViewAll = () => {
     setDrawerOpen(true);
   };
@@ -306,16 +306,16 @@ function AddMethodExample() {
         onClose={() => setDrawerOpen(false)}
         open={drawerOpen}
         title="通知中心"
-        controlBarAllRadioLabel="全部"
-        controlBarCustomButtonLabel="全部已讀"
-        controlBarDefaultValue="all"
-        controlBarOnCustomButtonClick={() => {}}
-        controlBarOnRadioChange={() => {}}
-        controlBarReadRadioLabel="已讀"
-        controlBarShow
-        controlBarShowUnreadButton
-        controlBarUnreadRadioLabel="未讀"
-        controlBarValue="all"
+        filterBarAllRadioLabel="全部"
+        filterBarCustomButtonLabel="全部已讀"
+        filterBarDefaultValue="all"
+        filterBarOnCustomButtonClick={() => { }}
+        filterBarOnRadioChange={() => { }}
+        filterBarReadRadioLabel="已讀"
+        filterBarShow
+        filterBarShowUnreadButton
+        filterBarUnreadRadioLabel="未讀"
+        filterBarValue="all"
       />
     </div>
   );
@@ -330,7 +330,7 @@ type DrawerStory = StoryObj<NotificationCenterDrawerProps>;
 function DrawerWithChildrenExample() {
   const [open, setOpen] = useState(false);
 
-  const handleBadgeSelect = (_: DropdownOption) => {};
+  const handleBadgeSelect = (_: DropdownOption) => { };
 
   return (
     <div>
@@ -338,16 +338,16 @@ function DrawerWithChildrenExample() {
         開啟通知中心
       </Button>
       <NotificationCenterDrawer
-        controlBarAllRadioLabel="全部"
-        controlBarCustomButtonLabel="全部已讀"
-        controlBarDefaultValue="all"
-        controlBarOnCustomButtonClick={() => {}}
-        controlBarOnRadioChange={() => {}}
-        controlBarReadRadioLabel="已讀"
-        controlBarShow
-        controlBarShowUnreadButton
-        controlBarUnreadRadioLabel="未讀"
-        controlBarValue="all"
+        filterBarAllRadioLabel="全部"
+        filterBarCustomButtonLabel="全部已讀"
+        filterBarDefaultValue="all"
+        filterBarOnCustomButtonClick={() => { }}
+        filterBarOnRadioChange={() => { }}
+        filterBarReadRadioLabel="已讀"
+        filterBarShow
+        filterBarShowUnreadButton
+        filterBarUnreadRadioLabel="未讀"
+        filterBarValue="all"
         drawerSize="narrow"
         onClose={() => setOpen(false)}
         open={open}
@@ -421,7 +421,7 @@ function DrawerWithNotificationListExample() {
       {
         description: '系統已完成更新，您現在可以使用最新版本功能。',
         key: '1',
-        onBadgeSelect: (_: DropdownOption) => {},
+        onBadgeSelect: (_: DropdownOption) => { },
         options: defaultBadgeOptions,
         severity: 'info' as NotificationSeverity,
         showBadge: true,
@@ -432,7 +432,7 @@ function DrawerWithNotificationListExample() {
       {
         description: '您的登入地點異常，請確認是否為本人操作。',
         key: '2',
-        onBadgeSelect: (_: DropdownOption) => {},
+        onBadgeSelect: (_: DropdownOption) => { },
         options: defaultBadgeOptions,
         severity: 'warning' as NotificationSeverity,
         timeStamp: '2025-12-14 10:00:00',
@@ -442,7 +442,7 @@ function DrawerWithNotificationListExample() {
       {
         description: '您的檔案「月報表.pdf」已成功上傳，可前往資料庫查看結果。',
         key: '3',
-        onBadgeSelect: (_: DropdownOption) => {},
+        onBadgeSelect: (_: DropdownOption) => { },
         options: defaultBadgeOptions,
         severity: 'success' as NotificationSeverity,
         timeStamp: '2025-12-14 10:00:00',
@@ -452,7 +452,7 @@ function DrawerWithNotificationListExample() {
       {
         description: '您的檔案「月報表.pdf」上傳失敗，請重新上傳。',
         key: '4',
-        onBadgeSelect: (_: DropdownOption) => {},
+        onBadgeSelect: (_: DropdownOption) => { },
         options: defaultBadgeOptions,
         severity: 'error' as NotificationSeverity,
         timeStamp: '2025-12-14 10:00:00',
@@ -463,7 +463,7 @@ function DrawerWithNotificationListExample() {
         description:
           '後端資料庫已完成更新，若您在操作中遇到延遲，屬正常現象，稍後即會改善。',
         key: '5',
-        onBadgeSelect: (_: DropdownOption) => {},
+        onBadgeSelect: (_: DropdownOption) => { },
         options: defaultBadgeOptions,
         severity: 'info' as NotificationSeverity,
         timeStamp: '2025-12-14 10:00:00',
@@ -485,16 +485,16 @@ function DrawerWithNotificationListExample() {
         onClose={() => setOpen(false)}
         open={open}
         title="通知中心"
-        controlBarAllRadioLabel="全部"
-        controlBarCustomButtonLabel="全部已讀"
-        controlBarDefaultValue="all"
-        controlBarOnCustomButtonClick={() => {}}
-        controlBarOnRadioChange={() => {}}
-        controlBarReadRadioLabel="已讀"
-        controlBarShow
-        controlBarShowUnreadButton
-        controlBarUnreadRadioLabel="未讀"
-        controlBarValue="all"
+        filterBarAllRadioLabel="全部"
+        filterBarCustomButtonLabel="全部已讀"
+        filterBarDefaultValue="all"
+        filterBarOnCustomButtonClick={() => { }}
+        filterBarOnRadioChange={() => { }}
+        filterBarReadRadioLabel="已讀"
+        filterBarShow
+        filterBarShowUnreadButton
+        filterBarUnreadRadioLabel="未讀"
+        filterBarValue="all"
       />
     </div>
   );
@@ -518,16 +518,16 @@ function DrawerEmptyExample() {
         onClose={() => setOpen(false)}
         open={open}
         title="通知中心"
-        controlBarAllRadioLabel="全部"
-        controlBarCustomButtonLabel="全部已讀"
-        controlBarDefaultValue="all"
-        controlBarOnCustomButtonClick={() => {}}
-        controlBarOnRadioChange={() => {}}
-        controlBarReadRadioLabel="已讀"
-        controlBarShow
-        controlBarShowUnreadButton
-        controlBarUnreadRadioLabel="未讀"
-        controlBarValue="all"
+        filterBarAllRadioLabel="全部"
+        filterBarCustomButtonLabel="全部已讀"
+        filterBarDefaultValue="all"
+        filterBarOnCustomButtonClick={() => { }}
+        filterBarOnRadioChange={() => { }}
+        filterBarReadRadioLabel="已讀"
+        filterBarShow
+        filterBarShowUnreadButton
+        filterBarUnreadRadioLabel="未讀"
+        filterBarValue="all"
       />
     </div>
   );
@@ -546,7 +546,7 @@ function DrawerTimeStampExample() {
 
     const today30minAgo = new Date(now);
     today30minAgo.setMinutes(now.getMinutes() - 30);
-    const handleBadgeSelect = (_: DropdownOption) => {};
+    const handleBadgeSelect = (_: DropdownOption) => { };
 
     notifications.push({
       description: '這是30分鐘前的通知，應該顯示「30 分鐘前」',
@@ -701,16 +701,16 @@ function DrawerTimeStampExample() {
         onClose={() => setOpen(false)}
         open={open}
         title="通知中心 - 時間戳記顯示範例"
-        controlBarAllRadioLabel="全部"
-        controlBarCustomButtonLabel="全部已讀"
-        controlBarDefaultValue="all"
-        controlBarOnCustomButtonClick={() => {}}
-        controlBarOnRadioChange={() => {}}
-        controlBarReadRadioLabel="已讀"
-        controlBarShow
-        controlBarShowUnreadButton
-        controlBarUnreadRadioLabel="未讀"
-        controlBarValue="all"
+        filterBarAllRadioLabel="全部"
+        filterBarCustomButtonLabel="全部已讀"
+        filterBarDefaultValue="all"
+        filterBarOnCustomButtonClick={() => { }}
+        filterBarOnRadioChange={() => { }}
+        filterBarReadRadioLabel="已讀"
+        filterBarShow
+        filterBarShowUnreadButton
+        filterBarUnreadRadioLabel="未讀"
+        filterBarValue="all"
       />
     </div>
   );
@@ -720,8 +720,15 @@ export const DrawerTimeStamp: DrawerStory = {
   render: () => <DrawerTimeStampExample />,
 };
 
-function DrawerWithRenderControlBarExample() {
+function DrawerWithFilterOptionsExample() {
   const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('all');
+
+  const filterOptions: DropdownOption[] = [
+    { id: 'mark-all-read', name: '全部標示已讀' },
+    { id: 'delete-read', name: '刪除已讀通知', showUnderline: true },
+    { id: 'delete-all', name: '刪除所有通知', validate: 'danger' },
+  ];
 
   const notificationList = useMemo(
     () => [
@@ -746,6 +753,16 @@ function DrawerWithRenderControlBarExample() {
         title: '帳號安全提醒',
         type: 'drawer' as const,
       },
+      {
+        description: '您的檔案「月報表.pdf」已成功上傳，可前往資料庫查看結果。',
+        key: '3',
+        onBadgeSelect: (_: DropdownOption) => {},
+        options: defaultBadgeOptions,
+        severity: 'success' as NotificationSeverity,
+        timeStamp: '2025-12-14 10:00:00',
+        title: '已上傳完成',
+        type: 'drawer' as const,
+      },
     ],
     [],
   );
@@ -753,50 +770,30 @@ function DrawerWithRenderControlBarExample() {
   return (
     <div>
       <Button variant="base-primary" onClick={() => setOpen(true)}>
-        開啟通知中心（使用 renderControlBar）
+        開啟通知中心（含篩選 Dropdown）
       </Button>
       <NotificationCenterDrawer
         drawerSize="narrow"
+        filterBarAllRadioLabel="全部"
+        filterBarDefaultValue="all"
+        filterBarOnRadioChange={(e) => setFilter(e.target.value)}
+        filterBarOnSelect={(opt) => alert(`已選擇：${opt.name}`)}
+        filterBarOptions={filterOptions}
+        filterBarReadRadioLabel="已讀"
+        filterBarShow
+        filterBarShowUnreadButton
+        filterBarUnreadRadioLabel="未讀"
+        filterBarValue={filter}
         notificationList={notificationList}
         onClose={() => setOpen(false)}
         open={open}
-        renderControlBar={() => (
-          <div
-            style={{
-              alignItems: 'center',
-              borderBottom: '1px solid #e0e0e0',
-              display: 'flex',
-              justifyContent: 'space-between',
-              padding: '16px',
-            }}
-          >
-            <Typography variant="caption">自訂工具列</Typography>
-            <div style={{ display: 'flex', gap: '8px' }}>
-              <Button
-                onClick={() => {}}
-                size="minor"
-                type="button"
-                variant="base-secondary"
-              >
-                標示全部已讀
-              </Button>
-              <Button
-                onClick={() => {}}
-                size="minor"
-                type="button"
-                variant="base-ghost"
-              >
-                清除全部
-              </Button>
-            </div>
-          </div>
-        )}
         title="通知中心"
       />
     </div>
   );
 }
 
-export const DrawerWithRenderControlBar: DrawerStory = {
-  render: () => <DrawerWithRenderControlBarExample />,
+export const DrawerWithFilterOptions: DrawerStory = {
+  render: () => <DrawerWithFilterOptionsExample />,
 };
+

--- a/packages/react/src/NotificationCenter/NotificationCenter.tsx
+++ b/packages/react/src/NotificationCenter/NotificationCenter.tsx
@@ -771,24 +771,36 @@ const {
 });
 
 /**
- * The react component for `mezzanine` notification center.
+ * 通知中心元件，支援即時提示（`notification`）與抽屜清單（`drawer`）兩種呈現模式。
  *
- * Trigger notifications imperatively via severity shorthand methods or `add`:
+ * 以 `<NotificationCenter type="notification" />` 宣告式渲染單筆浮動通知；
+ * 或使用靜態方法 `NotificationCenter.add()`、`.success()`、`.error()` 等命令式 API
+ * 觸發通知，並可透過回傳的 key 呼叫 `remove()` 收回。
+ * `type: 'drawer'` 模式下，請搭配 `NotificationCenterDrawer` 以清單方式顯示。
  *
  * @example
  * ```tsx
- * import NotificationCenter from '@mezzanine-ui/react/notification-center';
+ * import NotificationCenter from '@mezzanine-ui/react/NotificationCenter';
  *
- * NotificationCenter.success({ title: 'Saved!', description: 'Your changes have been saved.' });
- * NotificationCenter.error({ title: 'Error', description: 'Something went wrong.' });
+ * // 宣告式：嵌入畫面中的通知
+ * <NotificationCenter
+ *   reference="notify-1"
+ *   severity="success"
+ *   title="儲存成功"
+ *   type="notification"
+ * />
  *
- * // Dismiss programmatically
- * const key = NotificationCenter.add({ severity: 'info', title: 'Processing…', type: 'notification' });
+ * // 命令式：觸發浮動通知
+ * NotificationCenter.success({ title: '儲存成功', description: '資料已更新。' });
+ * NotificationCenter.error({ title: '操作失敗', description: '請稍後再試。' });
+ *
+ * // 手動控制生命週期
+ * const key = NotificationCenter.add({ severity: 'info', title: '處理中…', type: 'notification' });
  * NotificationCenter.remove(key);
  * ```
  *
- * @see {@link NotificationData} for all available notification options.
- * @see {@link NotificationCenterDrawer} for the drawer list variant.
+ * @see {@link NotificationData} 所有可用的通知設定項
+ * @see {@link NotificationCenterDrawer} 抽屜清單模式的容器元件
  */
 const NotificationCenter = Object.assign(NotificationCenterFC, {
   add: (notif: NotificationData & { key?: Key }) => {

--- a/packages/react/src/NotificationCenter/NotificationCenterDrawer.tsx
+++ b/packages/react/src/NotificationCenter/NotificationCenterDrawer.tsx
@@ -24,20 +24,60 @@ type NotificationDataForDrawer = NotificationData & {
 
 type NotificationCenterDrawerPropsBase = Pick<
   DrawerProps,
-  | 'controlBarAllRadioLabel'
-  | 'controlBarCustomButtonLabel'
-  | 'controlBarDefaultValue'
-  | 'controlBarOnCustomButtonClick'
-  | 'controlBarOnRadioChange'
-  | 'controlBarReadRadioLabel'
-  | 'controlBarShow'
-  | 'controlBarShowUnreadButton'
-  | 'controlBarUnreadRadioLabel'
-  | 'controlBarValue'
   | 'onClose'
   | 'open'
-  | 'renderControlBar'
 > & {
+  /**
+   * Label for the "all" filter option in the filter bar.
+   */
+  filterBarAllRadioLabel?: DrawerProps['filterAreaAllRadioLabel'];
+  /**
+   * Label for the custom action button in the filter bar.
+   */
+  filterBarCustomButtonLabel?: DrawerProps['filterAreaCustomButtonLabel'];
+  /**
+   * Default selected filter value in the filter bar.
+   */
+  filterBarDefaultValue?: DrawerProps['filterAreaDefaultValue'];
+  /**
+   * Callback fired when the custom action button is clicked.
+   */
+  filterBarOnCustomButtonClick?: DrawerProps['filterAreaOnCustomButtonClick'];
+  /**
+   * Callback fired when the filter option changes.
+   */
+  filterBarOnRadioChange?: DrawerProps['filterAreaOnRadioChange'];
+  /**
+   * Label for the "read" filter option in the filter bar.
+   */
+  filterBarReadRadioLabel?: DrawerProps['filterAreaReadRadioLabel'];
+  /**
+   * Whether to show the filter bar.
+   */
+  filterBarShow?: DrawerProps['filterAreaShow'];
+  /**
+   * Whether to show the "unread only" shortcut button.
+   */
+  filterBarShowUnreadButton?: DrawerProps['filterAreaShowUnreadButton'];
+  /**
+   * Label for the "unread" filter option in the filter bar.
+   */
+  filterBarUnreadRadioLabel?: DrawerProps['filterAreaUnreadRadioLabel'];
+  /**
+   * Controlled selected filter value in the filter bar.
+   */
+  filterBarValue?: DrawerProps['filterAreaValue'];
+  /**
+   * Options for the filter bar dropdown.
+   * When non-empty, the right-side filter area button is replaced by a Dropdown
+   * triggered by a `DotHorizontalIcon` icon button.
+   */
+  filterBarOptions?: DrawerProps['filterAreaOptions'];
+  /**
+   * Callback fired when a filter bar dropdown option is selected.
+   * Only used when `filterBarOptions` is non-empty.
+   */
+  filterBarOnSelect?: DrawerProps['filterAreaOnSelect'];
   /**
    * The size of the drawer.
    * @default 'narrow'
@@ -175,16 +215,18 @@ const getTimeGroup = (
 const NotificationCenterDrawer = (props: NotificationCenterDrawerProps) => {
   const {
     children,
-    controlBarAllRadioLabel,
-    controlBarCustomButtonLabel,
-    controlBarDefaultValue,
-    controlBarOnCustomButtonClick,
-    controlBarOnRadioChange,
-    controlBarReadRadioLabel,
-    controlBarShow,
-    controlBarShowUnreadButton,
-    controlBarUnreadRadioLabel,
-    controlBarValue,
+    filterBarAllRadioLabel,
+    filterBarCustomButtonLabel,
+    filterBarDefaultValue,
+    filterBarOnCustomButtonClick,
+    filterBarOnRadioChange,
+    filterBarOnSelect,
+    filterBarReadRadioLabel,
+    filterBarShow,
+    filterBarShowUnreadButton,
+    filterBarUnreadRadioLabel,
+    filterBarValue,
+    filterBarOptions,
     drawerSize = 'narrow',
     earlierLabel,
     emptyNotificationTitle = '目前沒有新的通知',
@@ -193,7 +235,6 @@ const NotificationCenterDrawer = (props: NotificationCenterDrawerProps) => {
     onClose,
     open,
     past7DaysLabel,
-    renderControlBar,
     title,
     todayLabel,
     yesterdayLabel,
@@ -298,22 +339,23 @@ const NotificationCenterDrawer = (props: NotificationCenterDrawerProps) => {
   return (
     <Drawer
       className={classes.drawer}
-      controlBarAllRadioLabel={controlBarAllRadioLabel}
-      controlBarCustomButtonLabel={controlBarCustomButtonLabel}
-      controlBarDefaultValue={controlBarDefaultValue}
-      controlBarIsEmpty={isEmpty}
-      controlBarOnCustomButtonClick={controlBarOnCustomButtonClick}
-      controlBarOnRadioChange={controlBarOnRadioChange}
-      controlBarReadRadioLabel={controlBarReadRadioLabel}
-      controlBarShow={controlBarShow}
-      controlBarShowUnreadButton={controlBarShowUnreadButton}
-      controlBarUnreadRadioLabel={controlBarUnreadRadioLabel}
-      controlBarValue={controlBarValue}
+      filterAreaAllRadioLabel={filterBarAllRadioLabel}
+      filterAreaCustomButtonLabel={filterBarCustomButtonLabel}
+      filterAreaDefaultValue={filterBarDefaultValue}
+      filterAreaIsEmpty={isEmpty}
+      filterAreaOnCustomButtonClick={filterBarOnCustomButtonClick}
+      filterAreaOnRadioChange={filterBarOnRadioChange}
+      filterAreaOnSelect={filterBarOnSelect}
+      filterAreaReadRadioLabel={filterBarReadRadioLabel}
+      filterAreaShow={filterBarShow}
+      filterAreaShowUnreadButton={filterBarShowUnreadButton}
+      filterAreaUnreadRadioLabel={filterBarUnreadRadioLabel}
+      filterAreaValue={filterBarValue}
+      filterAreaOptions={filterBarOptions}
       headerTitle={title}
       isHeaderDisplay={Boolean(title)}
       onClose={onClose}
       open={open}
-      renderControlBar={renderControlBar}
       size={drawerSize}
       {...restDrawerProps}
     >


### PR DESCRIPTION
## Summary
This PR aligns Drawer filter-area naming and behavior across core/react layers, and wires Notification Center to support filter option selection through the drawer API.

## Changes
- **Core Drawer**
  - Rename `controlBar` naming to `filterArea` in drawer classes/types/styles.
- **React Drawer**
  - Rename `controlBar*` props to `filterArea*`.
  - Add `filterAreaOptions` support and render a dropdown trigger when options are provided.
  - Update Drawer tests to cover the new filter options selection behavior.
  - Update Drawer stories to match renamed props and new option-trigger UX.
- **Notification Center**
  - Expose `filterBarOnSelect` from `NotificationCenterDrawer`.
  - Add `DrawerWithFilterOptions` story to demonstrate option selection integration.
  - Update related Notification Center stories to align with the new Drawer API.

## Breaking changes
- Consumers using old Drawer `controlBar*` props must migrate to `filterArea*` equivalents.
