### PR TITLE
feat(react/select-button): add closeOnSelect prop with controlled dropdown

### DIFF
--- a/packages/react/src/Input/Input.stories.tsx
+++ b/packages/react/src/Input/Input.stories.tsx
@@ -497,12 +497,14 @@ export const SelectInput = () => {
   const [bothValue, setBothValue] = useState('.com');
   const [sizeMainValue, setSizeMainValue] = useState('.com');
   const [sizeSubValue, setSizeSubValue] = useState('.com');
+  const [keepOpenValue, setKeepOpenValue] = useState('.com');
 
   const handlePrefixSelect = (value: string) => setPrefixValue(value);
   const handleSuffixSelect = (value: string) => setSuffixValue(value);
   const handleBothSelect = (value: string) => setBothValue(value);
   const handleSizeMainSelect = (value: string) => setSizeMainValue(value);
   const handleSizeSubSelect = (value: string) => setSizeSubValue(value);
+  const handleKeepOpenSelect = (value: string) => setKeepOpenValue(value);
 
   // Helper to create select input props with proper typing
   const createSelectProps = (
@@ -515,6 +517,7 @@ export const SelectInput = () => {
         'variant' | 'options' | 'selectedValue' | 'onSelect' | 'selectButton'
       >
     >,
+    selectButtonOverrides?: { closeOnSelect?: boolean },
   ): SelectInputProps =>
     ({
       variant: 'select',
@@ -524,6 +527,7 @@ export const SelectInput = () => {
       selectButton: {
         position,
         value: selectedValue,
+        ...selectButtonOverrides,
       },
       ...additionalProps,
     }) as SelectInputProps;
@@ -586,6 +590,21 @@ export const SelectInput = () => {
             size: 'sub',
             placeholder: 'Placeholder',
           })}
+        />
+      </section>
+
+      <section style={containerStyle}>
+        <Typography variant="h3" style={typoStyle}>
+          closeOnSelect = false (dropdown stays open after selecting)
+        </Typography>
+        <Input
+          {...createSelectProps(
+            keepOpenValue,
+            handleKeepOpenSelect,
+            'suffix',
+            { placeholder: 'Placeholder' },
+            { closeOnSelect: false },
+          )}
         />
       </section>
     </div>

--- a/packages/react/src/Input/SelectButton/SelectButton.tsx
+++ b/packages/react/src/Input/SelectButton/SelectButton.tsx
@@ -21,6 +21,11 @@ export interface SelectButtonProps
     'disabled' | 'onSelect' | 'type' | 'selectedValue'
   > {
   /**
+   * Whether clicking an option should automatically close the dropdown.
+   * @default true
+   */
+  closeOnSelect?: boolean;
+  /**
    * Whether the select button is disabled.
    */
   disabled?: boolean;
@@ -59,6 +64,7 @@ const SelectButton = forwardRef<HTMLButtonElement, SelectButtonProps>(
   function SelectButton(props, ref) {
     const {
       className,
+      closeOnSelect = true,
       disabled,
       dropdownMaxHeight = 114,
       dropdownPlacement = 'bottom-start',
@@ -72,21 +78,23 @@ const SelectButton = forwardRef<HTMLButtonElement, SelectButtonProps>(
 
     const [open, setOpen] = useState(false);
 
-    const handleOpen = useCallback(() => {
-      if (!disabled) {
-        setOpen(true);
-      }
-    }, [disabled]);
-
-    const handleClose = useCallback(() => {
-      setOpen(false);
-    }, []);
+    const handleVisibilityChange = useCallback(
+      (next: boolean) => {
+        if (disabled && next) return;
+        setOpen(next);
+      },
+      [disabled],
+    );
 
     const handleSelect = useCallback(
       (option: DropdownOption) => {
         onSelect?.(option.id);
+
+        if (closeOnSelect) {
+          setOpen(false);
+        }
       },
-      [onSelect],
+      [closeOnSelect, onSelect],
     );
 
     const dropdownOptions: DropdownOption[] = options.map((option) => ({
@@ -99,9 +107,9 @@ const SelectButton = forwardRef<HTMLButtonElement, SelectButtonProps>(
         customWidth={dropdownWidth}
         disabled={disabled}
         maxHeight={dropdownMaxHeight}
-        onClose={handleClose}
-        onOpen={handleOpen}
         onSelect={handleSelect}
+        onVisibilityChange={handleVisibilityChange}
+        open={open}
         options={dropdownOptions}
         placement={dropdownPlacement}
         value={value}


### PR DESCRIPTION
## Summary

- Add `closeOnSelect` prop to `SelectButton` (defaults to `true`) so single-select dropdowns close immediately after picking an option — the previously-reported UX issue.
- Make `Dropdown` controlled from `SelectButton` via `open` + `onVisibilityChange`, so `open` state is a single source of truth across trigger click, click-away, Escape, keyboard Enter, and option click.
- Add a Storybook example in the existing `SelectInput` story showing `closeOnSelect: false` for opt-out.

## Why

User feedback: clicking an option inside Input's select button did not close the dropdown. Root cause — `SelectButton`'s local `open` state only drove the chevron animation; `Dropdown` was uncontrolled and its built-in single-select close only fires on keyboard Enter (`Dropdown.tsx:729`), not on mouse click. Switching to controlled mode lets us reuse `Dropdown`'s existing visibility callbacks while adding an explicit close after `onSelect`.

`closeOnSelect` defaults to `true` because single-select UX generally expects the menu to dismiss after selection (matches `TableColumnTitleMenu` and the regular `Select` component). Consumers wanting the old behavior pass `closeOnSelect={false}`. `Input` already forwards all `SelectButtonProps` via its `selectButton` prop, so no changes needed there.

## Test plan

- [ ] Storybook → `Input/SelectInput`: verify existing prefix/suffix/both/size variants still open on trigger click, close on outside click and Escape.
- [ ] Storybook → new `closeOnSelect = false` section: dropdown stays open after picking an option; clicking outside still closes it.
- [ ] Keyboard: arrow keys + Enter on a single-select still closes as before.
- [ ] `yarn check` lint + TypeScript passes.