### PR TITLE
fix(react/picker): restore keyboard navigation across portalled popper

### DIFF
--- a/packages/react/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/react/src/DatePicker/DatePicker.spec.tsx
@@ -158,7 +158,7 @@ describe('<DatePicker />', () => {
       jest.useRealTimers();
     });
 
-    it('should close calendar when tab key down', async () => {
+    it('should redirect focus into calendar when tab key down from input', async () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <DatePicker />
@@ -183,7 +183,44 @@ describe('<DatePicker />', () => {
       });
 
       act(() => {
-        fireEvent.keyDown(document, { key: 'Tab' });
+        fireEvent.keyDown(inputElement, { key: 'Tab' });
+      });
+
+      await waitFor(() => {
+        expect(document.querySelector('.mzn-calendar')).toBeInstanceOf(
+          HTMLDivElement,
+        );
+        const popper = document.querySelector('.mzn-calendar');
+        expect(popper?.contains(document.activeElement)).toBe(true);
+      });
+    });
+
+    it('should close calendar when shift+tab key down from input', async () => {
+      const { getHostHTMLElement } = render(
+        <CalendarConfigProvider methods={CalendarMethodsMoment}>
+          <DatePicker />
+        </CalendarConfigProvider>,
+      );
+
+      const element = getHostHTMLElement();
+      const [inputElement] = element.getElementsByTagName('input');
+
+      act(() => {
+        fireEvent.focus(inputElement!);
+      });
+
+      await waitFor(() => {
+        expect(document.querySelector('.mzn-calendar')).toBeInstanceOf(
+          HTMLDivElement,
+        );
+      });
+
+      act(() => {
+        inputElement.focus();
+      });
+
+      act(() => {
+        fireEvent.keyDown(inputElement, { key: 'Tab', shiftKey: true });
       });
 
       await waitFor(() => {
@@ -418,7 +455,7 @@ describe('<DatePicker />', () => {
 
       await waitFor(() => {
         inputElement.focus();
-        fireEvent.keyDown(document, { key: 'Tab' });
+        fireEvent.keyDown(inputElement, { key: 'Tab', shiftKey: true });
       });
 
       await waitFor(() => {

--- a/packages/react/src/DateRangePicker/DateRangePicker.spec.tsx
+++ b/packages/react/src/DateRangePicker/DateRangePicker.spec.tsx
@@ -169,7 +169,7 @@ describe('<DateRangePicker />', () => {
       });
     });
 
-    it('should close calendar when tab key down on inputTo element', async () => {
+    it('should redirect focus into calendar when tab key down on inputTo element', async () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <DateRangePicker />
@@ -192,7 +192,39 @@ describe('<DateRangePicker />', () => {
       });
 
       await act(async () => {
-        fireEvent.keyDown(document, { key: 'Tab' });
+        fireEvent.keyDown(inputToElement, { key: 'Tab' });
+      });
+
+      await waitFor(() => {
+        expect(getRangeCalendar()).toBeInstanceOf(HTMLDivElement);
+        expect(getRangeCalendar()?.contains(document.activeElement)).toBe(true);
+      });
+    });
+
+    it('should close calendar when shift+tab key down on inputTo element', async () => {
+      const { getHostHTMLElement } = render(
+        <CalendarConfigProvider methods={CalendarMethodsMoment}>
+          <DateRangePicker />
+        </CalendarConfigProvider>,
+      );
+
+      const element = getHostHTMLElement();
+      const [, inputToElement] = element.getElementsByTagName('input');
+
+      await act(async () => {
+        fireEvent.focus(inputToElement!);
+      });
+
+      await waitFor(() => {
+        expect(getRangeCalendar()).toBeInstanceOf(HTMLDivElement);
+      });
+
+      await act(async () => {
+        inputToElement.focus();
+      });
+
+      await act(async () => {
+        fireEvent.keyDown(inputToElement, { key: 'Tab', shiftKey: true });
       });
 
       await waitFor(() => {

--- a/packages/react/src/Picker/getFocusableElements.ts
+++ b/packages/react/src/Picker/getFocusableElements.ts
@@ -1,0 +1,84 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function isVisible(element: HTMLElement): boolean {
+  if (element.hidden) return false;
+
+  const style = element.ownerDocument?.defaultView?.getComputedStyle(element);
+
+  if (!style) return true;
+
+  return style.visibility !== 'hidden' && style.display !== 'none';
+}
+
+export function getFocusableElements(
+  container: HTMLElement | null,
+): HTMLElement[] {
+  if (!container) return [];
+
+  const nodes = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+  const result: HTMLElement[] = [];
+
+  for (const node of Array.from(nodes)) {
+    if (node.getAttribute('aria-hidden') === 'true') continue;
+    if (!isVisible(node)) continue;
+    result.push(node);
+  }
+
+  return result;
+}
+
+export function getNextTabbableAfter(
+  element: HTMLElement,
+  skipContainer?: HTMLElement | null,
+): HTMLElement | null {
+  const doc = element.ownerDocument;
+  const all = getFocusableElements(doc.body);
+
+  for (const node of all) {
+    if (node === element || element.contains(node)) continue;
+    if (
+      skipContainer &&
+      (node === skipContainer || skipContainer.contains(node))
+    )
+      continue;
+    const position = element.compareDocumentPosition(node);
+    if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+      return node;
+    }
+  }
+
+  return null;
+}
+
+export function getPreviousTabbableBefore(
+  element: HTMLElement,
+): HTMLElement | null {
+  const doc = element.ownerDocument;
+  const all = getFocusableElements(doc.body);
+
+  let previous: HTMLElement | null = null;
+
+  for (const node of all) {
+    if (node === element || element.contains(node)) continue;
+    const position = element.compareDocumentPosition(node);
+    if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+      previous = node;
+    }
+  }
+
+  return previous;
+}

--- a/packages/react/src/Picker/usePickerDocumentEventClose.ts
+++ b/packages/react/src/Picker/usePickerDocumentEventClose.ts
@@ -1,7 +1,13 @@
-import { RefObject } from 'react';
+import { RefObject, useRef } from 'react';
 import { useClickAway } from '../hooks/useClickAway';
 import { useDocumentEscapeKeyDown } from '../hooks/useDocumentEscapeKeyDown';
-import { useTabKeyClose } from './useTabKeyClose';
+import { useDocumentTabKeyDown } from '../hooks/useDocumentTabKeyDown';
+import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
+import {
+  getFocusableElements,
+  getNextTabbableAfter,
+  getPreviousTabbableBefore,
+} from './getFocusableElements';
 
 export interface UsePickerDocumentEventCloseProps {
   anchorRef: RefObject<HTMLElement | null>;
@@ -20,32 +26,152 @@ export function usePickerDocumentEventClose({
   open,
   popperRef,
 }: UsePickerDocumentEventCloseProps) {
+  /**
+   * Mirror the latest values into refs so the document-level event handlers
+   * (which are installed once and only re-installed when deps change) always
+   * read the freshest props rather than a closure captured at install time.
+   */
+  const openRef = useRef(open);
+  const onCloseRef = useRef(onClose);
+  const onChangeCloseRef = useRef(onChangeClose);
+
+  useIsomorphicLayoutEffect(() => {
+    openRef.current = open;
+    onCloseRef.current = onClose;
+    onChangeCloseRef.current = onChangeClose;
+  });
+
   useClickAway(
-    () => {
-      if (!open) {
+    () => (event) => {
+      if (!openRef.current) return;
+      if (!popperRef.current?.contains(event.target as HTMLElement)) {
+        onChangeCloseRef.current();
+      }
+    },
+    anchorRef,
+    [],
+  );
+
+  /**
+   * Close popper on Escape and return focus to the trigger input so the
+   * user does not lose their place in the page tab order.
+   */
+  useDocumentEscapeKeyDown(
+    () => () => {
+      if (!openRef.current) return;
+      onCloseRef.current();
+      const popper = popperRef.current;
+      const active = document.activeElement as HTMLElement | null;
+      if (popper && active && popper.contains(active)) {
+        lastElementRefInFlow.current?.focus();
+      }
+    },
+    [lastElementRefInFlow, popperRef],
+  );
+
+  /**
+   * Keyboard navigation across the trigger input and the portalled popper.
+   *
+   * The popper is rendered into document.body via Portal, so the natural
+   * Tab order skips it entirely. We bridge the trigger and the popper as
+   * a logical sequence:
+   *
+   *   - Tab from trigger input  → first focusable inside popper  (handled by
+   *     the direct trigger listener below, which uses `stopPropagation` so
+   *     this document-level handler does not run again for that case)
+   *   - Shift+Tab from trigger  → close popper                  (same)
+   *   - Tab from last popper    → close + focus next tab stop after anchor
+   *   - Shift+Tab from first    → return focus to trigger input
+   *
+   * Other Tabs inside the popper fall through to the browser's default
+   * focus traversal, so users can walk through calendar buttons, footer
+   * actions, etc. with the regular keyboard.
+   */
+  useDocumentTabKeyDown(
+    () => (event) => {
+      if (!openRef.current) return;
+
+      const popper = popperRef.current;
+      const anchor = anchorRef.current;
+      const trigger = lastElementRefInFlow.current;
+
+      if (!popper || !anchor) return;
+
+      const active = document.activeElement as HTMLElement | null;
+
+      if (!active || !popper.contains(active)) return;
+
+      const focusables = getFocusableElements(popper);
+
+      if (focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        onChangeCloseRef.current();
+        const next = getNextTabbableAfter(anchor, popper);
+        if (next) {
+          next.focus();
+        } else {
+          trigger?.blur();
+        }
         return;
       }
 
-      return (event) => {
-        if (!popperRef.current?.contains(event.target as HTMLElement)) {
-          onChangeClose();
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        if (trigger) {
+          trigger.focus();
+        } else {
+          onChangeCloseRef.current();
+          getPreviousTabbableBefore(anchor)?.focus();
         }
-      };
-    },
-    anchorRef,
-    [open, onClose],
-  );
-
-  /** Close popper when escape key down */
-  useDocumentEscapeKeyDown(
-    () => () => {
-      if (open) {
-        onClose();
       }
     },
-    [open, onClose],
+    [anchorRef, popperRef, lastElementRefInFlow],
   );
 
-  /** Close popper when tab key down */
-  useTabKeyClose(onChangeClose, lastElementRefInFlow, [onChangeClose]);
+  /**
+   * Direct keydown listener on the trigger element for the Tab → popper
+   * bridge. Binding directly on the trigger (instead of the document) is
+   * more reliable: it still fires when the picker lives inside a Modal or
+   * focus trap that stops keydown propagation before it reaches document.
+   */
+  useIsomorphicLayoutEffect(() => {
+    const trigger = lastElementRefInFlow.current;
+
+    if (!trigger) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      if (!openRef.current) return;
+
+      const popper = popperRef.current;
+
+      if (!popper) return;
+
+      if (event.shiftKey) {
+        onChangeCloseRef.current();
+        return;
+      }
+
+      const focusables = getFocusableElements(popper);
+
+      if (focusables.length === 0) {
+        onChangeCloseRef.current();
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      focusables[0].focus();
+    };
+
+    trigger.addEventListener('keydown', handleKeyDown);
+    return () => {
+      trigger.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [lastElementRefInFlow, popperRef]);
 }

--- a/packages/react/src/TimePicker/TimePicker.spec.tsx
+++ b/packages/react/src/TimePicker/TimePicker.spec.tsx
@@ -145,7 +145,7 @@ describe('<TimePicker />', () => {
       expect(document.querySelector('.mzn-time-panel')).toBe(null);
     });
 
-    it('should close panel when tab key down', async () => {
+    it('should redirect focus into panel when tab key down', async () => {
       const { getHostHTMLElement } = render(
         <CalendarConfigProvider methods={CalendarMethodsMoment}>
           <TimePicker />
@@ -170,7 +170,42 @@ describe('<TimePicker />', () => {
       });
 
       act(() => {
-        fireEvent.keyDown(document, { key: 'Tab' });
+        fireEvent.keyDown(inputElement, { key: 'Tab' });
+      });
+
+      await waitFor(() => {
+        const panel = document.querySelector('.mzn-time-panel');
+        expect(panel).toBeInstanceOf(HTMLDivElement);
+        expect(panel?.contains(document.activeElement)).toBe(true);
+      });
+    });
+
+    it('should close panel when shift+tab key down', async () => {
+      const { getHostHTMLElement } = render(
+        <CalendarConfigProvider methods={CalendarMethodsMoment}>
+          <TimePicker />
+        </CalendarConfigProvider>,
+      );
+
+      const element = getHostHTMLElement();
+      const [inputElement] = element.getElementsByTagName('input');
+
+      act(() => {
+        fireEvent.focus(inputElement!);
+      });
+
+      await waitFor(() => {
+        expect(document.querySelector('.mzn-time-panel')).toBeInstanceOf(
+          HTMLDivElement,
+        );
+      });
+
+      act(() => {
+        inputElement.focus();
+      });
+
+      act(() => {
+        fireEvent.keyDown(inputElement, { key: 'Tab', shiftKey: true });
       });
 
       await waitFor(() => {


### PR DESCRIPTION
## Summary

- Restored WCAG combobox-style keyboard navigation after portal rendering was re-enabled in #437 (commit c657c636), which broke the natural DOM tab order between picker inputs and their calendars/panels.
- **Tab from input** now focuses the first focusable element inside the portalled popper instead of skipping it entirely.
- **Shift+Tab from first popper element** returns focus to the trigger input.
- **Tab from last popper element** closes the popper and moves focus to the next tabbable element in the page.
- **Escape** closes the popper and restores focus to the trigger only when focus was inside the popper (prevents close-then-reopen loop).

## Technical Changes

### New file: `Picker/getFocusableElements.ts`
- `getFocusableElements(container)` — queries all visible, non-aria-hidden focusable elements inside a container.
- `getNextTabbableAfter(element, skipContainer?)` — finds the next tabbable in the document after a given element, skipping the portalled popper itself.
- `getPreviousTabbableBefore(element)` — finds the last tabbable before a given element.

### Modified: `Picker/usePickerDocumentEventClose.ts`
- Added **ref-mirror pattern** (`openRef`, `onCloseRef`, `onChangeCloseRef` synced via `useIsomorphicLayoutEffect`) to eliminate closure staleness in document-level event handlers.
- Added **direct `keydown` listener on the trigger element** via `useIsomorphicLayoutEffect` to handle Tab/Shift+Tab from the input. Binding directly on the trigger (rather than on `document`) ensures it fires even when the picker is inside a Modal or focus trap that stops event propagation. Uses `stopPropagation()` so the document-level handler does not double-fire.
- Simplified **document Tab handler** to only handle popper-internal boundary cases (Tab from last / Shift+Tab from first).

### Modified: spec files (DatePicker, DateRangePicker, TimePicker)
- Updated Tab key tests to fire `keyDown` on the input element (not `document`) to match the direct listener approach.
- Added "redirect focus into panel/calendar when tab key down" assertions.
- Added "close panel/calendar when shift+tab key down" tests.

## Test Plan

- [ ] `yarn nx test react --testPathPatterns=DatePicker` passes
- [ ] `yarn nx test react --testPathPatterns=DateRangePicker` passes
- [ ] `yarn nx test react --testPathPatterns=TimePicker` passes
- [ ] Manual: Tab from DatePicker input → focus lands on calendar
- [ ] Manual: Shift+Tab from first calendar cell → focus returns to input
- [ ] Manual: Tab from last calendar footer button → popper closes, focus advances past picker
- [ ] Manual: Escape → popper closes; if focus was inside popper it returns to input
- [ ] Manual: picker inside Modal — Tab navigation still works