### PR TITLE
fix(ng): declare clsx as an explicit dependency

### DIFF
--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -26,6 +26,7 @@
     "@mezzanine-ui/core": "1.0.3",
     "@mezzanine-ui/icons": "1.0.2",
     "@mezzanine-ui/system": "1.0.2",
+    "clsx": "^2.1.1",
     "overlayscrollbars": "^2.13.0",
     "tslib": "^2.8.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,6 +5465,7 @@ __metadata:
     "@mezzanine-ui/core": "npm:1.0.3"
     "@mezzanine-ui/icons": "npm:1.0.2"
     "@mezzanine-ui/system": "npm:1.0.2"
+    clsx: "npm:^2.1.1"
     overlayscrollbars: "npm:^2.13.0"
     tslib: "npm:^2.8.1"
   peerDependencies:


### PR DESCRIPTION
## Summary

- `@mezzanine-ui/ng` 在 114 個 component 檔案中 `import clsx from 'clsx'`，但 `packages/ng/package.json` 的 `dependencies` 並沒有宣告 `clsx`。
- 目前能運作是因為 `@mezzanine-ui/react` 宣告了 `clsx`，被 hoist 到 workspace root；但這讓 `@mezzanine-ui/ng` 變成「phantom dependency」套件 — 一旦使用者單獨安裝 ng 套件（不同時安裝 react），執行期就會噴 `Cannot find module 'clsx'`。
- 顯式把 `clsx@^2.1.1` 加入 `dependencies`（與 react 套件同版本範圍，package manager 會自動去重到單一版本）。

## Why `dependencies` instead of `peerDependencies`

- 與 `@mezzanine-ui/react` 的宣告方式對稱（react 也放在 `dependencies`）。
- `clsx` 是約 240B 的純工具函式，沒有 state 衝突或 runtime 單例需求（不像 `@angular/core`）。
- 消費端不需額外裝任何東西，裝一個 ng 套件就能用。

## Impact

- `yarn.lock` 只新增 1 行（`clsx: "npm:^2.1.1"` 綁到 ng 套件區塊），沒有新增 lockfile entry，因為 `clsx@^2.1.1` 早已存在。
- 不影響 bundle size，不影響 runtime 行為，純粹是 metadata 修正。

## Test plan

- [x] `yarn install` 成功，lockfile 只產生預期的 minimal diff
- [ ] `yarn workspace @mezzanine-ui/ng build`（ng-packagr）在 CI 綠燈
- [ ] Angular Storybook AOT build 在 CI 綠燈
- [ ] 驗證（可手動）：在乾淨的測試專案中 `npm i @mezzanine-ui/ng` 不會遇到 `Cannot find module 'clsx'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)