### PR TITLE
fix(autocomplete): remove the full width props on the autocomplete component

### DIFF
--- a/packages/core/src/autocomplete/_autocomplete-styles.scss
+++ b/packages/core/src/autocomplete/_autocomplete-styles.scss
@@ -6,6 +6,7 @@
 
 .#{$prefix} {
   position: relative;
+  width: 100%;
 
   &--single {
     min-width: spacing.semantic-variable(size, container, concentrate-fixed);
@@ -21,10 +22,6 @@
     &:has(.#{select.$trigger-prefix} .#{text-field.$prefix}__prefix) {
       min-width: spacing.semantic-variable(size, container, small);
     }
-  }
-
-  &--full-width {
-    width: 100%;
   }
 
   &--inside-closed {

--- a/packages/core/src/autocomplete/autocomplete.ts
+++ b/packages/core/src/autocomplete/autocomplete.ts
@@ -27,7 +27,6 @@ export const autocompletePrefix = 'mzn-autocomplete';
 
 export const autocompleteClasses = {
   host: autocompletePrefix,
-  hostFullWidth: `${autocompletePrefix}--full-width`,
   hostInsideClosed: `${autocompletePrefix}--inside-closed`,
   hostMode: (mode: AutoCompleteMode) => `${autocompletePrefix}--${mode}`,
 } as const;

--- a/packages/react/src/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/Accordion/Accordion.stories.tsx
@@ -1,19 +1,19 @@
-import { useState, MouseEvent } from 'react';
 import {
   DotHorizontalIcon,
   EditIcon,
   PlusIcon,
   TrashIcon,
 } from '@mezzanine-ui/icons';
-import Accordion, { AccordionTitle, AccordionContent } from '.';
+import { MOTION_DURATION, MOTION_EASING } from '@mezzanine-ui/system/motion';
+import { MouseEvent, useState } from 'react';
+import Accordion, { AccordionContent, AccordionTitle } from '.';
+import AutoComplete from '../AutoComplete';
 import Button from '../Button';
 import Dropdown from '../Dropdown';
-import AccordionActions from './AccordionActions';
-import AutoComplete from '../AutoComplete';
-import AccordionGroup from './AccordionGroup';
-import Typography from '../Typography';
 import { Fade } from '../Transition';
-import { MOTION_DURATION, MOTION_EASING } from '@mezzanine-ui/system/motion';
+import Typography from '../Typography';
+import AccordionActions from './AccordionActions';
+import AccordionGroup from './AccordionGroup';
 
 export default {
   title: 'Data Display/Accordion',
@@ -191,7 +191,6 @@ export const WithActions = () => {
             style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}
           >
             <AutoComplete
-              fullWidth
               options={[
                 { id: 'electronics', name: '電子產品' },
                 { id: 'clothing', name: '服飾配件' },
@@ -200,7 +199,6 @@ export const WithActions = () => {
               placeholder="選擇產品分類"
             />
             <AutoComplete
-              fullWidth
               options={[
                 { id: 'on-sale', name: '上架中' },
                 { id: 'off-shelf', name: '已下架' },

--- a/packages/react/src/AutoComplete/AutoComplete.stories.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.stories.tsx
@@ -75,14 +75,12 @@ const BasicComponent = () => {
         }}
       >
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           options={originOptions}
           placeholder="單選"
           required
         />
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           mode="multiple"
           onChange={setMultipleSelections}
@@ -93,7 +91,6 @@ const BasicComponent = () => {
         />
         <AutoComplete
           error
-          fullWidth
           menuMaxHeight={140}
           options={originOptions}
           placeholder="錯誤"
@@ -101,7 +98,6 @@ const BasicComponent = () => {
         />
         <AutoComplete
           disabled
-          fullWidth
           menuMaxHeight={140}
           options={originOptions}
           placeholder="已禁用"
@@ -117,7 +113,6 @@ const BasicComponent = () => {
         }}
       >
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           options={originOptions}
           placeholder="單選"
@@ -125,7 +120,6 @@ const BasicComponent = () => {
           size="sub"
         />
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           mode="multiple"
           onChange={setMultipleSelections}
@@ -137,7 +131,6 @@ const BasicComponent = () => {
         />
         <AutoComplete
           error
-          fullWidth
           menuMaxHeight={140}
           options={originOptions}
           placeholder="錯誤"
@@ -146,7 +139,6 @@ const BasicComponent = () => {
         />
         <AutoComplete
           disabled
-          fullWidth
           menuMaxHeight={140}
           options={originOptions}
           placeholder="已禁用"
@@ -163,7 +155,6 @@ const BasicComponent = () => {
         }}
       >
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           mode="single"
           options={originOptions}
@@ -172,7 +163,6 @@ const BasicComponent = () => {
           required
         />
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           mode="single"
           size="sub"
@@ -182,7 +172,6 @@ const BasicComponent = () => {
           required
         />
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           mode="multiple"
           onChange={setMultipleSelections}
@@ -193,7 +182,6 @@ const BasicComponent = () => {
           value={multipleSelections}
         />
         <AutoComplete
-          fullWidth
           menuMaxHeight={140}
           mode="multiple"
           onChange={setMultipleSelections}
@@ -246,7 +234,6 @@ const SingleModeAsyncSearchComponent = () => {
         asyncData
         disabledOptionsFilter
         emptyText="沒有符合的選項"
-        fullWidth
         loadingText="載入中..."
         menuMaxHeight={200}
         mode="single"
@@ -290,7 +277,6 @@ const SingleModeSyncSearchComponent = () => {
       <AutoComplete
         disabledOptionsFilter
         emptyText="沒有符合的選項"
-        fullWidth
         menuMaxHeight={200}
         mode="single"
         onSearch={handleSearch}
@@ -372,7 +358,6 @@ const KeepSearchTextOnBlurComponent = () => {
             clearSearchText={false}
             disabledOptionsFilter
             emptyText="沒有符合的選項"
-            fullWidth
             menuMaxHeight={200}
             mode="single"
             onSearch={handleSingleSearch}
@@ -383,7 +368,6 @@ const KeepSearchTextOnBlurComponent = () => {
           <AutoComplete
             disabledOptionsFilter
             emptyText="沒有符合的選項"
-            fullWidth
             menuMaxHeight={200}
             mode="single"
             onSearch={handleSingleSearch}
@@ -406,7 +390,6 @@ const KeepSearchTextOnBlurComponent = () => {
             clearSearchText={false}
             disabledOptionsFilter
             emptyText="沒有符合的選項"
-            fullWidth
             menuMaxHeight={200}
             mode="multiple"
             onChange={setMultipleSelections}
@@ -419,7 +402,6 @@ const KeepSearchTextOnBlurComponent = () => {
           <AutoComplete
             disabledOptionsFilter
             emptyText="沒有符合的選項"
-            fullWidth
             menuMaxHeight={200}
             mode="multiple"
             onChange={setMultipleAutoClearSelections}
@@ -477,7 +459,6 @@ const MultipleComponent = () => {
       }}
     >
       <AutoComplete
-        fullWidth
         mode="multiple"
         onChange={(newOptions) => setSelections(newOptions)}
         options={originOptions}
@@ -520,7 +501,6 @@ const OverflowStrategyComponent = () => {
         <div style={{ maxWidth: '300px' }}>
           <AutoComplete
             disabledOptionsFilter
-            fullWidth
             mode="multiple"
             onChange={setCounterSelections}
             options={manyOptions}
@@ -541,7 +521,6 @@ const OverflowStrategyComponent = () => {
         <div style={{ maxWidth: '300px' }}>
           <AutoComplete
             disabledOptionsFilter
-            fullWidth
             mode="multiple"
             onChange={setWrapSelections}
             options={manyOptions}
@@ -602,7 +581,6 @@ const CreatableSingleComponent = () => {
         </p>
         <AutoComplete
           addable
-          fullWidth
           mode="single"
           onChange={setSelection}
           onInsert={handleInsert}
@@ -664,7 +642,6 @@ const CreatableMultipleComponent = () => {
         </p>
         <AutoComplete
           addable
-          fullWidth
           mode="multiple"
           onChange={setSelections}
           onInsert={handleInsert}
@@ -741,7 +718,6 @@ const BulkCreateComponent = () => {
           addable
           createSeparators={[',', '+', '\n']}
           emptyText="沒有符合的項目"
-          fullWidth
           mode="multiple"
           onChange={setSelections}
           onInsert={handleInsert}
@@ -874,7 +850,6 @@ const InputPositionInsideComponent = () => {
         />
         <AutoComplete
           addable
-          fullWidth
           mode="multiple"
           inputPosition="inside"
           onChange={setSelections}
@@ -979,7 +954,6 @@ const InsideBulkCreateComponent = () => {
         <AutoComplete
           addable
           createSeparators={[',', '+', '\n']}
-          fullWidth
           inputPosition="inside"
           mode="multiple"
           onChange={setSelections}
@@ -1036,7 +1010,6 @@ const InsideEmptyComponent = () => {
         />
         <AutoComplete
           emptyText="沒有符合的項目"
-          fullWidth
           inputPosition="inside"
           mode="multiple"
           open={open}
@@ -1083,7 +1056,6 @@ const InsideLoadingComponent = () => {
         />
         <AutoComplete
           emptyText="沒有符合的項目"
-          fullWidth
           inputPosition="inside"
           loading
           loadingPosition="full"
@@ -1161,7 +1133,6 @@ const LoadMoreOnReachBottomComponent = () => {
         <AutoComplete
           disabledOptionsFilter
           emptyText="沒有符合的選項"
-          fullWidth
           loading={loading}
           loadingText="載入中..."
           menuMaxHeight={120}
@@ -1233,7 +1204,6 @@ const SearchTextControlRefComponent = () => {
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
           <div style={{ flex: 1 }}>
             <AutoComplete
-              fullWidth
               options={originOptions}
               placeholder="輸入後點擊清除文字"
               searchTextControlRef={setSearchTextControlRef}
@@ -1257,7 +1227,6 @@ const SearchTextControlRefComponent = () => {
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
           <div style={{ flex: 1 }}>
             <AutoComplete
-              fullWidth
               mode="multiple"
               onChange={setResetValue}
               options={originOptions}
@@ -1287,7 +1256,6 @@ const SearchTextControlRefComponent = () => {
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
           <div style={{ flex: 1 }}>
             <AutoComplete
-              fullWidth
               mode="multiple"
               onChange={setSubmitValue}
               options={originOptions}

--- a/packages/react/src/AutoComplete/AutoComplete.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.tsx
@@ -46,6 +46,7 @@ import type {
 } from '../Select/typings';
 import { SelectValue } from '../Select/typings';
 import { PickRenameMulti } from '../utils/general';
+import AutoCompleteInsideTrigger from './AutoCompleteInside';
 import {
   getFullParsedList,
   useAutoCompleteCreation,
@@ -53,28 +54,27 @@ import {
 import { useAutoCompleteKeyboard } from './useAutoCompleteKeyboard';
 import { useAutoCompleteSearch } from './useAutoCompleteSearch';
 import { useCreationTracker } from './useCreationTracker';
-import AutoCompleteInsideTrigger from './AutoCompleteInside';
 
 export interface AutoCompleteBaseProps
   extends Omit<
-      SelectTriggerProps,
-      | 'active'
-      | 'clearable'
-      | 'forceHideSuffixActionIcon'
-      | 'fullWidth'
-      | 'mode'
-      | 'onClick'
-      | 'onKeyDown'
-      | 'onChange'
-      | 'renderValue'
-      | 'inputProps'
-      | 'suffixActionIcon'
-      | 'value'
-    >,
-    PickRenameMulti<
-      Pick<PopperProps, 'options'>,
-      { options: 'popperOptions' }
-    > {
+    SelectTriggerProps,
+    | 'active'
+    | 'clearable'
+    | 'forceHideSuffixActionIcon'
+    | 'fullWidth'
+    | 'mode'
+    | 'onClick'
+    | 'onKeyDown'
+    | 'onChange'
+    | 'renderValue'
+    | 'inputProps'
+    | 'suffixActionIcon'
+    | 'value'
+  >,
+  PickRenameMulti<
+    Pick<PopperProps, 'options'>,
+    { options: 'popperOptions' }
+  > {
   /**
    * Set to true when options can be added dynamically
    * @default false
@@ -211,9 +211,9 @@ export interface AutoCompleteBaseProps
    */
   searchTextControlRef?: RefObject<
     | {
-        reset: () => void;
-        setSearchText: Dispatch<SetStateAction<string>>;
-      }
+      reset: () => void;
+      setSearchText: Dispatch<SetStateAction<string>>;
+    }
     | undefined
   >;
   /**
@@ -502,49 +502,49 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     } = useAutoCompleteValueControl(
       isMultiple
         ? {
-            defaultValue: isMultipleValue(defaultValue)
-              ? defaultValue
+          defaultValue: isMultipleValue(defaultValue)
+            ? defaultValue
+            : undefined,
+          disabledOptionsFilter,
+          getOptionsFilterQuery:
+            stepByStepBulkCreate && addable && onInsert
+              ? (st) => {
+                const full = getFullParsedList(
+                  st,
+                  createSeparators,
+                  trimOnCreate,
+                );
+                return full.length > 1 ? (full[0] ?? undefined) : undefined;
+              }
               : undefined,
-            disabledOptionsFilter,
-            getOptionsFilterQuery:
-              stepByStepBulkCreate && addable && onInsert
-                ? (st) => {
-                    const full = getFullParsedList(
-                      st,
-                      createSeparators,
-                      trimOnCreate,
-                    );
-                    return full.length > 1 ? (full[0] ?? undefined) : undefined;
-                  }
-                : undefined,
-            mode: 'multiple',
-            onChange: onChangeProp as
-              | ((newOptions: SelectValue[]) => void)
-              | undefined,
-            onClear: onClearProp,
-            onClose: () => toggleOpen(false),
-            onSearch,
-            options: optionsProp,
-            value: isMultipleValue(valueProp) ? valueProp : undefined,
-          }
+          mode: 'multiple',
+          onChange: onChangeProp as
+            | ((newOptions: SelectValue[]) => void)
+            | undefined,
+          onClear: onClearProp,
+          onClose: () => toggleOpen(false),
+          onSearch,
+          options: optionsProp,
+          value: isMultipleValue(valueProp) ? valueProp : undefined,
+        }
         : {
-            defaultValue: isSingleValue(defaultValue)
-              ? defaultValue
+          defaultValue: isSingleValue(defaultValue)
+            ? defaultValue
+            : undefined,
+          disabledOptionsFilter,
+          mode: 'single',
+          onChange: onChangeProp as
+            | ((newOption: SelectValue | null) => void)
+            | undefined,
+          onClear: onClearProp,
+          onClose: () => toggleOpen(false),
+          onSearch,
+          options: optionsProp,
+          value:
+            isSingleValue(valueProp) || valueProp === null
+              ? valueProp
               : undefined,
-            disabledOptionsFilter,
-            mode: 'single',
-            onChange: onChangeProp as
-              | ((newOption: SelectValue | null) => void)
-              | undefined,
-            onClear: onClearProp,
-            onClose: () => toggleOpen(false),
-            onSearch,
-            options: optionsProp,
-            value:
-              isSingleValue(valueProp) || valueProp === null
-                ? valueProp
-                : undefined,
-          },
+        },
     );
 
     /** export set search text action to props (allow user to customize search text) */
@@ -899,9 +899,9 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
 
     const searchTextExistWithoutOption: boolean = !!(firstPendingText
       ? firstPendingText &&
-        options.find((option) => option.name === firstPendingText) === undefined
+      options.find((option) => option.name === firstPendingText) === undefined
       : searchText &&
-        options.find((option) => option.name === searchText) === undefined);
+      options.find((option) => option.name === searchText) === undefined);
 
     const shouldShowCreateAction = !!(
       searchTextExistWithoutOption &&
@@ -969,9 +969,9 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
         : undefined;
     const shouldForceClearable = isMultiple
       ? (isMultipleValue(value) && value.length > 0) ||
-        searchText.trim().length > 0
+      searchText.trim().length > 0
       : isSingleValue(value) ||
-        (!shouldClearSearchTextOnBlur && searchText.trim().length > 0);
+      (!shouldClearSearchTextOnBlur && searchText.trim().length > 0);
 
     // Handle dropdown option selection
     const handleDropdownSelect = useCallback(
@@ -1013,7 +1013,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     const [keyboardActiveIndex, setKeyboardActiveIndex] = useState<
       number | null
     >(null);
-    const setListboxHasVisualFocus = useCallback((_focus: boolean) => {}, []);
+    const setListboxHasVisualFocus = useCallback((_focus: boolean) => { }, []);
 
     // Reset activeIndex and keyboardActiveIndex when options change
     useEffect(() => {
@@ -1211,9 +1211,9 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
                 ? createActionText
                   ? createActionText(createActionDisplayText)
                   : createActionTextTemplate.replace(
-                      '{text}',
-                      createActionDisplayText,
-                    )
+                    '{text}',
+                    createActionDisplayText,
+                  )
                 : undefined
             }
             activeIndex={activeIndex}
@@ -1251,71 +1251,70 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
             onReachBottom={onReachBottom}
             onLeaveBottom={onLeaveBottom}
           >
-          {inputPosition === 'inside' ? (
-            <AutoCompleteInsideTrigger
-              active={open}
-              className={className}
-              clearable={shouldForceClearable}
-              disabled={isInputDisabled}
-              error={error}
-              fullWidth
-              inputRef={composedInputRef}
-              onClear={handleClear}
-              placeholder={getPlaceholder()}
-              resolvedInputProps={{
-                ...resolvedInputProps,
-                onClick: (e: ReactMouseEvent<HTMLInputElement>) => {
-                  resolvedInputProps.onClick?.(e);
-                },
-              }}
-              size={size}
-              value={insideInputValue}
-            />
-          ) : (
-            <SelectTrigger
-              ref={composedRef}
-              active={open}
-              className={className}
-              clearable
-              disabled={isInputDisabled}
-              fullWidth
-              isForceClearable={shouldForceClearable}
-              inputRef={composedInputRef}
-              mode={mode}
-              onTagClose={wrappedOnChange}
-              onClear={handleClear}
-              overflowStrategy={
-                isMultiple ? (overflowStrategy ?? 'wrap') : overflowStrategy
-              }
-              placeholder={getPlaceholder()}
-              prefix={prefix}
-              readOnly={false}
-              required={required}
-              type={error ? 'error' : 'default'}
-              inputProps={{
-                ...resolvedInputProps,
-                onClick: (e: ReactMouseEvent<HTMLInputElement>) => {
-                  // When inputPosition is inside, let Dropdown handle the click event
-                  // Otherwise, stop propagation to prevent conflicts
-                  // This branch is only rendered when `inputPosition !== 'inside'`.
-                  e.stopPropagation();
-                  resolvedInputProps.onClick?.(e);
-                },
-              }}
-              searchText={searchText}
-              size={size}
-              showTextInputAfterTags
-              suffixAction={onClickSuffixActionIcon}
-              value={
-                mode === 'multiple' &&
-                isMultipleValue(value) &&
-                value.length === 0
-                  ? undefined
-                  : (value ?? undefined)
-              }
-              {...(mode === 'single' && renderValue ? { renderValue } : {})}
-            />
-          )}
+            {inputPosition === 'inside' ? (
+              <AutoCompleteInsideTrigger
+                active={open}
+                className={className}
+                clearable={shouldForceClearable}
+                disabled={isInputDisabled}
+                error={error}
+                inputRef={composedInputRef}
+                onClear={handleClear}
+                placeholder={getPlaceholder()}
+                resolvedInputProps={{
+                  ...resolvedInputProps,
+                  onClick: (e: ReactMouseEvent<HTMLInputElement>) => {
+                    resolvedInputProps.onClick?.(e);
+                  },
+                }}
+                size={size}
+                value={insideInputValue}
+              />
+            ) : (
+              <SelectTrigger
+                ref={composedRef}
+                active={open}
+                className={className}
+                clearable
+                disabled={isInputDisabled}
+                fullWidth
+                isForceClearable={shouldForceClearable}
+                inputRef={composedInputRef}
+                mode={mode}
+                onTagClose={wrappedOnChange}
+                onClear={handleClear}
+                overflowStrategy={
+                  isMultiple ? (overflowStrategy ?? 'wrap') : overflowStrategy
+                }
+                placeholder={getPlaceholder()}
+                prefix={prefix}
+                readOnly={false}
+                required={required}
+                type={error ? 'error' : 'default'}
+                inputProps={{
+                  ...resolvedInputProps,
+                  onClick: (e: ReactMouseEvent<HTMLInputElement>) => {
+                    // When inputPosition is inside, let Dropdown handle the click event
+                    // Otherwise, stop propagation to prevent conflicts
+                    // This branch is only rendered when `inputPosition !== 'inside'`.
+                    e.stopPropagation();
+                    resolvedInputProps.onClick?.(e);
+                  },
+                }}
+                searchText={searchText}
+                size={size}
+                showTextInputAfterTags
+                suffixAction={onClickSuffixActionIcon}
+                value={
+                  mode === 'multiple' &&
+                    isMultipleValue(value) &&
+                    value.length === 0
+                    ? undefined
+                    : (value ?? undefined)
+                }
+                {...(mode === 'single' && renderValue ? { renderValue } : {})}
+              />
+            )}
           </Dropdown>
         </div>
       </SelectControlContext.Provider>

--- a/packages/react/src/AutoComplete/AutoComplete.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.tsx
@@ -61,6 +61,7 @@ export interface AutoCompleteBaseProps
       | 'active'
       | 'clearable'
       | 'forceHideSuffixActionIcon'
+      | 'fullWidth'
       | 'mode'
       | 'onClick'
       | 'onKeyDown'
@@ -418,7 +419,6 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
   function AutoComplete(props, ref) {
     const {
       disabled: disabledFromFormControl,
-      fullWidth: fullWidthFromFormControl,
       required: requiredFromFormControl,
       severity,
     } = useContext(FormControlContext) || {};
@@ -433,7 +433,6 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
       disabledOptionsFilter = false,
       emptyText = '沒有符合的項目',
       error = severity === 'error' || false,
-      fullWidth = fullWidthFromFormControl || false,
       id,
       inputPosition = 'outside',
       inputProps,
@@ -1202,7 +1201,6 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
         <div
           ref={nodeRef}
           className={cx(classes.host, {
-            [classes.hostFullWidth]: fullWidth,
             [classes.hostInsideClosed]: inputPosition === 'inside' && !open,
             [classes.hostMode(mode)]: mode,
           })}
@@ -1260,7 +1258,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
               clearable={shouldForceClearable}
               disabled={isInputDisabled}
               error={error}
-              fullWidth={fullWidth}
+              fullWidth
               inputRef={composedInputRef}
               onClear={handleClear}
               placeholder={getPlaceholder()}
@@ -1280,7 +1278,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
               className={className}
               clearable
               disabled={isInputDisabled}
-              fullWidth={fullWidth}
+              fullWidth
               isForceClearable={shouldForceClearable}
               inputRef={composedInputRef}
               mode={mode}

--- a/packages/react/src/AutoComplete/AutoCompleteInside.tsx
+++ b/packages/react/src/AutoComplete/AutoCompleteInside.tsx
@@ -32,10 +32,6 @@ export interface AutoCompleteInsideTriggerProps {
    */
   size?: InputProps['size'];
   /**
-   * Whether the input should occupy full width.
-   */
-  fullWidth?: boolean;
-  /**
    * Additional class name for the trigger.
    */
   className?: string;
@@ -71,7 +67,6 @@ export default function AutoCompleteInsideTrigger(
     clearable,
     disabled,
     error,
-    fullWidth,
     inputRef,
     onClear,
     placeholder,
@@ -89,7 +84,7 @@ export default function AutoCompleteInsideTrigger(
       className={className}
       {...(disabled ? { disabled: true as const } : {})}
       error={error}
-      fullWidth={fullWidth}
+      fullWidth
       id={id}
       name={name}
       placeholder={placeholder}


### PR DESCRIPTION
## What changed
- AutoComplete is full width by default. The `fullWidth` prop and CSS modifier are removed.
- Core: drop the `fullWidth` class; styles no longer need a flag for 100% width.
- React: remove the `fullWidth` prop from `AutoComplete`.
- Stories: stop passing `fullWidth` on `AutoComplete` (e.g. Accordion examples).
