### PR TITLE
Navigation, Stepper, Accordion bug fix

### DIFF
--- a/packages/core/src/accordion/_accordion-styles.scss
+++ b/packages/core/src/accordion/_accordion-styles.scss
@@ -101,6 +101,10 @@
   &__actions {
     position: absolute;
     right: spacing.semantic-variable(padding, horizontal, spacious);
+
+    .mzn-button {
+      min-width: unset;
+    }
   }
 
   &__icon {

--- a/packages/core/src/navigation/_navigation-styles.scss
+++ b/packages/core/src/navigation/_navigation-styles.scss
@@ -29,14 +29,22 @@ $option-height: calc(spacing.semantic-variable(padding, vertical, tight) * 2 + #
     flex-grow: 1;
     gap: spacing.semantic-variable(gap, tight-fixed);
     margin-right: -1px;
-    padding: spacing.semantic-variable(padding, vertical, base)
-      spacing.semantic-variable(padding, horizontal, comfort-fixed);
+    padding-block: spacing.semantic-variable(padding, vertical, base);
 
     .#{$prefix}__list {
       @include utils.reset();
 
       display: grid;
       gap: spacing.semantic-variable(gap, tight);
+      padding-inline: spacing.semantic-variable(padding, horizontal, comfort-fixed);
+    }
+  }
+
+  &__search-input {
+    padding-inline: spacing.semantic-variable(padding, horizontal, comfort-fixed);
+
+    .mzn-text-field {
+      width: 100%;
     }
   }
 

--- a/packages/core/src/navigation/_navigation-styles.scss
+++ b/packages/core/src/navigation/_navigation-styles.scss
@@ -479,6 +479,15 @@ $option-height: calc(spacing.semantic-variable(padding, vertical, tight) * 2 + #
       .mzn-badge {
         display: none;
       }
+
+      &:not(:has(.#{$option-prefix}__icon)) {
+        justify-content: center;
+        padding-inline: 0;
+
+        .#{$option-prefix}__title-wrapper {
+          margin-right: 0;
+        }
+      }
     }
 
     &.#{$option-prefix}--active.#{$option-prefix}--open {

--- a/packages/core/src/stepper/_stepper-styles.scss
+++ b/packages/core/src/stepper/_stepper-styles.scss
@@ -87,6 +87,20 @@ $dotBoxShadowMargin: #{spacing.semantic-variable(size, element, tiny)};
   }
 }
 
+@keyframes stepper-dot-breath-error {
+  0% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+
+  50% {
+    box-shadow: 0 0 0 #{$dotBoxShadowMargin} palette.semantic-variable(background, error-subtle);
+  }
+
+  100% {
+    box-shadow: 0 0 0 #{$dotBoxShadowMargin} transparent;
+  }
+}
+
 .#{$prefix-step} {
   &--interactive {
     border-radius: radius.variable(base);
@@ -283,6 +297,15 @@ $dotBoxShadowMargin: #{spacing.semantic-variable(size, element, tiny)};
 
         animation-iteration-count: infinite;
         animation-name: stepper-dot-breath;
+      }
+    }
+
+    &.#{$prefix-step}--processing-error {
+      .#{$prefix-step}__status-indicator-dot {
+        @include motion.pattern(breathe, animation);
+
+        animation-iteration-count: infinite;
+        animation-name: stepper-dot-breath-error;
       }
     }
   }

--- a/packages/react/src/Navigation/Navigation.tsx
+++ b/packages/react/src/Navigation/Navigation.tsx
@@ -281,13 +281,14 @@ const Navigation = forwardRef<HTMLElement, NavigationProps>((props, ref) => {
         >
           <div ref={contentRef} className={classes.content}>
             {filter && (
-              <Input
-                size="sub"
-                variant="search"
-                className={cx(classes.searchInput)}
-                value={filterText}
-                onChange={(e) => setFilterText(e.target.value)}
-              />
+              <div className={classes.searchInput}>
+                <Input
+                  size="sub"
+                  variant="search"
+                  value={filterText}
+                  onChange={(e) => setFilterText(e.target.value)}
+                />
+              </div>
             )}
             <Scrollbar
               disabled={collapsed}

--- a/packages/react/src/Navigation/NavigationOption.tsx
+++ b/packages/react/src/Navigation/NavigationOption.tsx
@@ -270,7 +270,9 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
 
               <span className={classes.titleWrapper}>
                 <Fade ref={titleRef} in={collapsed === false || !icon}>
-                  <span className={classes.title}>{title}</span>
+                  <span className={classes.title}>
+                    {collapsed && !icon ? title.slice(0, 2) : title}
+                  </span>
                 </Fade>
               </span>
 

--- a/packages/react/src/Navigation/NavigationOption.tsx
+++ b/packages/react/src/Navigation/NavigationOption.tsx
@@ -271,7 +271,7 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
               <span className={classes.titleWrapper}>
                 <Fade ref={titleRef} in={collapsed === false || !icon}>
                   <span className={classes.title}>
-                    {collapsed && !icon ? title.slice(0, 2) : title}
+                    {collapsed && !icon ? Array.from(title).slice(0, 2).join('') : title}
                   </span>
                 </Fade>
               </span>


### PR DESCRIPTION

## Summary

### 1. Navigation — 折疊時無 icon 選項顯示修正

- 折疊狀態下無 icon 的 option 隱藏 `padding-inline` 並將文字置中
- 標題截斷至前兩個字元，避免在折疊寬度下溢出
	- ＊工程會議討論時是無padding直接擷斷，但會後與設計討論結果為取前2字並置中

### 2. Navigation — Scrollbar 貼齊右邊與 Search 對齊

- 將 `__content` 的 `padding-inline` 移至 `__list`，使 scrollbar track 貼齊 Navigation 右側邊界
- Search input 改以 wrapper div 包裹並套用 `padding-inline`，確保視覺對齊 option 左右間距

### 3. Stepper — processing-error 動畫顏色修正

- `processing-error` dot breathe 動畫改用 `error-subtle` color token，符合設計規範

### 4. Accordion — AccordionActions 按鈕最小寬度移除

- 移除 `AccordionActions` 內按鈕的 `min-width`，避免版面被意外撐開


