### PR TITLE
fix(react/table): prevent SSR hydration mismatch from CSS variable read

### DIFF
--- a/packages/react/src/Table/Table.tsx
+++ b/packages/react/src/Table/Table.tsx
@@ -48,6 +48,7 @@ import { useTableScroll } from './hooks/useTableScroll';
 import { useTableSelection } from './hooks/useTableSelection';
 import { useTableSorting } from './hooks/useTableSorting';
 import { getNumericCSSVariablePixelValue } from '../utils/get-css-variable-value';
+import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
 import { spacingPrefix } from '@mezzanine-ui/system/spacing';
 import TableBulkActions from './components/TableBulkActions';
 import { useComposeRefs } from '../hooks/useComposeRefs';
@@ -106,43 +107,33 @@ function TableInner<T extends TableDataSource = TableDataSource>(
     : dataSource;
 
   /** Feature: Row Height Preset */
-  const rowHeight = useMemo(() => {
+  const rowHeightVariableName = useMemo(() => {
     switch (rowHeightPreset) {
       case 'condensed':
         return size === 'main'
-          ? getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-condensed`,
-            )
-          : getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-reduced`,
-            );
+          ? `--${spacingPrefix}-size-container-condensed`
+          : `--${spacingPrefix}-size-container-reduced`;
       case 'detailed':
         return size === 'main'
-          ? getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-tiny`,
-            )
-          : getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-tightened`,
-            );
+          ? `--${spacingPrefix}-size-container-tiny`
+          : `--${spacingPrefix}-size-container-tightened`;
       case 'roomy':
         return size === 'main'
-          ? getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-small`,
-            )
-          : getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-medium`,
-            );
+          ? `--${spacingPrefix}-size-container-small`
+          : `--${spacingPrefix}-size-container-medium`;
       case 'base':
       default:
         return size === 'main'
-          ? getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-minimized`,
-            )
-          : getNumericCSSVariablePixelValue(
-              `--${spacingPrefix}-size-container-minimal`,
-            );
+          ? `--${spacingPrefix}-size-container-minimized`
+          : `--${spacingPrefix}-size-container-minimal`;
     }
   }, [rowHeightPreset, size]);
+
+  const [rowHeight, setRowHeight] = useState<number | undefined>(undefined);
+
+  useIsomorphicLayoutEffect(() => {
+    setRowHeight(getNumericCSSVariablePixelValue(rowHeightVariableName));
+  }, [rowHeightVariableName]);
 
   /** Feature: Highlight */
   const [hoveredRowIndex, setHoveredRowIndex] = useState<number | null>(null);

--- a/packages/react/src/Table/TableContext.tsx
+++ b/packages/react/src/Table/TableContext.tsx
@@ -90,7 +90,7 @@ export interface TableContextValue<
   rowState?:
     | TableRowState
     | ((rowData: TableDataSource) => TableRowState | undefined);
-  rowHeight: number;
+  rowHeight: number | undefined;
   scroll?: TableScroll;
   scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
   selection?: TableSelectionState<T>;

--- a/packages/react/src/Table/components/TableRow.tsx
+++ b/packages/react/src/Table/components/TableRow.tsx
@@ -99,7 +99,7 @@ const TableRowInner = forwardRef<HTMLTableRowElement, TableRowProps>(
       () => ({
         ...style,
         ...draggableProvided?.draggableProps.style,
-        height: rowHeight,
+        ...(rowHeight !== undefined && { height: rowHeight }),
       }),
       [style, rowHeight, draggableProvided?.draggableProps.style],
     );

--- a/packages/react/src/Table/hooks/useTableVirtualization.ts
+++ b/packages/react/src/Table/hooks/useTableVirtualization.ts
@@ -52,7 +52,7 @@ export function useTableVirtualization<T extends TableDataSource>({
         return measuredHeight;
       }
 
-      return rowHeight;
+      return rowHeight ?? 0;
     },
     [dataSource, rowHeight],
   );


### PR DESCRIPTION
## Summary

- Row height was resolved via `getComputedStyle` inside `useMemo` during render, returning `0` on the server and the real pixel value (e.g. `40`) on the client. That produced `style={{ height: "0px" }}` on server HTML vs `style={{ height: 40 }}` on client hydration, triggering Next.js 16's hydration mismatch warning (`A tree hydrated but some attributes of the server rendered HTML didn't match the client properties`) and a first-paint flash where every `<tr>` had 0 height.
- Defer the CSS variable read to `useIsomorphicLayoutEffect`. The memo now returns only the variable name (pure string), the resolved pixel height lives in `useState<number | undefined>(undefined)`, and is set after mount. First render is deterministic across SSR and hydration.
- `TableRow.resolvedStyle` now omits the `height` key entirely when `rowHeight` is `undefined`, so SSR HTML and the first client render emit no inline `height` at all (fully symmetric — no attribute diff to reconcile).
- `useTableVirtualization.estimateSize` falls back to `0` while `rowHeight` is undefined; virtualization is gated on `isContainerReady` which is post-mount, so by the time it's active the real height is in place.

## Why

`useMemo` runs during render on both server and client, so it must never depend on `document` / `getComputedStyle` / `window`. The fix pattern is to keep render output purely a function of props/state, and reconcile DOM-derived values after mount.

Note on `useIsomorphicLayoutEffect`: it uses `typeof window` at **module-load time** to pick between `useLayoutEffect` (client) and `useEffect` (server). This does not affect render output — effects never run during server render. Only the render body using `typeof window` would cause a mismatch.

## Test plan

- [x] `yarn nx test react --testPathPatterns=Table` — 17 suites / 158 tests pass
- [ ] Verify in a Next.js 16 consumer app: reload with devtools open, confirm the hydration warning is gone and rows render at correct height on first paint
- [ ] Storybook smoke: `yarn react:storybook`, toggle `rowHeightPreset` across `base` / `condensed` / `detailed` / `roomy` and both `main` / sub sizes