### PR TITLE
fix(checkbox): improve chip interaction area and nested level spacing

### DIFF
--- a/packages/core/src/checkbox/_checkbox-styles.scss
+++ b/packages/core/src/checkbox/_checkbox-styles.scss
@@ -668,7 +668,7 @@ $checked-disabled: (
 
   &--nested {
     .#{$group-prefix}--content-wrapper.#{$group-prefix}--vertical.#{$group-prefix}--chip {
-      .#{$prefix}.#{$prefix}--indeterminate.#{$prefix}--chip {
+      .#{$prefix}.#{$prefix}--chip:first-child {
         margin-bottom: spacing.semantic-variable(padding, vertical, tiny);
       }
     }

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -2,6 +2,7 @@
 
 import {
   ChangeEventHandler,
+  KeyboardEvent,
   MouseEvent,
   Ref,
   forwardRef,
@@ -318,6 +319,27 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       prevIsCheckedRef.current = isChecked;
     }, [isChecked, shouldShowEditableInput]);
 
+    const handleChipHostClick = useCallback(
+      (e: MouseEvent<HTMLDivElement>) => {
+        if (disabled) return;
+        if (e.target === e.currentTarget) {
+          inputElementRef.current?.click();
+        }
+      },
+      [disabled],
+    );
+
+    const handleChipHostKeyDown = useCallback(
+      (e: KeyboardEvent<HTMLDivElement>) => {
+        if (disabled) return;
+        if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          inputElementRef.current?.click();
+        }
+      },
+      [disabled],
+    );
+
     const handleEditableInputMouseDown = useCallback(
       (event: MouseEvent<HTMLInputElement>) => {
         defaultEditableInput?.inputProps?.onMouseDown?.(event);
@@ -346,6 +368,8 @@ const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
           },
           classes.size(size),
         )}
+        onClick={mode === 'chip' ? handleChipHostClick : undefined}
+        onKeyDown={mode === 'chip' ? handleChipHostKeyDown : undefined}
       >
         <label ref={ref} {...rest} className={classes.labelContainer}>
           <div className={classes.inputContainer}>

--- a/packages/react/src/Checkbox/CheckboxGroup.tsx
+++ b/packages/react/src/Checkbox/CheckboxGroup.tsx
@@ -317,7 +317,7 @@ const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
       if (!name) {
         console.warn(
           'CheckboxGroup: The `name` prop is recommended, especially when integrating with react-hook-form. ' +
-            'All checkboxes in the group should share the same `name` attribute.',
+          'All checkboxes in the group should share the same `name` attribute.',
         );
       }
 
@@ -329,7 +329,7 @@ const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
             if (!checkboxProps.value) {
               console.warn(
                 `CheckboxGroup: Each Checkbox child should have a \`value\` prop. ` +
-                  `Checkbox at index ${index} is missing the \`value\` prop.`,
+                `Checkbox at index ${index} is missing the \`value\` prop.`,
               );
             }
           }
@@ -344,7 +344,7 @@ const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
           if (isValidElement(child) && child.type !== Checkbox) {
             console.warn(
               'CheckboxGroup: When using ReactNode (children) input, only Checkbox components are supported. ' +
-                `Found unsupported component: ${typeof child.type === 'string' ? child.type : child.type?.name || 'Unknown'}`,
+              `Found unsupported component: ${typeof child.type === 'string' ? child.type : child.type?.name || 'Unknown'}`,
             );
           }
         });


### PR DESCRIPTION
### Summary
- Fix chip-mode checkbox interaction so users can toggle by clicking the full chip host area, not only the label text.
- Add keyboard support (Enter / Space) for chip host interaction to keep behavior accessible.
- Make nested vertical chip level-control spacing consistent by applying bottom margin to the first chip item regardless of checked state.

### Changes
#### core
- Update nested chip group selector to apply level-control bottom spacing via :first-child instead of --indeterminate only.
#### react
- Add host-level click handler for chip mode to forward clicks on host padding area to the hidden input.
- Add host-level keydown handler for Enter / Space in chip mode.
- Keep existing label/input behavior unchanged and avoid style-level modifications for interaction fix.
- Include small formatting-only cleanup in CheckboxGroup.tsx warning strings.