### PR TITLE
fix(core): align calendar adapter week classification with CLDR weekInfo

### DIFF
--- a/packages/core/src/calendar/calendar.ts
+++ b/packages/core/src/calendar/calendar.ts
@@ -109,9 +109,24 @@ export function getCalendarYearRange(year: number) {
 }
 
 /**
- * Locales that use ISO week (Monday as first day of week).
- * These are primarily European and Middle Eastern locales.
- * Includes both full locale codes (e.g., 'de-de') and short codes (e.g., 'de').
+ * Locales that follow ISO 8601 week rules — Monday is the first day of week
+ * AND week 1 contains at least 4 days of the new year (`minimalDays = 4`).
+ *
+ * Audited against `Intl.Locale#weekInfo` (CLDR). Entries previously listed
+ * here that disagree with CLDR were removed:
+ *  - `pt-pt`, `pt`  → Sunday-first per CLDR (was emitting wrong week
+ *    boundaries for Portuguese)
+ *  - `he-il`, `he`  → Sunday-first per CLDR
+ *  - `ar-sa`, `ar`  → Sunday-first / Saturday-first per CLDR
+ *  - `en-au`, `en-nz` → Monday-first BUT minimalDays=1, NOT ISO
+ *  - `ro-ro`, `ro`, `sl-si`, `sl`, `hr-hr`, `hr`, `tr-tr`, `tr`,
+ *    `uk-ua`, `uk`, `lv-lv`, `lv` → Monday-first BUT minimalDays=1
+ *
+ * The Temporal adapter consumes `Intl.Locale#weekInfo` directly (see
+ * `usesISOWeekRules` in calendarMethodsTemporal). The dayjs/moment
+ * adapters still use this static set; the removals above also fix
+ * silent format/getWeek divergences in those adapters for the affected
+ * locales when CLDR data is the desired source of truth.
  */
 export const ISO_WEEK_LOCALES = new Set([
   'de-de',
@@ -126,8 +141,6 @@ export const ISO_WEEK_LOCALES = new Set([
   'nl',
   'pl-pl',
   'pl',
-  'pt-pt',
-  'pt',
   'ru-ru',
   'ru',
   'sv-se',
@@ -142,35 +155,17 @@ export const ISO_WEEK_LOCALES = new Set([
   'cs',
   'hu-hu',
   'hu',
-  'ro-ro',
-  'ro',
   'sk-sk',
   'sk',
-  'sl-si',
-  'sl',
-  'hr-hr',
-  'hr',
   'bg-bg',
   'bg',
   'el-gr',
   'el',
-  'tr-tr',
-  'tr',
-  'uk-ua',
-  'uk',
-  'he-il',
-  'he',
-  'ar-sa',
-  'ar',
   'et-ee',
   'et',
-  'lv-lv',
-  'lv',
   'lt-lt',
   'lt',
   'en-gb',
-  'en-au',
-  'en-nz',
 ]);
 
 /**

--- a/packages/core/src/calendarMethodsDayjs/calendarMethodsDayjs.spec.ts
+++ b/packages/core/src/calendarMethodsDayjs/calendarMethodsDayjs.spec.ts
@@ -1,0 +1,28 @@
+import CalendarMethodsDayjs from '.';
+
+describe('calendarMethodsDayjs', () => {
+  describe('getWeekYear (locale week-year heuristic for non-ISO locales)', () => {
+    // dayjs has no native `.weekYear()`, so we synthesize one using a
+    // moment-compatible heuristic. These cases lock the behaviour at the
+    // year-end boundary where calendar year diverges from week year.
+    const cases: Array<{ date: string; locale: string; expected: number }> = [
+      // en-US: Sunday-first, minimalDays=1.
+      { date: '2025-12-28T12:00:00Z', locale: 'en-US', expected: 2026 },
+      { date: '2025-12-31T12:00:00Z', locale: 'en-US', expected: 2026 },
+      { date: '2026-01-01T12:00:00Z', locale: 'en-US', expected: 2026 },
+      { date: '2026-12-31T12:00:00Z', locale: 'en-US', expected: 2027 },
+      { date: '2027-01-01T12:00:00Z', locale: 'en-US', expected: 2027 },
+
+      // zh-CN: Monday-first, minimalDays=1 (CLDR), but dayjs locale data
+      // matches CLDR for week boundaries.
+      { date: '2025-12-28T12:00:00Z', locale: 'zh-CN', expected: 2025 },
+      { date: '2027-01-01T12:00:00Z', locale: 'zh-CN', expected: 2026 },
+    ];
+
+    for (const { date, locale, expected } of cases) {
+      it(`${locale} ${date.slice(0, 10)} → weekYear ${expected}`, () => {
+        expect(CalendarMethodsDayjs.getWeekYear(date, locale)).toBe(expected);
+      });
+    }
+  });
+});

--- a/packages/core/src/calendarMethodsDayjs/index.ts
+++ b/packages/core/src/calendarMethodsDayjs/index.ts
@@ -174,6 +174,18 @@ const isMondayFirst = (locale: string): boolean => {
   return getActualFirstDayOfWeek(locale) === 1;
 };
 
+/**
+ * Whether the locale should be week-numbered using the ISO 8601 algorithm.
+ * Requires BOTH Monday-first AND `isISOWeekLocale` (i.e. minimalDays=4 per
+ * CLDR). For Monday-first locales whose CLDR `minimalDays` is 1 (en-AU,
+ * en-NZ, ro-RO, tr-TR, sl-SI, hr-HR, uk-UA, lv-LV …) this returns false so
+ * `getWeek`/`getWeekYear`/format `gggg/ww` use locale week numbering and
+ * stay consistent with `getDefaultModeFormat`.
+ */
+const usesISOWeekRules = (locale: string): boolean => {
+  return isMondayFirst(locale) && isISOWeekLocale(locale);
+};
+
 const CalendarMethodsDayjs: CalendarMethodsType = {
   /** Locale helpers */
   getFirstDayOfWeek: (locale) => getActualFirstDayOfWeek(locale),
@@ -186,16 +198,34 @@ const CalendarMethodsDayjs: CalendarMethodsType = {
   getHour: (date) => dayjs(date).hour(),
   getDate: (date) => dayjs(date).date(),
   getWeek: (date, locale) => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return dayjs(date).isoWeek();
     }
-    return dayjs(date).week();
+    // `.week()` reads the dayjs instance's locale (firstDayOfWeek + doy).
+    // Apply the requested locale explicitly — otherwise the global default
+    // (usually `en` Sunday-first) would be used, breaking Monday-first
+    // non-ISO locales such as en-AU / ro-RO.
+    return dayjs(date).locale(localeMapping(locale)).week();
   },
   getWeekYear: (date, locale) => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return dayjs(date).isoWeekYear();
     }
-    return dayjs(date).year(); // dayjs doesn't have weekYear, use year as approximation
+    // dayjs has no native locale `.weekYear()`. Use the same heuristic as
+    // moment.js: when the date sits on a year boundary that crosses week
+    // boundaries, the weekYear differs from the calendar year.
+    //   • early-January (month=0) with week >= 52 → previous calendar's
+    //     final week. weekYear = year - 1.
+    //   • late-December (month=11) with week === 1 → next calendar's first
+    //     week. weekYear = year + 1.
+    //   • otherwise weekYear = year.
+    const d = dayjs(date).locale(localeMapping(locale));
+    const week = d.week();
+    const month = d.month();
+    const year = d.year();
+    if (month === 0 && week >= 52) return year - 1;
+    if (month === 11 && week === 1) return year + 1;
+    return year;
   },
   getWeekDay: (date) => {
     const clone = dayjs(date).locale('en');
@@ -258,7 +288,7 @@ const CalendarMethodsDayjs: CalendarMethodsType = {
     dayjs(target).startOf(granularity).toISOString(),
 
   getCurrentWeekFirstDate: (value, locale) => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return dayjs(value)
         .startOf('isoWeek')
         .hour(0)
@@ -267,7 +297,10 @@ const CalendarMethodsDayjs: CalendarMethodsType = {
         .millisecond(0)
         .toISOString();
     }
+    // `.startOf('week')` honors the instance locale's firstDayOfWeek, so
+    // apply the requested locale before truncating.
     return dayjs(value)
+      .locale(localeMapping(locale))
       .startOf('week')
       .hour(0)
       .minute(0)
@@ -365,22 +398,27 @@ const CalendarMethodsDayjs: CalendarMethodsType = {
   isSameDate: (dateOne, dateTwo) =>
     dayjs(dateOne).isSame(dayjs(dateTwo), 'date'),
   isSameWeek: (dateOne, dateTwo, locale) => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return dayjs(dateOne).isSame(dayjs(dateTwo), 'isoWeek');
     }
-    return dayjs(dateOne).isSame(dayjs(dateTwo), 'week');
+    // `'week'` granularity uses the calling instance's locale — set locale
+    // on the comparator so non-ISO Monday-first locales align correctly.
+    return dayjs(dateOne)
+      .locale(localeMapping(locale))
+      .isSame(dayjs(dateTwo), 'week');
   },
   isInMonth: (target, month) => dayjs(target).month() === month,
   isDateIncluded: (date, targets) =>
     targets.some((target) => dayjs(date).isSame(dayjs(target), 'day')),
   isWeekIncluded: (firstDateOfWeek, targets, locale) => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return targets.some((target) =>
         dayjs(firstDateOfWeek).isSame(dayjs(target), 'isoWeek'),
       );
     }
+    const mappedLocale = localeMapping(locale);
     return targets.some((target) =>
-      dayjs(firstDateOfWeek).isSame(dayjs(target), 'week'),
+      dayjs(firstDateOfWeek).locale(mappedLocale).isSame(dayjs(target), 'week'),
     );
   },
   isMonthIncluded: (date, targets) =>
@@ -417,9 +455,12 @@ const CalendarMethodsDayjs: CalendarMethodsType = {
     //   ISO values because dayjs does not expose a locale `weekYear()`).
     // - GGGG / WW: ISO-8601 week year / number regardless of locale.
     if (format.includes('gggg') || format.includes('GGGG')) {
-      const isMon = isMondayFirst(locale);
-      const localeYear = isMon ? result.isoWeekYear() : result.year();
-      const localeWeek = isMon ? result.isoWeek() : result.week();
+      // Use ISO values for `gggg`/`ww` only when the locale truly uses
+      // ISO 8601 week rules. Monday-first non-ISO locales (e.g. en-AU,
+      // ro-RO) must emit locale-week values so format and getWeek agree.
+      const useISO = usesISOWeekRules(locale);
+      const localeYear = useISO ? result.isoWeekYear() : result.year();
+      const localeWeek = useISO ? result.isoWeek() : result.week();
       const isoYear = result.isoWeekYear();
       const isoWeek = result.isoWeek();
 

--- a/packages/core/src/calendarMethodsMoment/index.ts
+++ b/packages/core/src/calendarMethodsMoment/index.ts
@@ -20,6 +20,18 @@ const isMondayFirst = (locale: string): boolean => {
   return getActualFirstDayOfWeek(locale) === 1;
 };
 
+/**
+ * Whether the locale should be week-numbered using the ISO 8601 algorithm.
+ * Requires BOTH Monday-first AND `isISOWeekLocale` (i.e. minimalDays=4 per
+ * CLDR). For Monday-first locales whose CLDR `minimalDays` is 1 (en-AU,
+ * en-NZ, ro-RO, tr-TR, sl-SI, hr-HR, uk-UA, lv-LV …) this returns false so
+ * `getWeek`/`getWeekYear` use locale week numbering and stay consistent
+ * with `getDefaultModeFormat`.
+ */
+const usesISOWeekRules = (locale: string): boolean => {
+  return isMondayFirst(locale) && isISOWeekLocale(locale);
+};
+
 const CalendarMethodsMoment: CalendarMethodsType = {
   /** Get date infos */
   getNow: () => moment().toISOString(),
@@ -28,16 +40,20 @@ const CalendarMethodsMoment: CalendarMethodsType = {
   getHour: (date) => moment(date).hour(),
   getDate: (date) => moment(date).date(),
   getWeek: (date, locale) => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return moment(date).isoWeek();
     }
-    return moment(date).week();
+    // `.week()` reads the moment instance's locale (firstDayOfWeek + doy).
+    // Apply the requested locale explicitly — otherwise the global default
+    // (usually `en-US` Sunday-first) would be used, breaking Monday-first
+    // non-ISO locales such as ro-RO / tr-TR.
+    return moment(date).locale(locale).week();
   },
   getWeekYear: (date, locale) => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return moment(date).isoWeekYear();
     }
-    return moment(date).weekYear();
+    return moment(date).locale(locale).weekYear();
   },
   getWeekDay: (date) => {
     const clone = moment(date).locale('en_US');
@@ -151,10 +167,9 @@ const CalendarMethodsMoment: CalendarMethodsType = {
     moment(target).startOf(granularity).toISOString(),
 
   getCurrentWeekFirstDate: (value, locale) => {
-    const m = moment(value);
-    if (isMondayFirst(locale)) {
-      // Monday-first: starts on Monday
-      return m
+    if (usesISOWeekRules(locale)) {
+      // Monday-first AND ISO: starts on Monday using ISO week.
+      return moment(value)
         .startOf('isoWeek')
         .hour(0)
         .minute(0)
@@ -162,8 +177,10 @@ const CalendarMethodsMoment: CalendarMethodsType = {
         .millisecond(0)
         .toISOString();
     }
-    // Locale week: starts on Sunday (for en-us, zh-tw, etc.)
-    return m
+    // Otherwise: locale-week start. `.startOf('week')` uses the instance
+    // locale's firstDayOfWeek, so apply the requested locale first.
+    return moment(value)
+      .locale(locale)
       .startOf('week')
       .hour(0)
       .minute(0)
@@ -266,22 +283,23 @@ const CalendarMethodsMoment: CalendarMethodsType = {
   isSameDate: (dateOne, dateTwo) =>
     moment(dateOne).isSame(moment(dateTwo), 'date'),
   isSameWeek: (dateOne, dateTwo, locale = 'en-us') => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return moment(dateOne).isSame(moment(dateTwo), 'isoWeek');
     }
-    return moment(dateOne).isSame(moment(dateTwo), 'week');
+    // `'week'` granularity uses the calling instance's locale.
+    return moment(dateOne).locale(locale).isSame(moment(dateTwo), 'week');
   },
   isInMonth: (target, month) => moment(target).month() === month,
   isDateIncluded: (date, targets) =>
     targets.some((target) => moment(date).isSame(moment(target), 'day')),
   isWeekIncluded: (firstDateOfWeek, targets, locale = 'en-us') => {
-    if (isMondayFirst(locale)) {
+    if (usesISOWeekRules(locale)) {
       return targets.some((target) =>
         moment(firstDateOfWeek).isSame(moment(target), 'isoWeek'),
       );
     }
     return targets.some((target) =>
-      moment(firstDateOfWeek).isSame(moment(target), 'week'),
+      moment(firstDateOfWeek).locale(locale).isSame(moment(target), 'week'),
     );
   },
   isMonthIncluded: (date, targets) =>


### PR DESCRIPTION
## Summary

Fixes three long-standing correctness issues in `@mezzanine-ui/core`'s calendar adapter system that were exposed while auditing locale week handling:

1. The static `ISO_WEEK_LOCALES` set listed **11 locales** as ISO 8601 that don't actually follow ISO week rules per CLDR's `Intl.Locale#weekInfo` data.
2. The dayjs and moment adapters' `getWeek` / `getWeekYear` / `isSameWeek` / `isWeekIncluded` / `getCurrentWeekFirstDate` only checked `isMondayFirst(locale)` to decide between ISO and locale week algorithms — but ISO requires both Monday-first **AND** `minimalDays=4`.
3. dayjs adapter's `getWeekYear` for non-ISO locales used `.year()` (calendar year) as approximation, diverging from `moment.weekYear()` at year-end boundaries.

## Background

Cross-referencing each `CalendarLocale` enum entry against `Intl.Locale#weekInfo` (CLDR) revealed:

- Listed as ISO but **Sunday-first** per CLDR (week 1 should not start Mon): `pt-pt`/`pt`, `he-il`/`he`, `ar-sa`/`ar`
- Listed as ISO but Monday-first with **`minimalDays=1`** per CLDR (week 1 contains Jan 1, NOT first 4-day week): `en-au`, `en-nz`, `ro-ro`/`ro`, `sl-si`/`sl`, `hr-hr`/`hr`, `tr-tr`/`tr`, `uk-ua`/`uk`, `lv-lv`/`lv`

For these locales, `getDefaultModeFormat('week', locale)` was emitting `GGGG-[W]WW` (ISO format), but the actual week numbering should not follow ISO. dayjs/moment's `getWeek` then internally forced ISO via `.isoWeek()` — internally consistent within each adapter but incorrect per CLDR.

Commit 2/3 also fixes a latent bug exposed by these changes: locale-dependent ops like `.week()` / `.startOf('week')` / `.isSame(other, 'week')` were called without `.locale()`, so they fell through to the global default locale (typically `en` Sunday-first). Pre-existing behavior happened to be correct only because all Sunday-first locales agreed with the en default and all Monday-first locales took the ISO branch.

Commit 4 fixes `getWeekYear` divergence between dayjs and moment at year-end boundaries (e.g. `2025-12-28` in en-US: moment says weekYear=2026, dayjs returned 2025).

## Commits

1. \`fix(core/calendar): align ISO_WEEK_LOCALES with CLDR weekInfo\` — remove 11 misclassified entries, document audit basis
2. \`fix(core/calendarMethodsDayjs): align week math with CLDR for non-ISO Monday-first locales\` — \`usesISOWeekRules\` helper, \`.locale()\` application, \`getWeekYear\` heuristic + new spec
3. \`fix(core/calendarMethodsMoment): align week math with CLDR for non-ISO Monday-first locales\` — same pattern (no heuristic needed; moment has native \`.weekYear()\`)

## Test plan

- [x] \`yarn test\` in \`@mezzanine-ui/core\`: 207 tests pass (including 7 new dayjs spec cases)
- [x] \`yarn test\` in \`@mezzanine-ui/react\`: 3037 tests pass (no calendar/date-picker integration regressions)
- [x] dayjs/moment behaviour unchanged for ISO locales (de-DE, fr-FR, …)
- [x] dayjs/moment now correctly use locale week for en-AU / ro-RO / zh-CN
- [x] dayjs.getWeekYear() at year-end boundary now matches moment.weekYear()

## Visual-layout helpers untouched

\`getWeekDayNames\` / \`getWeekends\` / \`getCalendarGrid\` keep the simpler \`isMondayFirst\` check — their output depends only on first-day-of-week positioning, not on ISO classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)