### PR TITLE
feat: add JS-native Temporal calendar adapter

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,12 +23,16 @@
     "build:clean": "node ../../scripts/cleanBuild.js"
   },
   "peerDependencies": {
+    "@js-temporal/polyfill": ">=0.5",
     "dayjs": ">=1",
     "lodash": ">=4",
     "luxon": ">=3",
     "moment": ">=2"
   },
   "peerDependenciesMeta": {
+    "@js-temporal/polyfill": {
+      "optional": true
+    },
     "dayjs": {
       "optional": true
     },
@@ -46,6 +50,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
     "@types/luxon": "^3.6.2"
   }
 }

--- a/packages/core/src/calendarMethodsTemporal/calendarMethodsTemporal.spec.ts
+++ b/packages/core/src/calendarMethodsTemporal/calendarMethodsTemporal.spec.ts
@@ -1,0 +1,1345 @@
+import { Temporal } from '@js-temporal/polyfill';
+
+// Make Temporal available on the global as if a polyfill side-effect import had run.
+type TemporalGlobal = { Temporal: typeof Temporal };
+(globalThis as Partial<TemporalGlobal>).Temporal = Temporal;
+
+import { getDefaultModeFormat } from '../calendar/calendar';
+import CalendarMethodsTemporal from '.';
+
+const ZH_TW = 'zh-TW'; // Sunday-first
+const EN_US = 'en-US'; // Sunday-first
+const DE_DE = 'de-DE'; // Monday-first
+const FA_IR = 'fa-IR'; // Saturday-first (firstDay=6), weekend=[Friday]
+const AR_SA = 'ar-SA'; // Sunday-first, weekend=[Friday, Saturday]
+const ZH_CN = 'zh-CN'; // Monday-first BUT minimalDays=1 (NOT ISO)
+const EN_AU = 'en-AU'; // Monday-first BUT minimalDays=1 (NOT ISO)
+
+const fixedISO = '2026-05-05T14:30:45.000Z';
+
+describe('calendarMethodsTemporal', () => {
+  describe('basic getters', () => {
+    it('returns ISO 8601 string from getNow', () => {
+      const now = CalendarMethodsTemporal.getNow();
+      expect(typeof now).toBe('string');
+      expect(() => Temporal.Instant.from(now)).not.toThrow();
+    });
+
+    it('reads numeric components in system timezone', () => {
+      const date = '2026-01-15T08:30:45.123Z';
+      expect(CalendarMethodsTemporal.getYear(date)).toBe(2026);
+      // Month is 0-indexed for parity with moment/dayjs.
+      expect(CalendarMethodsTemporal.getMonth(date)).toBe(0);
+      // Day/hour/minute/second values shift with system timezone — assert they exist.
+      expect(typeof CalendarMethodsTemporal.getDate(date)).toBe('number');
+      expect(typeof CalendarMethodsTemporal.getHour(date)).toBe('number');
+      expect(CalendarMethodsTemporal.getMinute(date)).toBe(30);
+      expect(CalendarMethodsTemporal.getSecond(date)).toBe(45);
+    });
+
+    it('returns 0-indexed weekday matching moment/dayjs convention', () => {
+      // 2026-05-05 is Tuesday → ISO 2 → 0-indexed 2.
+      const tue = '2026-05-05T12:00:00Z';
+      expect(CalendarMethodsTemporal.getWeekDay(tue)).toBe(2);
+      // 2026-05-10 is Sunday → 0.
+      const sun = '2026-05-10T12:00:00Z';
+      expect(CalendarMethodsTemporal.getWeekDay(sun)).toBe(0);
+    });
+
+    it('computes quarter and half-year', () => {
+      expect(CalendarMethodsTemporal.getQuarter('2026-04-15T12:00:00Z')).toBe(
+        2,
+      );
+      expect(CalendarMethodsTemporal.getHalfYear('2026-04-15T12:00:00Z')).toBe(
+        1,
+      );
+      expect(CalendarMethodsTemporal.getHalfYear('2026-08-15T12:00:00Z')).toBe(
+        2,
+      );
+    });
+  });
+
+  describe('locale week numbering', () => {
+    it('uses ISO week (Monday-first) for Monday-first locales', () => {
+      // 2026-01-04 is Sunday — last day of ISO week 1 of 2026.
+      const sun = '2026-01-04T12:00:00Z';
+      expect(CalendarMethodsTemporal.getWeek(sun, DE_DE)).toBe(1);
+      expect(CalendarMethodsTemporal.getWeekYear(sun, DE_DE)).toBe(2026);
+
+      // 2026-01-05 (Mon) starts ISO week 2.
+      const mon = '2026-01-05T12:00:00Z';
+      expect(CalendarMethodsTemporal.getWeek(mon, DE_DE)).toBe(2);
+    });
+
+    it('uses locale week (Sunday-first, minimalDays=1) for en-US', () => {
+      // 2026-01-01 is Thursday. Week 1 contains Jan 1.
+      const jan1 = '2026-01-01T12:00:00Z';
+      expect(CalendarMethodsTemporal.getWeek(jan1, EN_US)).toBe(1);
+      expect(CalendarMethodsTemporal.getWeekYear(jan1, EN_US)).toBe(2026);
+
+      // 2026-01-04 is Sunday → starts week 2 in US numbering.
+      const jan4 = '2026-01-04T12:00:00Z';
+      expect(CalendarMethodsTemporal.getWeek(jan4, EN_US)).toBe(2);
+    });
+  });
+
+  describe('locale weekday/month names', () => {
+    it('returns Monday-first weekday names for de-DE', () => {
+      const names = CalendarMethodsTemporal.getWeekDayNames(DE_DE);
+      expect(names).toHaveLength(7);
+      // Monday-first locales should NOT start with Sunday.
+      const sun = names[0]; // Should be Monday narrow (M).
+      expect(sun.length).toBeGreaterThan(0);
+      // Last entry should be Sunday's narrow name.
+      expect(names[6].length).toBeGreaterThan(0);
+    });
+
+    it('returns Sunday-first weekday names for en-US', () => {
+      const names = CalendarMethodsTemporal.getWeekDayNames(EN_US);
+      expect(names).toHaveLength(7);
+    });
+
+    it('returns 12 month short names', () => {
+      const names = CalendarMethodsTemporal.getMonthShortNames(EN_US);
+      expect(names).toHaveLength(12);
+      expect(names[0]).toMatch(/^Jan/);
+    });
+
+    it('forces Gregorian calendar for locales with non-Gregorian defaults (fa-IR)', () => {
+      // fa-IR's default Intl calendar is Persian solar Hijri, where Jan 15
+      // 2024 sits in the Persian month "دی" (Day). Forcing Gregorian must
+      // give the Persian transliteration of "January" (ژانویه), matching
+      // the underlying ISO/Gregorian date math.
+      const names = CalendarMethodsTemporal.getMonthShortNames(FA_IR);
+      expect(names[0]).toMatch(/ژانویه|ژانو/);
+      // Specifically NOT the Persian-calendar default "دی".
+      expect(names[0]).not.toBe('دی');
+    });
+  });
+
+  describe('weekends', () => {
+    it('Monday-first locale weekends at positions 5,6', () => {
+      expect(CalendarMethodsTemporal.getWeekends(DE_DE)).toEqual([
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+      ]);
+    });
+
+    it('Sunday-first locale weekends at positions 0,6', () => {
+      expect(CalendarMethodsTemporal.getWeekends(EN_US)).toEqual([
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+      ]);
+    });
+
+    it('fa-IR (Saturday-first, Friday-only weekend) — Friday at position 6', () => {
+      // [Sat, Sun, Mon, Tue, Wed, Thu, Fri] → only Friday (position 6) weekend.
+      expect(CalendarMethodsTemporal.getWeekends(FA_IR)).toEqual([
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+      ]);
+    });
+
+    it('ar-SA (Sunday-first, Fri+Sat weekend) — Fri/Sat at positions 5,6', () => {
+      // [Sun, Mon, Tue, Wed, Thu, Fri, Sat] → Fri/Sat weekend at 5,6.
+      expect(CalendarMethodsTemporal.getWeekends(AR_SA)).toEqual([
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+      ]);
+    });
+  });
+
+  describe('isISOWeekLocale consistency with weekInfo', () => {
+    it('returns true only when weekInfo.firstDay=1 AND minimalDays=4', () => {
+      // de-DE: firstDay=1, minimalDays=4 → ISO.
+      expect(CalendarMethodsTemporal.isISOWeekLocale(DE_DE)).toBe(true);
+      // en-US: firstDay=7 (Sunday) → not ISO.
+      expect(CalendarMethodsTemporal.isISOWeekLocale(EN_US)).toBe(false);
+      // ar-SA: firstDay=7 per CLDR weekInfo even though listed in the
+      // legacy ISO_WEEK_LOCALES set — the Temporal adapter must report
+      // false so it stays consistent with its own grid/week math.
+      expect(CalendarMethodsTemporal.isISOWeekLocale(AR_SA)).toBe(false);
+      // fa-IR: firstDay=6 → not ISO.
+      expect(CalendarMethodsTemporal.isISOWeekLocale(FA_IR)).toBe(false);
+      // zh-CN / en-AU: firstDay=1 BUT minimalDays=1 → NOT ISO.
+      expect(CalendarMethodsTemporal.isISOWeekLocale(ZH_CN)).toBe(false);
+      expect(CalendarMethodsTemporal.isISOWeekLocale(EN_AU)).toBe(false);
+    });
+  });
+
+  describe('Monday-first non-ISO locales (zh-CN / en-AU): use locale week algorithm', () => {
+    // 2027-01-01 (Friday). Under ISO rules (de-DE) it sits in W53 of weekYear
+    // 2026 because ISO needs ≥4 days of the new year for week 1. Under
+    // zh-CN / en-AU rules (minimalDays=1) Jan 1 is in week 1 of 2027.
+    const jan1_2027 = '2027-01-01T12:00:00Z';
+
+    it('getWeekYear differs between zh-CN and de-DE on year boundary', () => {
+      expect(CalendarMethodsTemporal.getWeekYear(jan1_2027, ZH_CN)).toBe(2027);
+      expect(CalendarMethodsTemporal.getWeekYear(jan1_2027, DE_DE)).toBe(2026);
+    });
+
+    it('getWeek for zh-CN gives 1 not 53', () => {
+      expect(CalendarMethodsTemporal.getWeek(jan1_2027, ZH_CN)).toBe(1);
+      expect(CalendarMethodsTemporal.getWeek(jan1_2027, DE_DE)).toBe(53);
+    });
+
+    it('formatToString gggg-[W]ww uses locale week year for en-AU', () => {
+      expect(
+        CalendarMethodsTemporal.formatToString(EN_AU, jan1_2027, 'gggg-[W]ww'),
+      ).toBe('2027-W01');
+    });
+
+    it('formatToString GGGG-[W]WW always reports ISO week regardless of locale', () => {
+      // Even with a Monday-first non-ISO locale, ISO format tokens must
+      // still emit ISO numbers.
+      expect(
+        CalendarMethodsTemporal.formatToString(EN_AU, jan1_2027, 'GGGG-[W]WW'),
+      ).toBe('2026-W53');
+    });
+
+    it('getDefaultModeFormat picks gggg-[W]ww for en-AU after static set fix', () => {
+      // Regression for the format/getWeek divergence Codex flagged: with
+      // en-AU correctly classified as non-ISO, mode="week" should default
+      // to locale-week tokens, and the formatted output should match
+      // what getWeek/getWeekYear return.
+      const fmt = getDefaultModeFormat('week', EN_AU);
+      expect(fmt).toBe('gggg-[W]ww');
+      const formatted = CalendarMethodsTemporal.formatToString(
+        EN_AU,
+        jan1_2027,
+        fmt,
+      );
+      expect(formatted).toBe('2027-W01');
+      expect(CalendarMethodsTemporal.getWeek(jan1_2027, EN_AU)).toBe(1);
+      expect(CalendarMethodsTemporal.getWeekYear(jan1_2027, EN_AU)).toBe(2027);
+    });
+
+    it('getDefaultModeFormat picks gggg-[W]ww for ar-SA after static set fix', () => {
+      const fmt = getDefaultModeFormat('week', AR_SA);
+      expect(fmt).toBe('gggg-[W]ww');
+    });
+  });
+
+  describe('non-binary first day of week (fa-IR Saturday-first)', () => {
+    it('getFirstDayOfWeek returns 6 for fa-IR', () => {
+      // mezzanine convention: 0=Sunday, 1=Monday, …, 6=Saturday.
+      expect(CalendarMethodsTemporal.getFirstDayOfWeek(FA_IR)).toBe(6);
+    });
+
+    it('getWeekDayNames starts with Saturday for fa-IR', () => {
+      const names = CalendarMethodsTemporal.getWeekDayNames(FA_IR);
+      expect(names).toHaveLength(7);
+      // Compare against Sunday-indexed narrow names rotated by 6.
+      // We can't assert exact strings (locale dependent), but we can assert
+      // the rotation is consistent — first name should equal the original
+      // index-6 name.
+      const sundayIndexed = new Intl.DateTimeFormat(FA_IR, {
+        weekday: 'narrow',
+        timeZone: 'UTC',
+      });
+      const saturdayUtc = new Date(Date.UTC(2024, 0, 13)); // Sat
+      expect(names[0]).toBe(sundayIndexed.format(saturdayUtc));
+    });
+
+    it('getCalendarGrid for fa-IR starts week with Saturday', () => {
+      // Use 2026-01-15 (Thursday) — first day of January 2026 is Thursday.
+      // ISO Thursday = 4. firstDay = 6. daysFromPrev = (4 - 6 + 7) % 7 = 5.
+      // So row 0 has 5 days from December (27, 28, 29, 30, 31) then Jan 1, 2.
+      const grid = CalendarMethodsTemporal.getCalendarGrid(
+        '2026-01-15T12:00:00Z',
+        FA_IR,
+      );
+      expect(grid[0]).toEqual([27, 28, 29, 30, 31, 1, 2]);
+    });
+  });
+
+  describe('manipulation', () => {
+    it('addDay handles month boundaries', () => {
+      const result = CalendarMethodsTemporal.addDay('2026-01-31T12:00:00Z', 1);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(1); // February
+    });
+
+    it('addMonth clamps day to month length', () => {
+      const result = CalendarMethodsTemporal.addMonth(
+        '2026-01-31T12:00:00Z',
+        1,
+      );
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(1);
+      expect(CalendarMethodsTemporal.getDate(result)).toBeLessThanOrEqual(28);
+    });
+
+    it('startOf "month" zeros the time', () => {
+      const result = CalendarMethodsTemporal.startOf(fixedISO, 'month');
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(1);
+      expect(CalendarMethodsTemporal.getHour(result)).toBe(0);
+    });
+
+    it('startOf "year" returns Jan 1', () => {
+      const result = CalendarMethodsTemporal.startOf(fixedISO, 'year');
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(0);
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(1);
+    });
+
+    it('startOf "isoWeek" returns Monday', () => {
+      // 2026-05-08 is Friday → ISO week starts Monday 2026-05-04.
+      const result = CalendarMethodsTemporal.startOf(
+        '2026-05-08T12:00:00Z',
+        'isoWeek',
+      );
+      const zdt = Temporal.Instant.from(result).toZonedDateTimeISO(
+        Temporal.Now.zonedDateTimeISO().timeZoneId,
+      );
+      expect(zdt.dayOfWeek).toBe(1);
+    });
+
+    it('startOf "week" defaults to Sunday-first (matches dayjs/moment)', () => {
+      // 2026-05-08 is Friday → Sunday-first week starts Sunday 2026-05-03.
+      const result = CalendarMethodsTemporal.startOf(
+        '2026-05-08T12:00:00Z',
+        'week',
+      );
+      const zdt = Temporal.Instant.from(result).toZonedDateTimeISO(
+        Temporal.Now.zonedDateTimeISO().timeZoneId,
+      );
+      expect(zdt.dayOfWeek).toBe(7);
+    });
+  });
+
+  describe('setter rollover (parity with moment/dayjs)', () => {
+    // Previous-month grid cells pass `setMonth(ref, currentMonth - 1)` which
+    // can be -1 in January. moment/dayjs normalise this to last December.
+    it('setMonth handles month = -1 → previous December', () => {
+      const jan = '2026-01-15T12:00:00Z';
+      const result = CalendarMethodsTemporal.setMonth(jan, -1);
+      expect(CalendarMethodsTemporal.getYear(result)).toBe(2025);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(11);
+    });
+
+    it('setMonth handles month = 12 → next January', () => {
+      const jan = '2026-01-15T12:00:00Z';
+      const result = CalendarMethodsTemporal.setMonth(jan, 12);
+      expect(CalendarMethodsTemporal.getYear(result)).toBe(2027);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(0);
+    });
+
+    it('setMonth in-range still constrains day to month length', () => {
+      // Mar 31 → Feb: clamp to Feb 28 (2026 is non-leap).
+      const mar31 = '2026-03-31T12:00:00Z';
+      const result = CalendarMethodsTemporal.setMonth(mar31, 1);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(1);
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(28);
+    });
+
+    // Week range cells pass `setDate(value, currentDate ± 6)` which can spill
+    // out of the current month. moment/dayjs normalise across boundaries.
+    it('setDate handles target = 0 → last day of previous month', () => {
+      const may15 = '2026-05-15T12:00:00Z';
+      const result = CalendarMethodsTemporal.setDate(may15, 0);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(3); // April
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(30);
+    });
+
+    it('setDate handles target > daysInMonth → spills into next month', () => {
+      const may15 = '2026-05-15T12:00:00Z';
+      const result = CalendarMethodsTemporal.setDate(may15, 35);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(5); // June
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(4);
+    });
+
+    it('setDate target = -3 rolls back into previous month', () => {
+      const may15 = '2026-05-15T12:00:00Z';
+      const result = CalendarMethodsTemporal.setDate(may15, -3);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(3); // April
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(27);
+    });
+
+    it('setYear clamps Feb 29 of leap year to Feb 28 of non-leap year', () => {
+      // 2024 is leap; 2025 is not.
+      const feb29 = '2024-02-29T12:00:00Z';
+      const result = CalendarMethodsTemporal.setYear(feb29, 2025);
+      expect(CalendarMethodsTemporal.getYear(result)).toBe(2025);
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(1); // February
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(28);
+    });
+  });
+
+  describe('first-of-period helpers', () => {
+    it('getCurrentWeekFirstDate returns Monday for de-DE', () => {
+      // 2026-05-08 (Friday) → week starts Monday 2026-05-04.
+      const result = CalendarMethodsTemporal.getCurrentWeekFirstDate(
+        '2026-05-08T12:00:00Z',
+        DE_DE,
+      );
+      // Use Temporal to inspect — bypass tz-sensitive day check.
+      const zdt = Temporal.Instant.from(result).toZonedDateTimeISO(
+        Temporal.Now.zonedDateTimeISO().timeZoneId,
+      );
+      expect(zdt.dayOfWeek).toBe(1);
+    });
+
+    it('getCurrentWeekFirstDate returns Sunday for en-US', () => {
+      const result = CalendarMethodsTemporal.getCurrentWeekFirstDate(
+        '2026-05-08T12:00:00Z',
+        EN_US,
+      );
+      const zdt = Temporal.Instant.from(result).toZonedDateTimeISO(
+        Temporal.Now.zonedDateTimeISO().timeZoneId,
+      );
+      expect(zdt.dayOfWeek).toBe(7);
+    });
+
+    it('getCurrentQuarterFirstDate returns first day of the quarter', () => {
+      const result = CalendarMethodsTemporal.getCurrentQuarterFirstDate(
+        '2026-05-15T12:00:00Z',
+      );
+      expect(CalendarMethodsTemporal.getMonth(result)).toBe(3); // April
+      expect(CalendarMethodsTemporal.getDate(result)).toBe(1);
+    });
+
+    it('getCurrentHalfYearFirstDate returns Jan 1 or Jul 1', () => {
+      expect(
+        CalendarMethodsTemporal.getMonth(
+          CalendarMethodsTemporal.getCurrentHalfYearFirstDate(
+            '2026-05-15T12:00:00Z',
+          ),
+        ),
+      ).toBe(0);
+      expect(
+        CalendarMethodsTemporal.getMonth(
+          CalendarMethodsTemporal.getCurrentHalfYearFirstDate(
+            '2026-08-15T12:00:00Z',
+          ),
+        ),
+      ).toBe(6);
+    });
+  });
+
+  describe('comparators', () => {
+    const a = '2026-05-05T10:00:00Z';
+    const b = '2026-05-05T15:00:00Z';
+    const c = '2026-05-06T10:00:00Z';
+
+    it('isValid', () => {
+      expect(CalendarMethodsTemporal.isValid(a)).toBe(true);
+      expect(CalendarMethodsTemporal.isValid('not a date')).toBe(false);
+    });
+
+    it('isBefore', () => {
+      expect(CalendarMethodsTemporal.isBefore(a, b)).toBe(true);
+      expect(CalendarMethodsTemporal.isBefore(b, a)).toBe(false);
+    });
+
+    it('isBetween at "day" granularity ignores time-of-day', () => {
+      // a / b same UTC day → at day granularity b normalises to same day as
+      // a, so b is NOT strictly "between" a..c (exclusive).
+      expect(CalendarMethodsTemporal.isBetween(b, a, c, 'day')).toBe(false);
+
+      // Use noon-UTC fixtures so day boundaries don't shift across tz.
+      const before = '2026-05-03T12:00:00Z';
+      const between = '2026-05-04T12:00:00Z';
+      const after = '2026-05-05T12:00:00Z';
+      expect(
+        CalendarMethodsTemporal.isBetween(between, before, after, 'day'),
+      ).toBe(true);
+    });
+
+    it('isBetween treats both bounds as exclusive (matches dayjs/moment default)', () => {
+      const start = '2026-05-04T12:00:00Z';
+      const middle = '2026-05-05T12:00:00Z';
+      const end = '2026-05-06T12:00:00Z';
+      // Boundary values exactly equal lo/hi → exclusive → false.
+      expect(CalendarMethodsTemporal.isBetween(start, start, end, 'day')).toBe(
+        false,
+      );
+      expect(CalendarMethodsTemporal.isBetween(end, start, end, 'day')).toBe(
+        false,
+      );
+      // Strictly between → true.
+      expect(CalendarMethodsTemporal.isBetween(middle, start, end, 'day')).toBe(
+        true,
+      );
+    });
+
+    it('isSameDate ignores time-of-day', () => {
+      expect(CalendarMethodsTemporal.isSameDate(a, b)).toBe(true);
+    });
+
+    it('isSameWeek aligns with locale rules', () => {
+      const monday = '2026-05-04T12:00:00Z';
+      const sunday = '2026-05-10T12:00:00Z';
+      // de-DE Monday-first → Mon-Sun is one week.
+      expect(CalendarMethodsTemporal.isSameWeek(monday, sunday, DE_DE)).toBe(
+        true,
+      );
+      // en-US Sunday-first → Sunday May 10 starts a NEW week.
+      expect(CalendarMethodsTemporal.isSameWeek(monday, sunday, EN_US)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('calendar grid', () => {
+    it('returns 6×7 grid', () => {
+      const grid = CalendarMethodsTemporal.getCalendarGrid(fixedISO, EN_US);
+      expect(grid).toHaveLength(6);
+      grid.forEach((row) => expect(row).toHaveLength(7));
+    });
+
+    it('Monday-first vs Sunday-first alignment', () => {
+      const monday = CalendarMethodsTemporal.getCalendarGrid(
+        '2026-05-15T12:00:00Z',
+        DE_DE,
+      );
+      const sunday = CalendarMethodsTemporal.getCalendarGrid(
+        '2026-05-15T12:00:00Z',
+        EN_US,
+      );
+      // Both grids cover 42 cells but the offset differs by 1 day.
+      expect(monday.flat()).toHaveLength(42);
+      expect(sunday.flat()).toHaveLength(42);
+    });
+  });
+
+  describe('formatToString', () => {
+    it('formats common date tokens', () => {
+      const out = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-05-05T03:30:00Z',
+        'YYYY-MM-DD HH:mm:ss',
+      );
+      expect(out).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+      expect(out.startsWith('2026-')).toBe(true);
+    });
+
+    it('formats month names per locale', () => {
+      const out = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-01-15T12:00:00Z',
+        'MMM',
+      );
+      expect(out).toMatch(/^Jan/);
+
+      const outDE = CalendarMethodsTemporal.formatToString(
+        DE_DE,
+        '2026-01-15T12:00:00Z',
+        'MMMM',
+      );
+      expect(outDE).toMatch(/Januar/);
+    });
+
+    it('quotes literals via [...] brackets', () => {
+      const out = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-05-05T03:30:00Z',
+        'YYYY-[Q]Q',
+      );
+      expect(out).toBe('2026-Q2');
+    });
+
+    it('formats half-year via [H]n', () => {
+      const out1 = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-03-05T12:00:00Z',
+        'YYYY-[H]n',
+      );
+      expect(out1).toBe('2026-H1');
+
+      const out2 = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-08-05T12:00:00Z',
+        'YYYY-[H]n',
+      );
+      expect(out2).toBe('2026-H2');
+    });
+
+    it('formats ISO week year and number', () => {
+      // 2026-01-01 (Thursday) is in ISO week 1 of 2026.
+      const out = CalendarMethodsTemporal.formatToString(
+        DE_DE,
+        '2026-01-01T12:00:00Z',
+        'GGGG-[W]WW',
+      );
+      expect(out).toBe('2026-W01');
+    });
+
+    it('formats `d` (ISO Sunday-indexed weekday) consistently across locales', () => {
+      // 2026-05-04 is Monday → ISO Sunday-indexed = 1.
+      const monday = '2026-05-04T12:00:00Z';
+      expect(CalendarMethodsTemporal.formatToString(EN_US, monday, 'd')).toBe(
+        '1',
+      );
+      expect(CalendarMethodsTemporal.formatToString(DE_DE, monday, 'd')).toBe(
+        '1',
+      );
+    });
+
+    it('formats `e` as locale-relative weekday (firstDay = 0)', () => {
+      // 2026-05-04 is Monday.
+      const monday = '2026-05-04T12:00:00Z';
+      // de-DE: Monday-first → Monday = 0.
+      expect(CalendarMethodsTemporal.formatToString(DE_DE, monday, 'e')).toBe(
+        '0',
+      );
+      // en-US: Sunday-first → Monday = 1.
+      expect(CalendarMethodsTemporal.formatToString(EN_US, monday, 'e')).toBe(
+        '1',
+      );
+
+      // 2026-05-09 is Saturday.
+      const saturday = '2026-05-09T12:00:00Z';
+      // fa-IR: Saturday-first → Saturday = 0.
+      expect(CalendarMethodsTemporal.formatToString(FA_IR, saturday, 'e')).toBe(
+        '0',
+      );
+    });
+
+    it('formats DDDD (3-digit day-of-year) padded', () => {
+      // Jan 5 → day 5 → "005".
+      const out = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-01-05T12:00:00Z',
+        'DDDD',
+      );
+      expect(out).toBe('005');
+    });
+
+    it('round-trips DDDD output as YYYY-DDDD', () => {
+      const original = '2026-05-15T12:00:00Z';
+      const formatted = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        original,
+        'YYYY-DDDD',
+      );
+      const parsed = CalendarMethodsTemporal.parseFormattedValue(
+        formatted,
+        'YYYY-DDDD',
+        EN_US,
+      );
+      expect(parsed).toBeDefined();
+      expect(CalendarMethodsTemporal.getYear(parsed as string)).toBe(2026);
+      // Same calendar day in system tz.
+      const reformatted = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        parsed as string,
+        'YYYY-DDDD',
+      );
+      expect(reformatted).toBe(formatted);
+    });
+  });
+
+  describe('parseFormattedValue', () => {
+    it('round-trips a full date format', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-05-05',
+        'YYYY-MM-DD',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getYear(iso as string)).toBe(2026);
+      expect(CalendarMethodsTemporal.getMonth(iso as string)).toBe(4);
+      expect(CalendarMethodsTemporal.getDate(iso as string)).toBe(5);
+    });
+
+    it('rejects invalid month', () => {
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2026-13-01',
+          'YYYY-MM-DD',
+          EN_US,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('rejects invalid day for month', () => {
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2026-02-30',
+          'YYYY-MM-DD',
+          EN_US,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('parses month-only to first day', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-05',
+        'YYYY-MM',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getDate(iso as string)).toBe(1);
+    });
+
+    it('parses year-only to Jan 1', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '2026',
+        'YYYY',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getMonth(iso as string)).toBe(0);
+      expect(CalendarMethodsTemporal.getDate(iso as string)).toBe(1);
+    });
+
+    it('parses quarter format', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-Q2',
+        'YYYY-[Q]Q',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getMonth(iso as string)).toBe(3);
+    });
+
+    it('rejects out-of-range quarter', () => {
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2026-Q5',
+          'YYYY-[Q]Q',
+          EN_US,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('parses half-year format', () => {
+      const iso1 = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-H1',
+        'YYYY-[H]n',
+        EN_US,
+      );
+      const iso2 = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-H2',
+        'YYYY-[H]n',
+        EN_US,
+      );
+      expect(iso1).toBeDefined();
+      expect(iso2).toBeDefined();
+      expect(CalendarMethodsTemporal.getMonth(iso1 as string)).toBe(0);
+      expect(CalendarMethodsTemporal.getMonth(iso2 as string)).toBe(6);
+    });
+
+    it('rejects out-of-range half-year', () => {
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2026-H3',
+          'YYYY-[H]n',
+          EN_US,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('parses ISO week format', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-W01',
+        'GGGG-[W]WW',
+        DE_DE,
+      );
+      expect(iso).toBeDefined();
+      // ISO week 1 of 2026 starts on Monday Dec 29 2025.
+      expect(CalendarMethodsTemporal.getYear(iso as string)).toBe(2025);
+    });
+
+    it('rejects ISO week 53 in a 52-week year (e.g. 2021)', () => {
+      // 2021 is a 52-week ISO year; 2021-W53 is impossible.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2021-W53',
+          'GGGG-[W]WW',
+          DE_DE,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('accepts ISO week 53 in a 53-week year (e.g. 2020)', () => {
+      // 2020 is a 53-week ISO year.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2020-W53',
+          'GGGG-[W]WW',
+          DE_DE,
+        ),
+      ).toBeDefined();
+    });
+
+    it('returns undefined (not crash) when format has weekYear but no week number', () => {
+      // gggg-only: previously NaN propagated into Temporal.add() → RangeError.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue('2026', 'gggg', EN_US),
+      ).toBeUndefined();
+      // GGGG-only: same crash path.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue('2026', 'GGGG', DE_DE),
+      ).toBeUndefined();
+    });
+
+    it('parses YY 2-digit year with moment-style pivot at 68/69', () => {
+      // Pivot semantics matching dayjs/moment:
+      //   00..68 → 21st century (2000..2068)
+      //   69..99 → 20th century (1969..1999)
+      const cases: Array<[string, number]> = [
+        ['00-05-15', 2000],
+        ['67-05-15', 2067],
+        ['68-05-15', 2068],
+        ['69-05-15', 1969],
+        ['99-05-15', 1999],
+      ];
+      for (const [text, expectedYear] of cases) {
+        const iso = CalendarMethodsTemporal.parseFormattedValue(
+          text,
+          'YY-MM-DD',
+          EN_US,
+        );
+        expect(iso).toBeDefined();
+        expect(CalendarMethodsTemporal.getYear(iso as string)).toBe(
+          expectedYear,
+        );
+      }
+    });
+
+    it('returns undefined for incoherent mixed weekYear/week tokens', () => {
+      // gggg + WW: locale weekYear with ISO week number — incoherent
+      // semantics. Must return undefined rather than silently drop the week.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2026-W01',
+          'gggg-[W]WW',
+          EN_US,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('rejects en-US locale week 53 in a 52-week year (2025)', () => {
+      // en-US uses minimalDays=1, Sunday-first. 2025 has 52 locale weeks.
+      // Critically: 2025-12-28 (the previous Dec 28 anchor) is already
+      // 2026-W01 under en-US rules, so the old Dec-28 algorithm wrongly
+      // accepted 2025-W53.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2025-W53',
+          'gggg-[W]ww',
+          EN_US,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('accepts en-US locale week 53 in a 53-week year (2022)', () => {
+      // en-US 2022 has 53 locale weeks (Jan 1 2022 is Sat, Sunday-first
+      // calendar starts week 1 at 2021-12-26 → 53 buckets fit by year-end).
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2022-W53',
+          'gggg-[W]ww',
+          EN_US,
+        ),
+      ).toBeDefined();
+    });
+
+    it('parses datetime with hours and minutes', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-05-05 14:30:00',
+        'YYYY-MM-DD HH:mm:ss',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getMinute(iso as string)).toBe(30);
+    });
+
+    it('parses time-only HH:mm against today as anchor', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '14:30',
+        'HH:mm',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getHour(iso as string)).toBe(14);
+      expect(CalendarMethodsTemporal.getMinute(iso as string)).toBe(30);
+      expect(CalendarMethodsTemporal.getSecond(iso as string)).toBe(0);
+    });
+
+    it('parses time-only HH:mm:ss', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '23:59:45',
+        'HH:mm:ss',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getHour(iso as string)).toBe(23);
+      expect(CalendarMethodsTemporal.getMinute(iso as string)).toBe(59);
+      expect(CalendarMethodsTemporal.getSecond(iso as string)).toBe(45);
+    });
+
+    it('parses 12-hour time with meridiem', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '02:30 PM',
+        'hh:mm A',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getHour(iso as string)).toBe(14);
+      expect(CalendarMethodsTemporal.getMinute(iso as string)).toBe(30);
+    });
+
+    it('rejects out-of-range time-only values', () => {
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue('25:00', 'HH:mm', EN_US),
+      ).toBeUndefined();
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue('12:60', 'HH:mm', EN_US),
+      ).toBeUndefined();
+    });
+
+    it('parses MMM short month names back to month index (en-US)', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        'Jan 5, 2026',
+        'MMM D, YYYY',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getYear(iso as string)).toBe(2026);
+      expect(CalendarMethodsTemporal.getMonth(iso as string)).toBe(0);
+      expect(CalendarMethodsTemporal.getDate(iso as string)).toBe(5);
+    });
+
+    it('parses MMMM long month names + Do ordinal day', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        'January 5th, 2026',
+        'MMMM Do, YYYY',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getMonth(iso as string)).toBe(0);
+      expect(CalendarMethodsTemporal.getDate(iso as string)).toBe(5);
+    });
+
+    it('rejects MMM with mismatched casing/short-vs-long', () => {
+      // Long form input against short token → should not match.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          'January 5, 2026',
+          'MMM D, YYYY',
+          EN_US,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('round-trips formatToString output for MMM D, YYYY', () => {
+      const formatted = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-03-15T12:00:00Z',
+        'MMM D, YYYY',
+      );
+      const parsed = CalendarMethodsTemporal.parseFormattedValue(
+        formatted,
+        'MMM D, YYYY',
+        EN_US,
+      );
+      expect(parsed).toBeDefined();
+      expect(CalendarMethodsTemporal.getYear(parsed as string)).toBe(2026);
+      expect(CalendarMethodsTemporal.getMonth(parsed as string)).toBe(2);
+    });
+
+    it('parses SS fractional second (deciseconds → ms × 10)', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '12:00:00.45',
+        'HH:mm:ss.SS',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      const isoStr = iso as string;
+      // SS=45 → 450ms.
+      const dt = new Date(isoStr);
+      expect(dt.getUTCMilliseconds() % 1000).toBe(450);
+    });
+
+    it('parses S fractional second (centiseconds → ms × 100)', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '12:00:00.7',
+        'HH:mm:ss.S',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      const dt = new Date(iso as string);
+      expect(dt.getUTCMilliseconds()).toBe(700);
+    });
+
+    it('parses kk 1-24 hour clock; "24" maps to hour 0', () => {
+      const iso24 = CalendarMethodsTemporal.parseFormattedValue(
+        '24:00',
+        'kk:mm',
+        EN_US,
+      );
+      expect(iso24).toBeDefined();
+      expect(CalendarMethodsTemporal.getHour(iso24 as string)).toBe(0);
+
+      const iso13 = CalendarMethodsTemporal.parseFormattedValue(
+        '13:30',
+        'kk:mm',
+        EN_US,
+      );
+      expect(iso13).toBeDefined();
+      expect(CalendarMethodsTemporal.getHour(iso13 as string)).toBe(13);
+    });
+
+    it('rejects k=0 and k=25 (out of 1-24 range)', () => {
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue('00:00', 'kk:mm', EN_US),
+      ).toBeUndefined();
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue('25:00', 'kk:mm', EN_US),
+      ).toBeUndefined();
+    });
+
+    it('parses DDD day-of-year + YYYY back to a calendar date', () => {
+      // Day 125 of 2026 = May 5 (Jan=31 + Feb=28 + Mar=31 + Apr=30 + 5).
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '2026-125',
+        'YYYY-DDD',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getMonth(iso as string)).toBe(4);
+      expect(CalendarMethodsTemporal.getDate(iso as string)).toBe(5);
+    });
+
+    it('rejects DDD outside year length', () => {
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2026-366',
+          'YYYY-DDD',
+          EN_US,
+        ),
+      ).toBeUndefined(); // 2026 not leap
+      // Leap year accepts 366.
+      expect(
+        CalendarMethodsTemporal.parseFormattedValue(
+          '2024-366',
+          'YYYY-DDD',
+          EN_US,
+        ),
+      ).toBeDefined();
+    });
+
+    it('parses x unix epoch ms standalone', () => {
+      // 1746460800000 ≈ 2025-05-05T16:00:00Z (rough fixture).
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '1746460800000',
+        'x',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(new Date(iso as string).getTime()).toBe(1746460800000);
+    });
+
+    it('parses X unix epoch seconds standalone', () => {
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        '1746460800',
+        'X',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(new Date(iso as string).getTime()).toBe(1746460800 * 1000);
+    });
+
+    it('consumes weekday tokens but discards them', () => {
+      // dddd appears in input but year/month/day come from other tokens.
+      const iso = CalendarMethodsTemporal.parseFormattedValue(
+        'Tuesday, May 5, 2026',
+        'dddd, MMMM D, YYYY',
+        EN_US,
+      );
+      expect(iso).toBeDefined();
+      expect(CalendarMethodsTemporal.getMonth(iso as string)).toBe(4);
+      expect(CalendarMethodsTemporal.getDate(iso as string)).toBe(5);
+    });
+  });
+
+  describe('inclusion checks', () => {
+    // Use noon UTC fixtures so the day boundary is unambiguous across timezones.
+    const targets = ['2026-05-05T12:00:00Z', '2026-08-15T12:00:00Z'];
+
+    it('isDateIncluded', () => {
+      // Two times within the same UTC day as the first target.
+      expect(
+        CalendarMethodsTemporal.isDateIncluded('2026-05-05T11:30:00Z', targets),
+      ).toBe(true);
+      expect(
+        CalendarMethodsTemporal.isDateIncluded('2026-05-07T12:00:00Z', targets),
+      ).toBe(false);
+    });
+
+    it('isMonthIncluded', () => {
+      expect(
+        CalendarMethodsTemporal.isMonthIncluded(
+          '2026-05-15T20:00:00Z',
+          targets,
+        ),
+      ).toBe(true);
+      expect(
+        CalendarMethodsTemporal.isMonthIncluded(
+          '2026-06-15T20:00:00Z',
+          targets,
+        ),
+      ).toBe(false);
+    });
+
+    it('isQuarterIncluded', () => {
+      // 2026-05-05 is Q2; 2026-08-15 is Q3.
+      expect(
+        CalendarMethodsTemporal.isQuarterIncluded(
+          '2026-04-30T12:00:00Z',
+          targets,
+        ),
+      ).toBe(true);
+    });
+
+    it('isYearIncluded', () => {
+      expect(
+        CalendarMethodsTemporal.isYearIncluded('2026-12-31T12:00:00Z', targets),
+      ).toBe(true);
+      expect(
+        CalendarMethodsTemporal.isYearIncluded('2025-01-01T12:00:00Z', targets),
+      ).toBe(false);
+    });
+  });
+
+  describe('format ↔ parse round-trip property', () => {
+    // Fixture dates spread across the year so we exercise different months,
+    // quarters, half-years, and ISO week boundaries.
+    const fixtures = [
+      '2026-01-15T12:00:00Z', // mid-January, Q1, H1
+      '2026-03-31T12:00:00Z', // end of March (boundary day)
+      '2026-05-05T12:00:00Z', // mid-Q2
+      '2026-08-15T12:00:00Z', // mid-Q3, H2
+      '2026-12-31T12:00:00Z', // end-of-year
+    ];
+
+    // mezzanine's mode-format catalogue. We validate the same date keys the
+    // mode is actually meant to round-trip:
+    //  - day:        Y/M/D
+    //  - week:       weekYear / weekNumber
+    //  - month:      Y/M
+    //  - year:       Y
+    //  - quarter:    Y / quarter
+    //  - half-year:  Y / halfYear
+    const modes = [
+      'day',
+      'week',
+      'month',
+      'year',
+      'quarter',
+      'half-year',
+    ] as const;
+
+    type Mode = (typeof modes)[number];
+
+    function expectRoundTrip(iso: string, locale: string, mode: Mode): void {
+      const format = getDefaultModeFormat(mode, locale);
+      const formatted = CalendarMethodsTemporal.formatToString(
+        locale,
+        iso,
+        format,
+      );
+      const parsed = CalendarMethodsTemporal.parseFormattedValue(
+        formatted,
+        format,
+        locale,
+      );
+      expect(parsed).toBeDefined();
+      const p = parsed as string;
+
+      switch (mode) {
+        case 'day':
+          expect(CalendarMethodsTemporal.getYear(p)).toBe(
+            CalendarMethodsTemporal.getYear(iso),
+          );
+          expect(CalendarMethodsTemporal.getMonth(p)).toBe(
+            CalendarMethodsTemporal.getMonth(iso),
+          );
+          expect(CalendarMethodsTemporal.getDate(p)).toBe(
+            CalendarMethodsTemporal.getDate(iso),
+          );
+          break;
+        case 'week':
+          expect(CalendarMethodsTemporal.getWeek(p, locale)).toBe(
+            CalendarMethodsTemporal.getWeek(iso, locale),
+          );
+          expect(CalendarMethodsTemporal.getWeekYear(p, locale)).toBe(
+            CalendarMethodsTemporal.getWeekYear(iso, locale),
+          );
+          break;
+        case 'month':
+          expect(CalendarMethodsTemporal.getYear(p)).toBe(
+            CalendarMethodsTemporal.getYear(iso),
+          );
+          expect(CalendarMethodsTemporal.getMonth(p)).toBe(
+            CalendarMethodsTemporal.getMonth(iso),
+          );
+          break;
+        case 'year':
+          expect(CalendarMethodsTemporal.getYear(p)).toBe(
+            CalendarMethodsTemporal.getYear(iso),
+          );
+          break;
+        case 'quarter':
+          expect(CalendarMethodsTemporal.getYear(p)).toBe(
+            CalendarMethodsTemporal.getYear(iso),
+          );
+          expect(CalendarMethodsTemporal.getQuarter(p)).toBe(
+            CalendarMethodsTemporal.getQuarter(iso),
+          );
+          break;
+        case 'half-year':
+          expect(CalendarMethodsTemporal.getYear(p)).toBe(
+            CalendarMethodsTemporal.getYear(iso),
+          );
+          expect(CalendarMethodsTemporal.getHalfYear(p)).toBe(
+            CalendarMethodsTemporal.getHalfYear(iso),
+          );
+          break;
+      }
+    }
+
+    for (const locale of [EN_US, DE_DE, ZH_TW]) {
+      for (const mode of modes) {
+        for (const iso of fixtures) {
+          it(`${locale} / ${mode} / ${iso.slice(0, 10)}`, () => {
+            expectRoundTrip(iso, locale, mode);
+          });
+        }
+      }
+    }
+
+    // Also cover the default time format used by TimePicker.
+    it('time format HH:mm:ss round-trips', () => {
+      const formatted = CalendarMethodsTemporal.formatToString(
+        EN_US,
+        '2026-05-05T03:30:45Z',
+        'HH:mm:ss',
+      );
+      const parsed = CalendarMethodsTemporal.parseFormattedValue(
+        formatted,
+        'HH:mm:ss',
+        EN_US,
+      );
+      expect(parsed).toBeDefined();
+      // Hour will reflect system tz, so just compare the formatted view.
+      expect(
+        CalendarMethodsTemporal.formatToString(
+          EN_US,
+          parsed as string,
+          'HH:mm:ss',
+        ),
+      ).toBe(formatted);
+    });
+  });
+
+  describe('weekInfo partial response (older runtime simulation)', () => {
+    // Some older V8 / Safari builds expose `Intl.Locale#weekInfo` but only
+    // populate `firstDay` / `weekend`, not `minimalDays`. The adapter must
+    // fall back to the static ISO_WEEK_LOCALES set for `minimalDays` so
+    // that ISO locales like de-DE stay classified as ISO.
+    const OriginalLocale = Intl.Locale;
+
+    afterEach(() => {
+      (Intl as unknown as { Locale: typeof OriginalLocale }).Locale =
+        OriginalLocale;
+      // Re-import to clear the module's weekInfoCache.
+      jest.resetModules();
+    });
+
+    it('classifies de-DE as ISO when minimalDays is missing from weekInfo', () => {
+      class StubLocale extends OriginalLocale {
+        get weekInfo(): { firstDay: number; weekend: number[] } {
+          // Mirror what de-DE looks like with the minimalDays field absent.
+          return { firstDay: 1, weekend: [6, 7] };
+        }
+      }
+      (Intl as unknown as { Locale: typeof OriginalLocale }).Locale =
+        StubLocale as unknown as typeof OriginalLocale;
+
+      // Re-import so the new module instance reads the patched Intl.Locale
+      // and starts with a fresh weekInfoCache.
+      jest.isolateModules(() => {
+         
+        const adapter = require('.').default as typeof CalendarMethodsTemporal;
+        expect(adapter.isISOWeekLocale(DE_DE)).toBe(true);
+        // 2027-01-01 (Friday): with the static-set fallback giving
+        // minimalDays=4, this must resolve to ISO weekYear 2026 W53.
+        const jan1_2027 = '2027-01-01T12:00:00Z';
+        expect(adapter.getWeekYear(jan1_2027, DE_DE)).toBe(2026);
+        expect(adapter.getWeek(jan1_2027, DE_DE)).toBe(53);
+      });
+    });
+
+    it('classifies ISO variants (de-AT, fr-CH) as ISO via language-only fallback', () => {
+      // de-AT and fr-CH are not literally in ISO_WEEK_LOCALES, but their
+      // language codes (de, fr) are. The variant-aware defaultMinimalDays
+      // must inherit ISO from the language code when the runtime omits
+      // minimalDays.
+      class StubLocale extends OriginalLocale {
+        get weekInfo(): { firstDay: number; weekend: number[] } {
+          return { firstDay: 1, weekend: [6, 7] };
+        }
+      }
+      (Intl as unknown as { Locale: typeof OriginalLocale }).Locale =
+        StubLocale as unknown as typeof OriginalLocale;
+
+      jest.isolateModules(() => {
+         
+        const adapter = require('.').default as typeof CalendarMethodsTemporal;
+        expect(adapter.isISOWeekLocale('de-AT')).toBe(true);
+        expect(adapter.isISOWeekLocale('fr-CH')).toBe(true);
+        // 2027-01-01 → ISO 2026-W53.
+        expect(adapter.getWeekYear('2027-01-01T12:00:00Z', 'de-AT')).toBe(2026);
+      });
+    });
+  });
+
+  describe('polyfill guard', () => {
+    it('throws a descriptive error if Temporal is missing', () => {
+      const original = (globalThis as Partial<TemporalGlobal>).Temporal;
+      (globalThis as Partial<TemporalGlobal>).Temporal = undefined;
+      try {
+        expect(() => CalendarMethodsTemporal.getNow()).toThrow(
+          /@js-temporal\/polyfill|Temporal API/,
+        );
+      } finally {
+        (globalThis as Partial<TemporalGlobal>).Temporal = original;
+      }
+    });
+
+    it('isValid surfaces the polyfill guard instead of returning false', () => {
+      // Otherwise consumers in Safari / unpolyfilled Node would see "every
+      // date is invalid" without ever seeing the installation guide.
+      const original = (globalThis as Partial<TemporalGlobal>).Temporal;
+      (globalThis as Partial<TemporalGlobal>).Temporal = undefined;
+      try {
+        expect(() =>
+          CalendarMethodsTemporal.isValid('2026-05-05T12:00:00Z'),
+        ).toThrow(/@js-temporal\/polyfill|Temporal API/);
+      } finally {
+        (globalThis as Partial<TemporalGlobal>).Temporal = original;
+      }
+    });
+  });
+});

--- a/packages/core/src/calendarMethodsTemporal/index.ts
+++ b/packages/core/src/calendarMethodsTemporal/index.ts
@@ -1,0 +1,1088 @@
+/**
+ * CalendarMethodsTemporal — JS-native Temporal implementation of CalendarMethods.
+ *
+ * Wire format: ISO 8601 string (matches the moment/dayjs adapters, NOT the
+ * `Temporal.PlainDateTime#toString()` form). The internal representation is
+ * `Temporal.ZonedDateTime` in the system time zone, mirroring how dayjs/moment
+ * default to local time when reading/writing ISO strings.
+ *
+ * Locale week support: uses `Intl.Locale(locale).weekInfo` (Stage 3 / widely
+ * available) to determine the first day of week and minimal days in week 1.
+ * Falls back to the static ISO_WEEK_LOCALES set when `weekInfo` is missing
+ * from the runtime.
+ *
+ * Polyfill: this module relies on `globalThis.Temporal`. Apps that need to
+ * support Safari or Node SSR must install `@js-temporal/polyfill` and
+ * register it on `globalThis` from a Client Component (or equivalent client
+ * entry point) BEFORE this module is imported:
+ *
+ *   import { Temporal } from '@js-temporal/polyfill';
+ *   (globalThis as { Temporal?: unknown }).Temporal = Temporal;
+ *
+ * If Temporal is not present at the time any method is invoked, the call
+ * throws with the same installation guide.
+ */
+
+import range from 'lodash/range';
+import chunk from 'lodash/chunk';
+import type { Temporal as TemporalType } from '@js-temporal/polyfill';
+import { CalendarMethods as CalendarMethodsType } from '../calendar/typings';
+import { isISOWeekLocale } from '../calendar/calendar';
+import {
+  applyParseRegex,
+  buildParseRegex,
+  formatTokens,
+  ParsedFields,
+} from './tokens';
+
+type ZonedDateTime = TemporalType.ZonedDateTime;
+type PlainDate = TemporalType.PlainDate;
+
+interface TemporalGlobal {
+  Temporal: typeof TemporalType;
+}
+
+/**
+ * Resolve the active Temporal namespace. Throws a helpful installation
+ * message if the polyfill (or native API) is unavailable.
+ */
+function getTemporal(): typeof TemporalType {
+  const globalRef = globalThis as Partial<TemporalGlobal>;
+  if (!globalRef.Temporal) {
+    throw new Error(
+      '[@mezzanine-ui/core] CalendarMethodsTemporal requires the JS Temporal API. ' +
+        'Install `@js-temporal/polyfill` and register it on globalThis at your app entry, ' +
+        'BEFORE any code imports CalendarMethodsTemporal:\n' +
+        '  import { Temporal } from "@js-temporal/polyfill";\n' +
+        '  (globalThis as { Temporal?: unknown }).Temporal = Temporal;\n' +
+        'Or run on a runtime with native Temporal support ' +
+        '(Chrome 144+, Firefox 139+, Node 24+ with --harmony-temporal).',
+    );
+  }
+  return globalRef.Temporal;
+}
+
+interface WeekInfo {
+  /** ISO 1=Mon..7=Sun. */
+  firstDay: number;
+  minimalDays: number;
+  weekend: number[];
+}
+
+const weekInfoCache = new Map<string, WeekInfo>();
+
+/**
+ * Best-effort default for `minimalDays` on runtimes whose
+ * `Intl.Locale#weekInfo` exposes `firstDay`/`weekend` but not `minimalDays`
+ * (older V8 versions, Safari incomplete impls). The static
+ * `ISO_WEEK_LOCALES` set is the same source the other adapters use, so
+ * deferring to it here keeps Temporal's ISO detection consistent with
+ * dayjs/moment when the runtime is partially equipped.
+ *
+ * Variant-aware: the static set lists country variants like `de-de` and
+ * the language code `de`, but not every variant. For `de-AT` / `fr-CH`
+ * etc. we fall back to the language-only lookup so ISO inheritance is
+ * preserved when CLDR `minimalDays` is missing from the runtime.
+ */
+function defaultMinimalDays(locale: string): number {
+  if (isISOWeekLocale(locale)) return 4;
+  const language = locale.split('-')[0].toLowerCase();
+  if (
+    language &&
+    language !== locale.toLowerCase() &&
+    isISOWeekLocale(language)
+  ) {
+    return 4;
+  }
+  return 1;
+}
+
+/**
+ * Read locale week info from `Intl.Locale#weekInfo`. Falls back to the
+ * mezzanine ISO_WEEK_LOCALES set when the runtime lacks weekInfo support
+ * entirely OR when the returned object is missing `minimalDays`.
+ */
+function getWeekInfo(locale: string): WeekInfo {
+  const cached = weekInfoCache.get(locale);
+  if (cached) return cached;
+
+  let info: WeekInfo;
+  try {
+    const intlLocale = new Intl.Locale(locale) as Intl.Locale & {
+      weekInfo?: Partial<WeekInfo>;
+      getWeekInfo?: () => Partial<WeekInfo>;
+    };
+    const raw = intlLocale.weekInfo ?? intlLocale.getWeekInfo?.();
+    if (raw && typeof raw.firstDay === 'number') {
+      info = {
+        firstDay: raw.firstDay,
+        // Trust the runtime's firstDay (fresher than the static set and
+        // covers all 7 weekdays), but fall back to the static set for
+        // minimalDays so ISO locales stay classified as ISO when the
+        // runtime omits the field.
+        minimalDays:
+          typeof raw.minimalDays === 'number'
+            ? raw.minimalDays
+            : defaultMinimalDays(locale),
+        weekend: raw.weekend ?? [6, 7],
+      };
+    } else {
+      throw new Error('weekInfo unavailable');
+    }
+  } catch {
+    info = isISOWeekLocale(locale)
+      ? { firstDay: 1, minimalDays: 4, weekend: [6, 7] }
+      : { firstDay: 7, minimalDays: 1, weekend: [6, 7] };
+  }
+
+  weekInfoCache.set(locale, info);
+  return info;
+}
+
+/**
+ * Whether a locale follows ISO 8601 week rules (Monday-first AND week 1
+ * contains at least 4 days of the new year).
+ *
+ * Used as the fast-path predicate for picking Temporal's native
+ * `weekOfYear` / `yearOfWeek` (which are ISO-defined). For non-ISO Monday-
+ * first locales such as `en-AU`, `en-NZ`, `ar-AE`, `zh-CN` (firstDay=1 but
+ * minimalDays=1), the locale algorithm in `getLocaleWeekInfo` is required —
+ * Temporal's native week math would yield wrong results around year ends.
+ */
+function usesISOWeekRules(locale: string): boolean {
+  const info = getWeekInfo(locale);
+  return info.firstDay === 1 && info.minimalDays === 4;
+}
+
+const systemTimeZone = (): string =>
+  getTemporal().Now.zonedDateTimeISO().timeZoneId;
+
+/**
+ * Parse an ISO 8601 string into a ZonedDateTime in the system timezone.
+ * Accepts inputs with `Z` suffix, with offset, or naked PlainDateTime form.
+ */
+function parseISO(value: string): ZonedDateTime {
+  const Temporal = getTemporal();
+  const tz = systemTimeZone();
+
+  try {
+    return Temporal.Instant.from(value).toZonedDateTimeISO(tz);
+  } catch {
+    // Naked datetime / partial form — fall back to PlainDateTime semantics.
+  }
+
+  try {
+    return Temporal.PlainDateTime.from(value).toZonedDateTime(tz);
+  } catch {
+    return Temporal.PlainDate.from(value)
+      .toPlainDateTime(Temporal.PlainTime.from('00:00:00'))
+      .toZonedDateTime(tz);
+  }
+}
+
+/** Round-trip a ZonedDateTime back to UTC ISO string (matches dayjs/moment wire format). */
+function toISO(value: ZonedDateTime): string {
+  return value.toInstant().toString();
+}
+
+const isoDow = (zdt: ZonedDateTime): number => zdt.dayOfWeek;
+
+/**
+ * Move the given date back to the start of the week as defined by the locale.
+ * `firstDay` follows ISO numbering (1=Mon..7=Sun).
+ */
+function startOfWeekDate(date: PlainDate, firstDay: number): PlainDate {
+  const offset = (date.dayOfWeek - firstDay + 7) % 7;
+  return date.subtract({ days: offset });
+}
+
+/**
+ * Compute the locale-aware week number for a given date using the standard
+ * CLDR/ICU algorithm: week 1 of year Y is the week containing Jan `minimalDays` of Y.
+ */
+function getLocaleWeekInfo(
+  zdt: ZonedDateTime,
+  locale: string,
+): { week: number; weekYear: number } {
+  const Temporal = getTemporal();
+  const { firstDay, minimalDays } = getWeekInfo(locale);
+  const date = zdt.toPlainDate();
+  const thisWeekStart = startOfWeekDate(date, firstDay);
+
+  let year = date.year;
+
+  const week1StartFor = (y: number): PlainDate =>
+    startOfWeekDate(
+      Temporal.PlainDate.from({
+        year: y,
+        month: 1,
+        day: minimalDays,
+      }),
+      firstDay,
+    );
+
+  let week1Start = week1StartFor(year);
+
+  if (Temporal.PlainDate.compare(thisWeekStart, week1Start) < 0) {
+    year -= 1;
+    week1Start = week1StartFor(year);
+  } else {
+    const nextYearWeek1 = week1StartFor(year + 1);
+    if (Temporal.PlainDate.compare(thisWeekStart, nextYearWeek1) >= 0) {
+      year += 1;
+      week1Start = nextYearWeek1;
+    }
+  }
+
+  const daysDiff = thisWeekStart.since(week1Start, {
+    largestUnit: 'days',
+  }).days;
+  return {
+    week: Math.floor(daysDiff / 7) + 1,
+    weekYear: year,
+  };
+}
+
+/** Cached Intl formatters keyed by `${locale}|${kind}`. */
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat {
+  const key = `${locale}|${JSON.stringify(options)}`;
+  let fmt = formatterCache.get(key);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(locale, options);
+    formatterCache.set(key, fmt);
+  }
+  return fmt;
+}
+
+function intlMonthNames(locale: string, width: 'short' | 'long'): string[] {
+  // Force Gregorian — locales whose default Intl calendar is non-Gregorian
+  // (fa-IR → Persian solar Hijri, others may be Buddhist / Hijri / Japanese)
+  // would otherwise emit month names from a different calendar system while
+  // our Temporal date math is ISO/Gregorian, producing wrong labels.
+  const fmt = getFormatter(locale, { month: width, calendar: 'gregory' });
+  return range(0, 12).map((m) => {
+    const date = new Date(Date.UTC(2024, m, 15));
+    return fmt.format(date);
+  });
+}
+
+function intlWeekdayNames(
+  locale: string,
+  width: 'short' | 'long' | 'narrow',
+): string[] {
+  // 2024-01-07 is Sunday; subsequent days run through Saturday.
+  const fmt = getFormatter(locale, {
+    weekday: width,
+    timeZone: 'UTC',
+    calendar: 'gregory',
+  });
+  return range(0, 7).map((d) => {
+    const date = new Date(Date.UTC(2024, 0, 7 + d));
+    return fmt.format(date);
+  });
+}
+
+function startOf(zdt: ZonedDateTime, granularity: string): ZonedDateTime {
+  const lower = granularity.toLowerCase();
+
+  if (lower === 'year' || lower === 'years' || lower === 'y') {
+    return zdt.with({
+      month: 1,
+      day: 1,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  if (lower === 'month' || lower === 'months') {
+    return zdt.with({
+      day: 1,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  if (lower === 'quarter' || lower === 'quarters' || lower === 'q') {
+    const quarterStartMonth = Math.floor((zdt.month - 1) / 3) * 3 + 1;
+    return zdt.with({
+      month: quarterStartMonth,
+      day: 1,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  if (
+    lower === 'week' ||
+    lower === 'weeks' ||
+    lower === 'isoweek' ||
+    lower === 'isoweeks'
+  ) {
+    // Match dayjs/moment defaults when no locale is in scope:
+    //   `isoWeek` → always Monday-first (firstDay = 1)
+    //   `week`    → Sunday-first by default (firstDay = 7)
+    // Locale-aware week bucketing happens through getCurrentWeekFirstDate,
+    // which is the path mezzanine components actually use.
+    const isoWeekMode = lower.startsWith('isoweek');
+    const firstDay = isoWeekMode ? 1 : 7;
+    const offset = (zdt.dayOfWeek - firstDay + 7) % 7;
+    return zdt.subtract({ days: offset }).with({
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  if (
+    lower === 'day' ||
+    lower === 'days' ||
+    lower === 'd' ||
+    lower === 'date'
+  ) {
+    return zdt.with({
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  if (lower === 'hour' || lower === 'hours' || lower === 'h') {
+    return zdt.with({
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  if (lower === 'minute' || lower === 'minutes') {
+    return zdt.with({
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  if (lower === 'second' || lower === 'seconds' || lower === 's') {
+    return zdt.with({
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 0,
+    });
+  }
+  // Unknown granularity — return as-is (matches dayjs/moment behavior).
+  return zdt;
+}
+
+function dayOfYear(zdt: ZonedDateTime): number {
+  return zdt.dayOfYear;
+}
+
+const CalendarMethodsTemporal: CalendarMethodsType = {
+  getFirstDayOfWeek: (locale) => {
+    const fd = getWeekInfo(locale).firstDay;
+    // ISO 1..7 → mezzanine 0..6 (0=Sun, 1=Mon ..)
+    return fd === 7 ? 0 : fd;
+  },
+  // Note: this differs from the global `isISOWeekLocale` (a static set in
+  // calendar/calendar.ts shared with the dayjs/moment adapters). The static
+  // set can disagree with CLDR `weekInfo` (e.g. it lists ar-SA as ISO, but
+  // ar-SA is Sunday-first per CLDR). Inside the Temporal adapter, this
+  // method reflects the same source of truth used everywhere else.
+  isISOWeekLocale: usesISOWeekRules,
+
+  getNow: () => toISO(getTemporal().Now.zonedDateTimeISO()),
+  getSecond: (date) => parseISO(date).second,
+  getMinute: (date) => parseISO(date).minute,
+  getHour: (date) => parseISO(date).hour,
+  getDate: (date) => parseISO(date).day,
+  getWeek: (date, locale) => {
+    if (usesISOWeekRules(locale)) {
+      return parseISO(date).weekOfYear ?? 1;
+    }
+    return getLocaleWeekInfo(parseISO(date), locale).week;
+  },
+  getWeekYear: (date, locale) => {
+    if (usesISOWeekRules(locale)) {
+      return parseISO(date).yearOfWeek ?? parseISO(date).year;
+    }
+    return getLocaleWeekInfo(parseISO(date), locale).weekYear;
+  },
+  getWeekDay: (date) => {
+    const dow = isoDow(parseISO(date));
+    return dow === 7 ? 0 : dow;
+  },
+  getMonth: (date) => parseISO(date).month - 1,
+  getYear: (date) => parseISO(date).year,
+  getQuarter: (date) => Math.floor((parseISO(date).month - 1) / 3) + 1,
+  getHalfYear: (date) => Math.floor((parseISO(date).month - 1) / 6) + 1,
+  getWeekDayNames: (locale) => {
+    // Intl returns Sunday-indexed names. Rotate left by `firstDay % 7` so the
+    // array is ordered starting from the locale's first-day-of-week.
+    const sundayIndexed = intlWeekdayNames(locale, 'narrow');
+    const offset = getWeekInfo(locale).firstDay % 7;
+    return [...sundayIndexed.slice(offset), ...sundayIndexed.slice(0, offset)];
+  },
+  getMonthShortName: (month, locale) => {
+    return intlMonthNames(locale, 'short')[month];
+  },
+  getMonthShortNames: (locale) => intlMonthNames(locale, 'short'),
+  getWeekends: (locale) => {
+    // weekInfo.weekend lists the weekend days using ISO numbering (1=Mon..7=Sun).
+    // Project that set onto the locale's first-day-rotated week positions.
+    const { firstDay, weekend } = getWeekInfo(locale);
+    const weekendSet = new Set(weekend);
+    const result: boolean[] = [];
+    for (let p = 0; p < 7; p += 1) {
+      const isoDay = ((p + firstDay - 1) % 7) + 1;
+      result.push(weekendSet.has(isoDay));
+    }
+    return result;
+  },
+
+  addHour: (date, diff) => toISO(parseISO(date).add({ hours: diff })),
+  addMinute: (date, diff) => toISO(parseISO(date).add({ minutes: diff })),
+  addSecond: (date, diff) => toISO(parseISO(date).add({ seconds: diff })),
+  addDay: (date, diff) => toISO(parseISO(date).add({ days: diff })),
+  addYear: (date, diff) => toISO(parseISO(date).add({ years: diff })),
+  addMonth: (date, diff) => toISO(parseISO(date).add({ months: diff })),
+  setMillisecond: (date, millisecond) =>
+    toISO(parseISO(date).with({ millisecond })),
+  setSecond: (date, second) => toISO(parseISO(date).with({ second })),
+  setMinute: (date, minute) => toISO(parseISO(date).with({ minute })),
+  setHour: (date, hour) => toISO(parseISO(date).with({ hour })),
+  // Out-of-range setters: moment/dayjs normalize values like `setMonth(d, -1)`
+  // (→ previous year's December) or `setDate(d, 0)` (→ last day of previous
+  // month). Temporal's `with()` rejects month=0 and clamps day overflow, so
+  // we route through `add()` to preserve cross-boundary semantics.
+  setMonth: (date, month) => {
+    const current = parseISO(date);
+    return toISO(current.add({ months: month - (current.month - 1) }));
+  },
+  setYear: (date, year) => {
+    const current = parseISO(date);
+    return toISO(current.add({ years: year - current.year }));
+  },
+  setDate: (date, target) => {
+    const current = parseISO(date);
+    return toISO(current.add({ days: target - current.day }));
+  },
+  startOf: (target, granularity) =>
+    toISO(startOf(parseISO(target), String(granularity))),
+
+  getCurrentWeekFirstDate: (value, locale) => {
+    const zdt = parseISO(value);
+    const { firstDay } = getWeekInfo(locale);
+    const offset = (zdt.dayOfWeek - firstDay + 7) % 7;
+    return toISO(
+      zdt.subtract({ days: offset }).with({
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        microsecond: 0,
+        nanosecond: 0,
+      }),
+    );
+  },
+  getCurrentMonthFirstDate: (value) =>
+    toISO(
+      parseISO(value).with({
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        microsecond: 0,
+        nanosecond: 0,
+      }),
+    ),
+  getCurrentYearFirstDate: (value) =>
+    toISO(
+      parseISO(value).with({
+        month: 1,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        microsecond: 0,
+        nanosecond: 0,
+      }),
+    ),
+  getCurrentQuarterFirstDate: (value) => {
+    const zdt = parseISO(value);
+    const quarterStartMonth = Math.floor((zdt.month - 1) / 3) * 3 + 1;
+    return toISO(
+      zdt.with({
+        month: quarterStartMonth,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        microsecond: 0,
+        nanosecond: 0,
+      }),
+    );
+  },
+  getCurrentHalfYearFirstDate: (value) => {
+    const zdt = parseISO(value);
+    const halfYearStartMonth = Math.floor((zdt.month - 1) / 6) * 6 + 1;
+    return toISO(
+      zdt.with({
+        month: halfYearStartMonth,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        microsecond: 0,
+        nanosecond: 0,
+      }),
+    );
+  },
+
+  getCalendarGrid: (target, locale) => {
+    const Temporal = getTemporal();
+    const zdt = parseISO(target);
+    const { firstDay } = getWeekInfo(locale);
+
+    const firstOfMonth = zdt.with({ day: 1 });
+    const firstDayWeekdayIso = firstOfMonth.dayOfWeek; // 1..7
+
+    const lastDateOfPrevMonth = firstOfMonth.subtract({ days: 1 }).day;
+    const lastDateOfCurrentMonth = Temporal.PlainYearMonth.from({
+      year: zdt.year,
+      month: zdt.month,
+    }).daysInMonth;
+
+    // How many cells from the previous month appear before day-1: the offset
+    // between the first day of the month and the locale's first-day-of-week.
+    const daysFromPrevMonth = (firstDayWeekdayIso - firstDay + 7) % 7;
+
+    const totalDaysInGrid = 42;
+    const daysFromNextMonth =
+      totalDaysInGrid - daysFromPrevMonth - lastDateOfCurrentMonth;
+
+    return chunk(
+      [
+        ...range(
+          lastDateOfPrevMonth - daysFromPrevMonth + 1,
+          lastDateOfPrevMonth + 1,
+        ),
+        ...range(1, lastDateOfCurrentMonth + 1),
+        ...range(1, daysFromNextMonth + 1),
+      ],
+      7,
+    );
+  },
+
+  isValid: (date) => {
+    // Trigger the polyfill guard up-front: a missing Temporal API is an
+    // environmental error that callers must see, not a "this date string
+    // is invalid" answer. Only the actual parsing step is wrapped.
+    getTemporal();
+    try {
+      parseISO(date);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  isBefore: (target, comparison) => {
+    const Temporal = getTemporal();
+    return (
+      Temporal.ZonedDateTime.compare(parseISO(target), parseISO(comparison)) < 0
+    );
+  },
+  isBetween: (value, target1, target2, granularity) => {
+    const Temporal = getTemporal();
+    const a = parseISO(target1);
+    const b = parseISO(target2);
+    const v = parseISO(value);
+
+    // Truncate to the requested granularity so that values within the same
+    // bucket compare equal (e.g. `'day'` ignores time-of-day differences).
+    // Default granularity matches dayjs/moment default of `'milliseconds'`,
+    // which is effectively no truncation.
+    const granularityKey =
+      typeof granularity === 'string' && granularity.length > 0
+        ? granularity
+        : 'milliseconds';
+    const aT = startOf(a, granularityKey);
+    const bT = startOf(b, granularityKey);
+    const vT = startOf(v, granularityKey);
+
+    const lo = Temporal.ZonedDateTime.compare(aT, bT) <= 0 ? aT : bT;
+    const hi = Temporal.ZonedDateTime.compare(aT, bT) <= 0 ? bT : aT;
+
+    // Match dayjs/moment default inclusivity `'()'` — both bounds exclusive.
+    return (
+      Temporal.ZonedDateTime.compare(vT, lo) > 0 &&
+      Temporal.ZonedDateTime.compare(vT, hi) < 0
+    );
+  },
+  isSameDate: (dateOne, dateTwo) => {
+    const a = parseISO(dateOne);
+    const b = parseISO(dateTwo);
+    return a.year === b.year && a.month === b.month && a.day === b.day;
+  },
+  isSameWeek: (dateOne, dateTwo, locale) => {
+    if (usesISOWeekRules(locale)) {
+      const a = parseISO(dateOne);
+      const b = parseISO(dateTwo);
+      return (
+        (a.yearOfWeek ?? a.year) === (b.yearOfWeek ?? b.year) &&
+        (a.weekOfYear ?? 1) === (b.weekOfYear ?? 1)
+      );
+    }
+    const a = getLocaleWeekInfo(parseISO(dateOne), locale);
+    const b = getLocaleWeekInfo(parseISO(dateTwo), locale);
+    return a.week === b.week && a.weekYear === b.weekYear;
+  },
+  isInMonth: (target, month) => parseISO(target).month === month + 1,
+  isDateIncluded: (date, targets) =>
+    targets.some((target) => CalendarMethodsTemporal.isSameDate(date, target)),
+  isWeekIncluded: (firstDateOfWeek, targets, locale) =>
+    targets.some((target) =>
+      CalendarMethodsTemporal.isSameWeek(firstDateOfWeek, target, locale),
+    ),
+  isMonthIncluded: (date, targets) => {
+    const a = parseISO(date);
+    return targets.some((target) => {
+      const t = parseISO(target);
+      return a.year === t.year && a.month === t.month;
+    });
+  },
+  isYearIncluded: (date, targets) => {
+    const y = parseISO(date).year;
+    return targets.some((target) => parseISO(target).year === y);
+  },
+  isQuarterIncluded: (date, targets) => {
+    const a = parseISO(date);
+    const q = Math.floor((a.month - 1) / 3);
+    return targets.some((target) => {
+      const t = parseISO(target);
+      return t.year === a.year && Math.floor((t.month - 1) / 3) === q;
+    });
+  },
+  isHalfYearIncluded: (date, targets) => {
+    const a = parseISO(date);
+    const h = Math.floor((a.month - 1) / 6);
+    return targets.some((target) => {
+      const t = parseISO(target);
+      return t.year === a.year && Math.floor((t.month - 1) / 6) === h;
+    });
+  },
+
+  formatToString: (locale, date, format) => {
+    const isoInput =
+      typeof date === 'string' ? date : (date as unknown as Date).toISOString();
+    const zdt = parseISO(isoInput);
+    const isoWeek = zdt.weekOfYear ?? 1;
+    const isoWeekYear = zdt.yearOfWeek ?? zdt.year;
+    const localeInfo = usesISOWeekRules(locale)
+      ? { week: isoWeek, weekYear: isoWeekYear }
+      : getLocaleWeekInfo(zdt, locale);
+    const monthShorts = intlMonthNames(locale, 'short');
+    const monthLongs = intlMonthNames(locale, 'long');
+    const weekdayShorts = intlWeekdayNames(locale, 'short');
+    const weekdayLongs = intlWeekdayNames(locale, 'long');
+    const weekdayNarrows = intlWeekdayNames(locale, 'narrow');
+    const sundayIndex = zdt.dayOfWeek === 7 ? 0 : zdt.dayOfWeek;
+
+    const { firstDay } = getWeekInfo(locale);
+    const localeWeekDay = (zdt.dayOfWeek - firstDay + 7) % 7;
+
+    return formatTokens(format, {
+      year: zdt.year,
+      month: zdt.month,
+      day: zdt.day,
+      hour: zdt.hour,
+      minute: zdt.minute,
+      second: zdt.second,
+      millisecond: zdt.millisecond,
+      dayOfWeek: zdt.dayOfWeek,
+      localeWeekDay,
+      isoWeek,
+      isoWeekYear,
+      localeWeek: localeInfo.week,
+      localeWeekYear: localeInfo.weekYear,
+      quarter: Math.floor((zdt.month - 1) / 3) + 1,
+      halfYear: zdt.month <= 6 ? 1 : 2,
+      monthShort: monthShorts[zdt.month - 1],
+      monthLong: monthLongs[zdt.month - 1],
+      weekdayShort: weekdayShorts[sundayIndex],
+      weekdayLong: weekdayLongs[sundayIndex],
+      weekdayNarrow: weekdayNarrows[sundayIndex],
+      dayOfYear: dayOfYear(zdt),
+      unixMs: Number(zdt.epochMilliseconds),
+    });
+  },
+  formatToISOString: (date) => toISO(parseISO(date)),
+
+  parseFormattedValue: (text, format, locale) => {
+    const Temporal = getTemporal();
+    const localeNames = {
+      monthShort: intlMonthNames(locale, 'short'),
+      monthLong: intlMonthNames(locale, 'long'),
+      weekdayShort: intlWeekdayNames(locale, 'short'),
+      weekdayLong: intlWeekdayNames(locale, 'long'),
+      weekdayNarrow: intlWeekdayNames(locale, 'narrow'),
+    };
+    const { regex, captures, tokens } = buildParseRegex(format, localeNames);
+    const fields = applyParseRegex(text, regex, captures, localeNames);
+    if (!fields) return undefined;
+
+    if (!validateFields(fields, tokens)) return undefined;
+
+    // If a token was present but couldn't be parsed (e.g. half-year out of range),
+    // treat the whole parse as failed instead of silently dropping the field.
+    if (tokens.has('[H]n') && fields.halfYear === undefined) return undefined;
+    if (tokens.has('Q') && fields.quarter === undefined) return undefined;
+
+    const tz = systemTimeZone();
+    // ISO mode is determined by the *weekYear* token (GGGG), not the week
+    // number tokens. Mixed formats like `YYYY-WW` (calendar year + ISO week)
+    // would otherwise enable isoMode but lack `fields.isoWeekYear`, silently
+    // dropping the parsed week number and falling through to the year-only
+    // branch.
+    const isoMode = tokens.has('GGGG');
+    const localeMode =
+      tokens.has('gggg') || tokens.has('ww') || tokens.has('w');
+    const hasYear = fields.year !== undefined;
+    const hasMonth = fields.month !== undefined;
+    const hasDay = fields.day !== undefined;
+    const hasQuarter = fields.quarter !== undefined;
+    const hasHalfYear = fields.halfYear !== undefined;
+    const hasWeek =
+      isoMode ||
+      localeMode ||
+      fields.localeWeek !== undefined ||
+      fields.isoWeek !== undefined;
+    const hasUnixMs = fields.unixMs !== undefined;
+    const hasDayOfYear = fields.dayOfYear !== undefined;
+
+    // Unix epoch — standalone enough to derive a full datetime regardless
+    // of whether other date tokens were present in the format.
+    if (hasUnixMs) {
+      try {
+        return Temporal.Instant.fromEpochMilliseconds(
+          fields.unixMs as number,
+        ).toString();
+      } catch {
+        return undefined;
+      }
+    }
+
+    // Day-of-year + year — derive the date by adding (doy-1) days to Jan 1.
+    if (hasDayOfYear && hasYear && !hasMonth && !hasDay) {
+      const year = fields.year as number;
+      const doy = fields.dayOfYear as number;
+      const jan1 = Temporal.PlainDate.from({ year, month: 1, day: 1 });
+      const daysInYear = Temporal.PlainDate.from({
+        year: year + 1,
+        month: 1,
+        day: 1,
+      }).since(jan1, { largestUnit: 'days' }).days;
+      if (doy < 1 || doy > daysInYear) return undefined;
+      return toISO(
+        jan1
+          .add({ days: doy - 1 })
+          .toPlainDateTime(Temporal.PlainTime.from('00:00:00'))
+          .toZonedDateTime(tz),
+      );
+    }
+
+    // Half-year: re-route to quarter-based normalization.
+    if (hasHalfYear && hasYear && !hasMonth && !hasDay) {
+      const quarter = fields.halfYear === 1 ? 1 : 3;
+      return CalendarMethodsTemporal.getCurrentQuarterFirstDate(
+        toISO(
+          Temporal.PlainDateTime.from({
+            year: fields.year as number,
+            month: (quarter - 1) * 3 + 1,
+            day: 1,
+          }).toZonedDateTime(tz),
+        ),
+      );
+    }
+
+    // Week format
+    if (hasWeek && (isoMode ? fields.isoWeekYear : fields.localeWeekYear)) {
+      const weekYear = (
+        isoMode ? fields.isoWeekYear : fields.localeWeekYear
+      ) as number;
+      const weekNum = isoMode ? fields.isoWeek : fields.localeWeek;
+      // Reject when the weekYear token was present but the week-number
+      // token was missing or unparsed. Otherwise a `gggg`-only or `GGGG`-only
+      // format would propagate `undefined` into Temporal's `add({days:NaN})`
+      // and throw RangeError instead of returning undefined per contract.
+      if (weekNum === undefined || weekNum < 1) return undefined;
+
+      const { firstDay, minimalDays } = isoMode
+        ? { firstDay: 1, minimalDays: 4 }
+        : getWeekInfo(locale);
+
+      // Compute the actual max-week of `weekYear` instead of trusting the
+      // hard-coded ceiling of 53. Dec 28 always falls into the LAST week of
+      // its weekYear under ISO/CLDR rules, so its weekOfYear gives the max.
+      const maxWeeks = computeMaxWeeksOfYear(
+        weekYear,
+        firstDay,
+        minimalDays,
+        isoMode,
+      );
+      if (weekNum > maxWeeks) return undefined;
+
+      // Anchor: week 1 contains Jan minimalDays (or Jan 4 for ISO).
+      const anchor = Temporal.PlainDate.from({
+        year: weekYear,
+        month: 1,
+        day: minimalDays,
+      });
+      const week1Start = startOfWeekDate(anchor, firstDay);
+      const target = week1Start.add({ days: (weekNum - 1) * 7 });
+      return toISO(
+        target
+          .toPlainDateTime(Temporal.PlainTime.from('00:00:00'))
+          .toZonedDateTime(tz),
+      );
+    }
+
+    // Quarter format
+    if (hasQuarter && hasYear && !hasMonth && !hasDay) {
+      const quarter = fields.quarter as number;
+      if (quarter < 1 || quarter > 4) return undefined;
+      return toISO(
+        Temporal.PlainDateTime.from({
+          year: fields.year as number,
+          month: (quarter - 1) * 3 + 1,
+          day: 1,
+        }).toZonedDateTime(tz),
+      );
+    }
+
+    // Month-only — first of month.
+    if (hasYear && hasMonth && !hasDay && !hasWeek && !hasQuarter) {
+      const month = fields.month as number;
+      if (month < 1 || month > 12) return undefined;
+      return toISO(
+        Temporal.PlainDateTime.from({
+          year: fields.year as number,
+          month,
+          day: 1,
+        }).toZonedDateTime(tz),
+      );
+    }
+
+    // Year-only — first of year.
+    if (hasYear && !hasMonth && !hasDay && !hasWeek && !hasQuarter) {
+      return toISO(
+        Temporal.PlainDateTime.from({
+          year: fields.year as number,
+          month: 1,
+          day: 1,
+        }).toZonedDateTime(tz),
+      );
+    }
+
+    // Full date (with optional time).
+    if (hasYear && hasMonth && hasDay) {
+      const month = fields.month as number;
+      const day = fields.day as number;
+      if (month < 1 || month > 12) return undefined;
+      if (day < 1 || day > 31) return undefined;
+
+      const hour = resolveHour(fields);
+      try {
+        return toISO(
+          Temporal.PlainDateTime.from(
+            {
+              year: fields.year as number,
+              month,
+              day,
+              hour,
+              minute: fields.minute ?? 0,
+              second: fields.second ?? 0,
+              millisecond: fields.millisecond ?? 0,
+            },
+            { overflow: 'reject' },
+          ).toZonedDateTime(tz),
+        );
+      } catch {
+        return undefined;
+      }
+    }
+
+    // Time-only (HH:mm, HH:mm:ss, hh:mm A, …) — anchor to today's date.
+    // Used by TimePicker / TimeRangePicker, which round-trip values through
+    // `parseFormattedValue` with formats that contain no date tokens.
+    const hasTime =
+      fields.hour !== undefined ||
+      fields.hour12 !== undefined ||
+      fields.minute !== undefined ||
+      fields.second !== undefined ||
+      fields.millisecond !== undefined;
+    if (
+      hasTime &&
+      !hasYear &&
+      !hasMonth &&
+      !hasDay &&
+      !hasWeek &&
+      !hasQuarter &&
+      !hasHalfYear
+    ) {
+      const hour = resolveHour(fields);
+      const today = Temporal.Now.zonedDateTimeISO(tz);
+      try {
+        return toISO(
+          today.with({
+            hour,
+            minute: fields.minute ?? 0,
+            second: fields.second ?? 0,
+            millisecond: fields.millisecond ?? 0,
+            microsecond: 0,
+            nanosecond: 0,
+          }),
+        );
+      } catch {
+        return undefined;
+      }
+    }
+
+    return undefined;
+  },
+};
+
+function resolveHour(fields: ParsedFields): number {
+  if (fields.hour12 !== undefined) {
+    const base = fields.hour12 % 12;
+    return (fields.meridiem ?? 'am') === 'pm' ? base + 12 : base;
+  }
+  return fields.hour ?? 0;
+}
+
+/**
+ * Compute the actual maximum week number of `weekYear` for the supplied
+ * locale week rule.
+ *
+ * For ISO 8601 (minimalDays=4), Dec 28 is guaranteed to fall in the last
+ * week of its own weekYear, so Temporal's native `weekOfYear` is correct.
+ *
+ * For other locale rules (e.g. minimalDays=1 in en-US), Dec 28 may already
+ * belong to the NEXT weekYear (en-US 2025-12-28 → 2026-W01). Instead we
+ * derive the last day of `weekYear` as `week1StartFor(weekYear + 1) - 1`,
+ * then count how many weeks elapse between `week1Start` of `weekYear` and
+ * that last day's week start.
+ */
+function computeMaxWeeksOfYear(
+  weekYear: number,
+  firstDay: number,
+  minimalDays: number,
+  isoMode: boolean,
+): number {
+  const Temporal = getTemporal();
+
+  if (isoMode) {
+    return (
+      Temporal.PlainDate.from({
+        year: weekYear,
+        month: 12,
+        day: 28,
+      }).weekOfYear ?? 52
+    );
+  }
+
+  const week1Start = startOfWeekDate(
+    Temporal.PlainDate.from({
+      year: weekYear,
+      month: 1,
+      day: minimalDays,
+    }),
+    firstDay,
+  );
+  const nextYearWeek1Start = startOfWeekDate(
+    Temporal.PlainDate.from({
+      year: weekYear + 1,
+      month: 1,
+      day: minimalDays,
+    }),
+    firstDay,
+  );
+  // The last day belonging to `weekYear` sits one day before next year's
+  // week 1. Count the week-buckets between week 1 of `weekYear` and the
+  // bucket containing that last day.
+  const lastDayOfWeekYear = nextYearWeek1Start.subtract({ days: 1 });
+  const lastDayWeekStart = startOfWeekDate(lastDayOfWeekYear, firstDay);
+  const daysDiff = lastDayWeekStart.since(week1Start, {
+    largestUnit: 'days',
+  }).days;
+  return Math.floor(daysDiff / 7) + 1;
+}
+
+function validateFields(fields: ParsedFields, tokens: Set<string>): boolean {
+  if (fields.month !== undefined && (fields.month < 1 || fields.month > 12)) {
+    return false;
+  }
+  if (fields.day !== undefined && (fields.day < 1 || fields.day > 31)) {
+    return false;
+  }
+  if (fields.hour !== undefined && (fields.hour < 0 || fields.hour > 23)) {
+    return false;
+  }
+  if (
+    fields.hour12 !== undefined &&
+    (fields.hour12 < 1 || fields.hour12 > 12)
+  ) {
+    return false;
+  }
+  if (
+    fields.minute !== undefined &&
+    (fields.minute < 0 || fields.minute > 59)
+  ) {
+    return false;
+  }
+  if (
+    fields.second !== undefined &&
+    (fields.second < 0 || fields.second > 59)
+  ) {
+    return false;
+  }
+  if (
+    fields.quarter !== undefined &&
+    (fields.quarter < 1 || fields.quarter > 4)
+  ) {
+    return false;
+  }
+  if (
+    fields.halfYear !== undefined &&
+    fields.halfYear !== 1 &&
+    fields.halfYear !== 2
+  ) {
+    return false;
+  }
+  void tokens;
+  return true;
+}
+
+export default CalendarMethodsTemporal;

--- a/packages/core/src/calendarMethodsTemporal/tokens.ts
+++ b/packages/core/src/calendarMethodsTemporal/tokens.ts
@@ -1,0 +1,604 @@
+/**
+ * Token translation helpers for the Temporal-based CalendarMethods.
+ *
+ * The other adapters (dayjs/moment/luxon) inherit moment's format token syntax
+ * (YYYY/MM/DD/HH/mm/ss/Q/[H]n/gggg/GGGG/ww/WW/...). Temporal has no such API,
+ * so we tokenize the format string manually and translate to either:
+ *  1. A formatted output string (formatTokens), or
+ *  2. A regex with field captures for parsing (buildParseRegex).
+ */
+
+const pad = (value: number, length = 2): string =>
+  String(Math.abs(value)).padStart(length, '0');
+
+const TOKEN_PATTERN =
+  'YYYY|YY|Y|MMMM|MMM|MM|M|DDDD|DDD|DD|Do|D|dddd|ddd|dd|d|e|HH|H|hh|h|kk|k|mm|m|ss|s|SSS|SS|S|A|a|Q|gggg|GGGG|ww|WW|w|W|x|X';
+
+const TOKEN_REGEX = new RegExp(TOKEN_PATTERN, 'g');
+
+export interface FormatContext {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  millisecond: number;
+  /** ISO day of week (1=Mon..7=Sun). */
+  dayOfWeek: number;
+  /**
+   * Locale-relative day of week (0=locale firstDay..6). Used by the moment
+   * `e` token. For Sunday-first locales this equals `dayOfWeek === 7 ? 0 : dayOfWeek`;
+   * for Monday-first it shifts so Monday=0; for Saturday-first Saturday=0.
+   */
+  localeWeekDay: number;
+  isoWeek: number;
+  isoWeekYear: number;
+  localeWeek: number;
+  localeWeekYear: number;
+  quarter: number;
+  halfYear: 1 | 2;
+  monthShort: string;
+  monthLong: string;
+  weekdayShort: string;
+  weekdayLong: string;
+  weekdayNarrow: string;
+  dayOfYear: number;
+  unixMs: number;
+}
+
+interface Segment {
+  literal?: string;
+  token?: string;
+}
+
+function tokenize(format: string): Segment[] {
+  const segments: Segment[] = [];
+  let cursor = 0;
+
+  while (cursor < format.length) {
+    if (format[cursor] === '[') {
+      const end = format.indexOf(']', cursor);
+      if (end === -1) {
+        segments.push({ literal: format.slice(cursor) });
+        return segments;
+      }
+      segments.push({ literal: format.slice(cursor + 1, end) });
+      cursor = end + 1;
+      continue;
+    }
+
+    TOKEN_REGEX.lastIndex = cursor;
+    const match = TOKEN_REGEX.exec(format);
+    if (match && match.index === cursor) {
+      segments.push({ token: match[0] });
+      cursor += match[0].length;
+      continue;
+    }
+
+    const nextSpecial = findNextSpecial(format, cursor);
+    segments.push({ literal: format.slice(cursor, nextSpecial) });
+    cursor = nextSpecial;
+  }
+
+  return segments;
+}
+
+function findNextSpecial(format: string, from: number): number {
+  for (let i = from; i < format.length; i += 1) {
+    if (format[i] === '[') return i;
+    TOKEN_REGEX.lastIndex = i;
+    const m = TOKEN_REGEX.exec(format);
+    if (m && m.index === i) return i;
+  }
+  return format.length;
+}
+
+function preprocessHalfYear(format: string, halfYear: 1 | 2): string {
+  if (!format.includes('[H]n')) return format;
+  return format.replace('[H]n', `[H${halfYear}]`);
+}
+
+const hour12 = (hour: number): number => {
+  const mod = hour % 12;
+  return mod === 0 ? 12 : mod;
+};
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+}
+
+export function formatTokens(format: string, ctx: FormatContext): string {
+  const normalized = preprocessHalfYear(format, ctx.halfYear);
+  const segments = tokenize(normalized);
+
+  return segments
+    .map((segment) => {
+      if (segment.literal !== undefined) return segment.literal;
+      const token = segment.token as string;
+
+      switch (token) {
+        case 'YYYY':
+          return pad(ctx.year, 4);
+        case 'YY':
+          return pad(ctx.year % 100, 2);
+        case 'Y':
+          return String(ctx.year);
+        case 'MMMM':
+          return ctx.monthLong;
+        case 'MMM':
+          return ctx.monthShort;
+        case 'MM':
+          return pad(ctx.month);
+        case 'M':
+          return String(ctx.month);
+        case 'DDDD':
+          return pad(ctx.dayOfYear, 3);
+        case 'DDD':
+          return String(ctx.dayOfYear);
+        case 'DD':
+          return pad(ctx.day);
+        case 'Do':
+          return ordinal(ctx.day);
+        case 'D':
+          return String(ctx.day);
+        case 'dddd':
+          return ctx.weekdayLong;
+        case 'ddd':
+          return ctx.weekdayShort;
+        case 'dd':
+          return ctx.weekdayNarrow;
+        case 'd':
+          // moment `d`: ISO Sunday-indexed (Sun=0..Sat=6).
+          return String(ctx.dayOfWeek === 7 ? 0 : ctx.dayOfWeek);
+        case 'e':
+          // moment `e`: locale-relative (firstDay=0..6).
+          return String(ctx.localeWeekDay);
+        case 'HH':
+          return pad(ctx.hour);
+        case 'H':
+          return String(ctx.hour);
+        case 'hh':
+          return pad(hour12(ctx.hour));
+        case 'h':
+          return String(hour12(ctx.hour));
+        case 'kk':
+          return pad(ctx.hour === 0 ? 24 : ctx.hour);
+        case 'k':
+          return String(ctx.hour === 0 ? 24 : ctx.hour);
+        case 'mm':
+          return pad(ctx.minute);
+        case 'm':
+          return String(ctx.minute);
+        case 'ss':
+          return pad(ctx.second);
+        case 's':
+          return String(ctx.second);
+        case 'SSS':
+          return pad(ctx.millisecond, 3);
+        case 'SS':
+          return pad(Math.floor(ctx.millisecond / 10), 2);
+        case 'S':
+          return String(Math.floor(ctx.millisecond / 100));
+        case 'A':
+          return ctx.hour < 12 ? 'AM' : 'PM';
+        case 'a':
+          return ctx.hour < 12 ? 'am' : 'pm';
+        case 'Q':
+          return String(ctx.quarter);
+        case 'gggg':
+          return pad(ctx.localeWeekYear, 4);
+        case 'GGGG':
+          return pad(ctx.isoWeekYear, 4);
+        case 'ww':
+          return pad(ctx.localeWeek);
+        case 'WW':
+          return pad(ctx.isoWeek);
+        case 'w':
+          return String(ctx.localeWeek);
+        case 'W':
+          return String(ctx.isoWeek);
+        case 'x':
+          return String(ctx.unixMs);
+        case 'X':
+          return String(Math.floor(ctx.unixMs / 1000));
+        default:
+          return token;
+      }
+    })
+    .join('');
+}
+
+export type ParseFieldKey =
+  | 'year'
+  | 'month'
+  | 'day'
+  | 'hour'
+  | 'hour12'
+  | 'minute'
+  | 'second'
+  | 'millisecond'
+  | 'isoWeek'
+  | 'isoWeekYear'
+  | 'localeWeek'
+  | 'localeWeekYear'
+  | 'quarter'
+  | 'halfYear'
+  | 'meridiem-upper'
+  | 'meridiem-lower'
+  /** Captured short month name; resolved against `LocaleNames.monthShort`. */
+  | 'month-short'
+  /** Captured long month name; resolved against `LocaleNames.monthLong`. */
+  | 'month-long'
+  /** `Do` ordinal — captured digit only, suffix consumed by regex. */
+  | 'day-ordinal'
+  /** `S` token — 1-digit centiseconds; multiply by 100 → millisecond. */
+  | 'fractional-1'
+  /** `SS` token — 2-digit deciseconds; multiply by 10 → millisecond. */
+  | 'fractional-2'
+  /**
+   * `k` / `kk` — 1-24 hour clock used by some locales. The digit 24
+   * represents midnight (= hour 0); other values map straight to `hour`.
+   */
+  | 'hour-1to24'
+  /** `DDD` / `DDDD` — day of year (1-366); resolved with `year` to a date. */
+  | 'day-of-year'
+  /** `x` — Unix epoch milliseconds; standalone enough to derive full datetime. */
+  | 'unix-ms'
+  /** `X` — Unix epoch seconds; standalone enough to derive full datetime. */
+  | 'unix-s'
+  /** Weekday tokens / `d` / `e` are consumed but discarded (redundant). */
+  | 'skip';
+
+/**
+ * Locale-aware name tables consumed by `buildParseRegex`. Each array is
+ * pre-computed by the caller so that `tokens.ts` stays free of `Intl.*` use.
+ */
+export interface LocaleNames {
+  /** 12 entries, January..December — short form ("Jan"). */
+  monthShort: string[];
+  /** 12 entries, January..December — long form ("January"). */
+  monthLong: string[];
+  /** 7 entries, Sunday-indexed — short form ("Mon"). */
+  weekdayShort: string[];
+  /** 7 entries, Sunday-indexed — long form ("Monday"). */
+  weekdayLong: string[];
+  /** 7 entries, Sunday-indexed — narrow form ("M"). */
+  weekdayNarrow: string[];
+}
+
+export interface ParsedFields {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  hour12?: number;
+  minute?: number;
+  second?: number;
+  millisecond?: number;
+  isoWeek?: number;
+  isoWeekYear?: number;
+  localeWeek?: number;
+  localeWeekYear?: number;
+  quarter?: number;
+  halfYear?: 1 | 2;
+  meridiem?: 'am' | 'pm';
+  dayOfYear?: number;
+  unixMs?: number;
+}
+
+const HALF_YEAR_SENTINEL = '\x00HALFYEAR\x00';
+
+export function buildParseRegex(
+  format: string,
+  names: LocaleNames,
+): {
+  regex: RegExp;
+  captures: ParseFieldKey[];
+  tokens: Set<string>;
+} {
+  const normalized = format.replace('[H]n', HALF_YEAR_SENTINEL);
+
+  let body = '';
+  const captures: ParseFieldKey[] = [];
+  const tokens = new Set<string>();
+
+  let cursor = 0;
+  while (cursor < normalized.length) {
+    if (normalized.startsWith(HALF_YEAR_SENTINEL, cursor)) {
+      body += 'H(\\d)';
+      captures.push('halfYear');
+      tokens.add('[H]n');
+      cursor += HALF_YEAR_SENTINEL.length;
+      continue;
+    }
+
+    if (normalized[cursor] === '[') {
+      const end = normalized.indexOf(']', cursor);
+      if (end === -1) {
+        body += escapeRegex(normalized.slice(cursor));
+        break;
+      }
+      body += escapeRegex(normalized.slice(cursor + 1, end));
+      cursor = end + 1;
+      continue;
+    }
+
+    TOKEN_REGEX.lastIndex = cursor;
+    const match = TOKEN_REGEX.exec(normalized);
+    if (match && match.index === cursor) {
+      const token = match[0];
+      tokens.add(token);
+
+      const result = tokenToCapture(token, names);
+      if (result) {
+        body += result.pattern;
+        if (result.field) captures.push(result.field);
+      } else {
+        body += escapeRegex(token);
+      }
+      cursor += token.length;
+      continue;
+    }
+
+    const next = findNextSpecialOrSentinel(normalized, cursor);
+    body += escapeRegex(normalized.slice(cursor, next));
+    cursor = next;
+  }
+
+  return {
+    regex: new RegExp(`^${body}$`),
+    captures,
+    tokens,
+  };
+}
+
+/**
+ * Build a regex alternation that matches any of the supplied names, longest
+ * first to avoid the regex engine matching a prefix of a longer entry.
+ */
+function namesAlternation(names: string[]): string {
+  // De-dupe and sort longest-first.
+  const sorted = Array.from(new Set(names))
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+  return `(${sorted.map(escapeRegex).join('|')})`;
+}
+
+/** Variant that also stops at the half-year sentinel. */
+function findNextSpecialOrSentinel(format: string, from: number): number {
+  for (let i = from; i < format.length; i += 1) {
+    if (format[i] === '[') return i;
+    if (format.startsWith(HALF_YEAR_SENTINEL, i)) return i;
+    TOKEN_REGEX.lastIndex = i;
+    const m = TOKEN_REGEX.exec(format);
+    if (m && m.index === i) return i;
+  }
+  return format.length;
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function tokenToCapture(
+  token: string,
+  names: LocaleNames,
+): { pattern: string; field?: ParseFieldKey } | null {
+  switch (token) {
+    case 'YYYY':
+      return { pattern: '(\\d{4})', field: 'year' };
+    case 'YY':
+      return { pattern: '(\\d{2})', field: 'year' };
+    case 'Y':
+      return { pattern: '(\\d{1,4})', field: 'year' };
+    case 'MMMM':
+      return {
+        pattern: namesAlternation(names.monthLong),
+        field: 'month-long',
+      };
+    case 'MMM':
+      return {
+        pattern: namesAlternation(names.monthShort),
+        field: 'month-short',
+      };
+    case 'MM':
+      return { pattern: '(\\d{2})', field: 'month' };
+    case 'M':
+      return { pattern: '(\\d{1,2})', field: 'month' };
+    case 'Do':
+      // Capture the digit; consume the ordinal suffix non-capturing.
+      return {
+        pattern: '(\\d{1,2})(?:st|nd|rd|th)',
+        field: 'day-ordinal',
+      };
+    case 'DDDD':
+      return { pattern: '(\\d{3})', field: 'day-of-year' };
+    case 'DDD':
+      return { pattern: '(\\d{1,3})', field: 'day-of-year' };
+    case 'DD':
+      return { pattern: '(\\d{2})', field: 'day' };
+    case 'D':
+      return { pattern: '(\\d{1,2})', field: 'day' };
+    case 'dddd':
+      return { pattern: namesAlternation(names.weekdayLong), field: 'skip' };
+    case 'ddd':
+      return { pattern: namesAlternation(names.weekdayShort), field: 'skip' };
+    case 'dd':
+      return { pattern: namesAlternation(names.weekdayNarrow), field: 'skip' };
+    case 'd':
+      // ISO Sunday-indexed weekday number — consume but cannot derive date.
+      return { pattern: '(\\d)', field: 'skip' };
+    case 'e':
+      // Locale-relative weekday number — consume but cannot derive date.
+      return { pattern: '(\\d)', field: 'skip' };
+    case 'HH':
+      return { pattern: '(\\d{2})', field: 'hour' };
+    case 'H':
+      return { pattern: '(\\d{1,2})', field: 'hour' };
+    case 'hh':
+      return { pattern: '(\\d{2})', field: 'hour12' };
+    case 'h':
+      return { pattern: '(\\d{1,2})', field: 'hour12' };
+    case 'mm':
+      return { pattern: '(\\d{2})', field: 'minute' };
+    case 'm':
+      return { pattern: '(\\d{1,2})', field: 'minute' };
+    case 'ss':
+      return { pattern: '(\\d{2})', field: 'second' };
+    case 's':
+      return { pattern: '(\\d{1,2})', field: 'second' };
+    case 'SSS':
+      return { pattern: '(\\d{3})', field: 'millisecond' };
+    case 'SS':
+      return { pattern: '(\\d{2})', field: 'fractional-2' };
+    case 'S':
+      return { pattern: '(\\d)', field: 'fractional-1' };
+    case 'kk':
+      return { pattern: '(\\d{2})', field: 'hour-1to24' };
+    case 'k':
+      return { pattern: '(\\d{1,2})', field: 'hour-1to24' };
+    case 'A':
+      return { pattern: '(AM|PM)', field: 'meridiem-upper' };
+    case 'a':
+      return { pattern: '(am|pm)', field: 'meridiem-lower' };
+    case 'Q':
+      return { pattern: '(\\d)', field: 'quarter' };
+    case 'gggg':
+      return { pattern: '(\\d{4})', field: 'localeWeekYear' };
+    case 'GGGG':
+      return { pattern: '(\\d{4})', field: 'isoWeekYear' };
+    case 'ww':
+      return { pattern: '(\\d{2})', field: 'localeWeek' };
+    case 'WW':
+      return { pattern: '(\\d{2})', field: 'isoWeek' };
+    case 'w':
+      return { pattern: '(\\d{1,2})', field: 'localeWeek' };
+    case 'W':
+      return { pattern: '(\\d{1,2})', field: 'isoWeek' };
+    case 'x':
+      // Unix epoch milliseconds — anchor `$` and adjacent literals constrain
+      // the greedy match.
+      return { pattern: '(\\d+)', field: 'unix-ms' };
+    case 'X':
+      // Unix epoch seconds.
+      return { pattern: '(\\d+)', field: 'unix-s' };
+    default:
+      return null;
+  }
+}
+
+export function applyParseRegex(
+  text: string,
+  regex: RegExp,
+  captures: ParseFieldKey[],
+  names: LocaleNames,
+): ParsedFields | undefined {
+  const match = text.match(regex);
+  if (!match) return undefined;
+
+  const fields: ParsedFields = {};
+  for (let idx = 0; idx < captures.length; idx += 1) {
+    const field = captures[idx];
+    const raw = match[idx + 1];
+    if (raw === undefined) continue;
+
+    if (field === 'skip') continue;
+
+    if (field === 'meridiem-upper') {
+      fields.meridiem = raw === 'PM' ? 'pm' : 'am';
+      continue;
+    }
+    if (field === 'meridiem-lower') {
+      fields.meridiem = raw === 'pm' ? 'pm' : 'am';
+      continue;
+    }
+
+    if (field === 'month-short' || field === 'month-long') {
+      const table =
+        field === 'month-short' ? names.monthShort : names.monthLong;
+      const monthIndex = table.indexOf(raw);
+      if (monthIndex === -1) return undefined;
+      fields.month = monthIndex + 1;
+      continue;
+    }
+
+    if (field === 'day-ordinal') {
+      const value = parseInt(raw, 10);
+      if (Number.isNaN(value)) return undefined;
+      fields.day = value;
+      continue;
+    }
+
+    if (field === 'fractional-1') {
+      const value = parseInt(raw, 10);
+      if (Number.isNaN(value)) return undefined;
+      fields.millisecond = value * 100;
+      continue;
+    }
+
+    if (field === 'fractional-2') {
+      const value = parseInt(raw, 10);
+      if (Number.isNaN(value)) return undefined;
+      fields.millisecond = value * 10;
+      continue;
+    }
+
+    if (field === 'hour-1to24') {
+      const value = parseInt(raw, 10);
+      if (Number.isNaN(value)) return undefined;
+      if (value < 1 || value > 24) return undefined;
+      // 24 represents midnight (start of next day in moment), but mezzanine
+      // round-trips through ISO so we map it to hour 0 of the same day.
+      fields.hour = value === 24 ? 0 : value;
+      continue;
+    }
+
+    if (field === 'day-of-year') {
+      const value = parseInt(raw, 10);
+      if (Number.isNaN(value)) return undefined;
+      // Validate against max possible (366 for leap year). Tighter validation
+      // against the actual `year` happens in the parseFormattedValue branch.
+      if (value < 1 || value > 366) return undefined;
+      fields.dayOfYear = value;
+      continue;
+    }
+
+    if (field === 'unix-ms') {
+      const value = Number(raw);
+      if (!Number.isFinite(value)) return undefined;
+      fields.unixMs = value;
+      continue;
+    }
+
+    if (field === 'unix-s') {
+      const value = Number(raw);
+      if (!Number.isFinite(value)) return undefined;
+      fields.unixMs = value * 1000;
+      continue;
+    }
+
+    const value = parseInt(raw, 10);
+    if (Number.isNaN(value)) continue;
+
+    if (field === 'halfYear') {
+      if (value !== 1 && value !== 2) continue;
+      fields.halfYear = value;
+      continue;
+    }
+
+    if (field === 'year' && raw.length === 2) {
+      // 2-digit year pivot matches moment.js / dayjs behaviour:
+      //   00..68 → 2000..2068
+      //   69..99 → 1969..1999
+      fields.year = value > 68 ? value + 1900 : value + 2000;
+      continue;
+    }
+
+    (fields as Record<string, number>)[field] = value;
+  }
+
+  return fields;
+}

--- a/packages/ng/calendar/calendar.stories.ts
+++ b/packages/ng/calendar/calendar.stories.ts
@@ -11,6 +11,10 @@ import {
 import CalendarMethodsDayjs from '@mezzanine-ui/core/calendarMethodsDayjs';
 import CalendarMethodsLuxon from '@mezzanine-ui/core/calendarMethodsLuxon';
 import CalendarMethodsMoment from '@mezzanine-ui/core/calendarMethodsMoment';
+import { Temporal } from '@js-temporal/polyfill';
+// Register the polyfill so CalendarMethodsTemporal can use globalThis.Temporal.
+(globalThis as { Temporal?: unknown }).Temporal = Temporal;
+import CalendarMethodsTemporal from '@mezzanine-ui/core/calendarMethodsTemporal';
 import { MznToggle } from '@mezzanine-ui/ng/toggle';
 import { MznTypography } from '@mezzanine-ui/ng/typography';
 import {
@@ -213,6 +217,10 @@ class InnerCalendarPlaygroundComponent {
         <p mznTypography>Luxon</p>
         <story-inner-calendar-playground [mode]="mode" />
       </div>
+      <div mznCalendarConfigProvider [methods]="temporalMethods" locale="en-US">
+        <p mznTypography>Temporal</p>
+        <story-inner-calendar-playground [mode]="mode" />
+      </div>
     </div>
   `,
 })
@@ -222,6 +230,7 @@ class CalendarPlaygroundComponent {
   readonly momentMethods = CalendarMethodsMoment;
   readonly dayjsMethods = CalendarMethodsDayjs;
   readonly luxonMethods = CalendarMethodsLuxon;
+  readonly temporalMethods = CalendarMethodsTemporal;
 }
 
 export const CalendarPlayground: Story = {

--- a/packages/ng/date-range-picker/date-range-picker.stories.ts
+++ b/packages/ng/date-range-picker/date-range-picker.stories.ts
@@ -9,6 +9,10 @@ import {
 import CalendarMethodsDayjs from '@mezzanine-ui/core/calendarMethodsDayjs';
 import CalendarMethodsLuxon from '@mezzanine-ui/core/calendarMethodsLuxon';
 import CalendarMethodsMoment from '@mezzanine-ui/core/calendarMethodsMoment';
+import { Temporal } from '@js-temporal/polyfill';
+// Register the polyfill so CalendarMethodsTemporal can use globalThis.Temporal.
+(globalThis as { Temporal?: unknown }).Temporal = Temporal;
+import CalendarMethodsTemporal from '@mezzanine-ui/core/calendarMethodsTemporal';
 import { RangePickerValue } from '@mezzanine-ui/core/picker';
 import {
   MZN_CALENDAR_CONFIG,
@@ -313,15 +317,30 @@ export const Basic: Story = {
         ></div>
       </div>
     </div>
+    <div [mznCalendarConfigProvider] [methods]="temporalMethods" locale="zh-TW">
+      <div style="margin: 0 0 24px 0;">
+        <h3 mznTypography variant="h3" style="margin: 0 0 12px 0;"
+          >CalendarMethodsTemporal</h3
+        >
+        <div
+          mznDateRangePicker
+          [(ngModel)]="rangeTemporal"
+          inputFromPlaceholder="Start Date"
+          inputToPlaceholder="End Date"
+        ></div>
+      </div>
+    </div>
   `,
 })
 class DateRangePickerMethodStoryComponent {
   readonly momentMethods = CalendarMethodsMoment;
   readonly dayjsMethods = CalendarMethodsDayjs;
   readonly luxonMethods = CalendarMethodsLuxon;
+  readonly temporalMethods = CalendarMethodsTemporal;
   rangeMoment: RangePickerValue | undefined;
   rangeDayjs: RangePickerValue | undefined;
   rangeLuxon: RangePickerValue | undefined;
+  rangeTemporal: RangePickerValue | undefined;
 }
 
 export const Method: Story = {

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -35,5 +35,8 @@
     "build:clean": "rimraf dist && ng-packagr -p ng-package.json",
     "test": "jest --config jest.config.js",
     "test:coverage": "jest --config jest.config.js --coverage"
+  },
+  "devDependencies": {
+    "@js-temporal/polyfill": "^0.5.1"
   }
 }

--- a/packages/react/COMPONENTS.md
+++ b/packages/react/COMPONENTS.md
@@ -150,37 +150,41 @@
 
 ## Utility（工具）
 
-| 元件                   | 匯入名稱                 | 說明                                                                                 |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| Calendar               | `Calendar`               | 完整日曆元件，支援日/週/月/季/半年/年視圖切換                                        |
-| RangeCalendar          | `RangeCalendar`          | 範圍日曆，支援選取起始至結束日期範圍                                                 |
-| CalendarCell           | `CalendarCell`           | 日曆中的單一日期格子                                                                 |
-| CalendarConfigProvider | `CalendarConfigProvider` | 日曆全域設定提供者，設定語系與格式                                                   |
-| CalendarControls       | `CalendarControls`       | 日曆的月份/年份切換控制列                                                            |
-| CalendarDayOfWeek      | `CalendarDayOfWeek`      | 日曆的週幾標題列                                                                     |
-| CalendarDays           | `CalendarDays`           | 日曆的日期格子區域                                                                   |
-| CalendarHalfYears      | `CalendarHalfYears`      | 日曆的半年視圖                                                                       |
-| CalendarMonths         | `CalendarMonths`         | 日曆的月份視圖                                                                       |
-| CalendarQuarters       | `CalendarQuarters`       | 日曆的季度視圖                                                                       |
-| CalendarWeeks          | `CalendarWeeks`          | 日曆的週視圖                                                                         |
-| CalendarYears          | `CalendarYears`          | 日曆的年份視圖                                                                       |
-| Dropdown               | `Dropdown`               | 下拉選單面板，由 Select、AutoComplete、Cascader 等元件內部使用                       |
-| DropdownAction         | `DropdownAction`         | Dropdown 中的操作按鈕項目                                                            |
-| DropdownItem           | `DropdownItem`           | Dropdown 中的標準選項項目                                                            |
-| DropdownItemCard       | `DropdownItemCard`       | Dropdown 中的卡片式選項項目                                                          |
-| DropdownStatus         | `DropdownStatus`         | Dropdown 的狀態提示顯示（空狀態、載入中等）                                          |
-| Popper                 | `Popper`                 | 定位浮層元件，基於 Floating UI，Tooltip / Dropdown 的定位基底                        |
-| Portal                 | `Portal`                 | 將子元件渲染到指定 DOM 節點，Modal、Drawer 使用此元件脫離文件流                      |
-| TimePanel              | `TimePanel`              | 時間選取面板，包含時/分/秒的滾輪選取                                                 |
-| TimePanelColumn        | `TimePanelColumn`        | TimePanel 中的單一時間欄（時、分或秒）的滾輪列                                       |
-| Transition             | `Transition`             | 動畫過渡基底元件，提供 Collapse / Fade / Rotate / Scale / Slide / Translate 六種動畫 |
-| Collapse               | `Collapse`               | 收合展開動畫（高度過渡）                                                             |
-| Fade                   | `Fade`                   | 淡入淡出動畫                                                                         |
-| Rotate                 | `Rotate`                 | 旋轉動畫                                                                             |
-| Scale                  | `Scale`                  | 縮放動畫                                                                             |
-| Slide                  | `Slide`                  | 滑動動畫，Drawer 使用此元件進行進出場                                                |
-| Translate              | `Translate`              | 位移動畫                                                                             |
-| createNotifier         | `createNotifier`         | 工廠函式，建立通知管理器實例，用於指令式顯示 toast / 通知訊息                        |
+| 元件                           | 匯入名稱                         | 說明                                                                                                                                                        |
+| ------------------------------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Calendar                       | `Calendar`                       | 完整日曆元件，支援日/週/月/季/半年/年視圖切換                                                                                                               |
+| RangeCalendar                  | `RangeCalendar`                  | 範圍日曆，支援選取起始至結束日期範圍                                                                                                                        |
+| CalendarCell                   | `CalendarCell`                   | 日曆中的單一日期格子                                                                                                                                        |
+| CalendarConfigProvider         | `CalendarConfigProvider`         | 日曆全域設定提供者，設定語系與格式                                                                                                                          |
+| CalendarConfigProviderDayjs    | `CalendarConfigProviderDayjs`    | 預設綁定 dayjs 實作的 CalendarConfigProvider，sub-path entry `@mezzanine-ui/react/dayjs`                                                                    |
+| CalendarConfigProviderLuxon    | `CalendarConfigProviderLuxon`    | 預設綁定 luxon 實作的 CalendarConfigProvider，sub-path entry `@mezzanine-ui/react/luxon`                                                                    |
+| CalendarConfigProviderMoment   | `CalendarConfigProviderMoment`   | 預設綁定 moment 實作的 CalendarConfigProvider，sub-path entry `@mezzanine-ui/react/moment`                                                                  |
+| CalendarConfigProviderTemporal | `CalendarConfigProviderTemporal` | 預設綁定 JS-native Temporal 實作的 CalendarConfigProvider，sub-path entry `@mezzanine-ui/react/temporal`；Safari / Node 22 須先安裝 `@js-temporal/polyfill` |
+| CalendarControls               | `CalendarControls`               | 日曆的月份/年份切換控制列                                                                                                                                   |
+| CalendarDayOfWeek              | `CalendarDayOfWeek`              | 日曆的週幾標題列                                                                                                                                            |
+| CalendarDays                   | `CalendarDays`                   | 日曆的日期格子區域                                                                                                                                          |
+| CalendarHalfYears              | `CalendarHalfYears`              | 日曆的半年視圖                                                                                                                                              |
+| CalendarMonths                 | `CalendarMonths`                 | 日曆的月份視圖                                                                                                                                              |
+| CalendarQuarters               | `CalendarQuarters`               | 日曆的季度視圖                                                                                                                                              |
+| CalendarWeeks                  | `CalendarWeeks`                  | 日曆的週視圖                                                                                                                                                |
+| CalendarYears                  | `CalendarYears`                  | 日曆的年份視圖                                                                                                                                              |
+| Dropdown                       | `Dropdown`                       | 下拉選單面板，由 Select、AutoComplete、Cascader 等元件內部使用                                                                                              |
+| DropdownAction                 | `DropdownAction`                 | Dropdown 中的操作按鈕項目                                                                                                                                   |
+| DropdownItem                   | `DropdownItem`                   | Dropdown 中的標準選項項目                                                                                                                                   |
+| DropdownItemCard               | `DropdownItemCard`               | Dropdown 中的卡片式選項項目                                                                                                                                 |
+| DropdownStatus                 | `DropdownStatus`                 | Dropdown 的狀態提示顯示（空狀態、載入中等）                                                                                                                 |
+| Popper                         | `Popper`                         | 定位浮層元件，基於 Floating UI，Tooltip / Dropdown 的定位基底                                                                                               |
+| Portal                         | `Portal`                         | 將子元件渲染到指定 DOM 節點，Modal、Drawer 使用此元件脫離文件流                                                                                             |
+| TimePanel                      | `TimePanel`                      | 時間選取面板，包含時/分/秒的滾輪選取                                                                                                                        |
+| TimePanelColumn                | `TimePanelColumn`                | TimePanel 中的單一時間欄（時、分或秒）的滾輪列                                                                                                              |
+| Transition                     | `Transition`                     | 動畫過渡基底元件，提供 Collapse / Fade / Rotate / Scale / Slide / Translate 六種動畫                                                                        |
+| Collapse                       | `Collapse`                       | 收合展開動畫（高度過渡）                                                                                                                                    |
+| Fade                           | `Fade`                           | 淡入淡出動畫                                                                                                                                                |
+| Rotate                         | `Rotate`                         | 旋轉動畫                                                                                                                                                    |
+| Scale                          | `Scale`                          | 縮放動畫                                                                                                                                                    |
+| Slide                          | `Slide`                          | 滑動動畫，Drawer 使用此元件進行進出場                                                                                                                       |
+| Translate                      | `Translate`                      | 位移動畫                                                                                                                                                    |
+| createNotifier                 | `createNotifier`                 | 工廠函式，建立通知管理器實例，用於指令式顯示 toast / 通知訊息                                                                                               |
 
 ---
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,6 +46,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
     "@types/lodash": "^4.17.20",
     "@types/moment": "^2.13.0",
     "@types/react": "^19.2.2",

--- a/packages/react/src/Calendar/Calendar.mdx
+++ b/packages/react/src/Calendar/Calendar.mdx
@@ -16,19 +16,87 @@ import * as CalendarStories from './Calendar.stories';
 
 <Description of={Calendar} />
 
-### For typescript users (currently set to Moment as default)
+### Choosing a date adapter
 
-When using calendar, you should declare an exported `DateType` with your desired date library.
-For example, having below code in your `index.d.ts`:
-(Currently don't need to set this)
+Calendar requires a `CalendarMethods` adapter for the underlying date math.
+Mezzanine ships four interchangeable adapters — pick **one** based on which
+date library is already in your app, or pick **Temporal** to avoid pulling
+any third-party date library at all:
 
-```ts
-import { Moment } from 'moment';
+| Adapter  | Sub-path entry                 | Peer dependency                    | Notes                                                                 |
+| -------- | ------------------------------ | ---------------------------------- | --------------------------------------------------------------------- |
+| Moment   | `@mezzanine-ui/react/moment`   | `moment`                           | Heaviest, most features.                                              |
+| Dayjs    | `@mezzanine-ui/react/dayjs`    | `dayjs`                            | Lightweight; same API surface as moment.                              |
+| Luxon    | `@mezzanine-ui/react/luxon`    | `luxon`                            | ISO-week only (Monday-first).                                         |
+| Temporal | `@mezzanine-ui/react/temporal` | `@js-temporal/polyfill` (optional) | JS-native, no extra date library; needs polyfill on Safari / Node 22. |
 
-declare module '@mezzanine-ui/core/calendar' {
-  export type DateType = Moment;
+#### Temporal — polyfill setup
+
+Native Temporal is available in Chrome 144+, Firefox 139+, Edge 144+. Safari
+and Node ≤ 23 do **not** ship Temporal natively, so any application that
+needs to support those environments must register
+[`@js-temporal/polyfill`](https://www.npmjs.com/package/@js-temporal/polyfill)
+on `globalThis` once **before** `CalendarMethodsTemporal` is imported
+anywhere. **The polyfill must run on the client**, not just the server —
+in SSR setups where the layout is a Server Component the global assignment
+on the server does not reach the browser.
+
+##### Vite / CRA / non-RSC setups
+
+Add the registration to your client entry (`main.tsx` / `index.tsx`):
+
+```tsx
+// main.tsx — single client entry point.
+import { Temporal } from '@js-temporal/polyfill';
+(globalThis as { Temporal?: unknown }).Temporal = Temporal;
+
+import {
+  CalendarConfigProviderTemporal,
+  CalendarLocale,
+} from '@mezzanine-ui/react/temporal';
+// …
+```
+
+##### Next.js App Router (Server Components by default)
+
+Layouts run on the server, so place the polyfill in a Client Component and
+import that component from your layout. The Client Component's module-level
+side effect runs in the browser before render.
+
+```tsx
+// app/temporal-polyfill.tsx
+'use client';
+import { Temporal } from '@js-temporal/polyfill';
+(globalThis as { Temporal?: unknown }).Temporal = Temporal;
+export function TemporalPolyfill() {
+  return null;
 }
 ```
+
+```tsx
+// app/layout.tsx
+import { TemporalPolyfill } from './temporal-polyfill';
+import {
+  CalendarConfigProviderTemporal,
+  CalendarLocale,
+} from '@mezzanine-ui/react/temporal';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <TemporalPolyfill />
+        <CalendarConfigProviderTemporal locale={CalendarLocale.ZH_TW}>
+          {children}
+        </CalendarConfigProviderTemporal>
+      </body>
+    </html>
+  );
+}
+```
+
+If `globalThis.Temporal` is absent at the time `CalendarMethodsTemporal`
+runs, every method throws a descriptive error pointing at this section.
 
 [Source Code](https://github.com/Mezzanine-UI/mezzanine/blob/main/packages/react/src/Calendar/Calendar.tsx)
 

--- a/packages/react/src/Calendar/Calendar.stories.tsx
+++ b/packages/react/src/Calendar/Calendar.stories.tsx
@@ -17,6 +17,10 @@ import { useCalendarControls } from './useCalendarControls';
 import Toggle from '../Toggle';
 import CalendarMethodsLuxon from '@mezzanine-ui/core/calendarMethodsLuxon';
 import CalendarMethodsDayjs from '@mezzanine-ui/core/calendarMethodsDayjs';
+import { Temporal } from '@js-temporal/polyfill';
+// Register the polyfill so CalendarMethodsTemporal can use globalThis.Temporal.
+(globalThis as { Temporal?: unknown }).Temporal = Temporal;
+import CalendarMethodsTemporal from '@mezzanine-ui/core/calendarMethodsTemporal';
 
 const meta: Meta<typeof Calendar> = {
   title: 'Internal/Calendar',
@@ -238,6 +242,15 @@ export const CalendarPlayground: Story = {
           Luxon
           <CalendarConfigProvider
             methods={CalendarMethodsLuxon}
+            locale={locale}
+          >
+            <InnerCalendarPlayground mode={mode} locale={locale} />
+          </CalendarConfigProvider>
+        </div>
+        <div>
+          Temporal
+          <CalendarConfigProvider
+            methods={CalendarMethodsTemporal}
             locale={locale}
           >
             <InnerCalendarPlayground mode={mode} locale={locale} />

--- a/packages/react/src/Calendar/CalendarConfigProviderTemporal.spec.tsx
+++ b/packages/react/src/Calendar/CalendarConfigProviderTemporal.spec.tsx
@@ -1,0 +1,67 @@
+import { Temporal } from '@js-temporal/polyfill';
+
+// Register the polyfill on globalThis so Temporal is available before
+// CalendarMethodsTemporal is imported. Mirrors what apps must do at their
+// own entry on runtimes that lack native Temporal (Safari, Node 22).
+(globalThis as { Temporal?: unknown }).Temporal = Temporal;
+
+import { CalendarLocale } from '@mezzanine-ui/core/calendar';
+import { cleanup, render } from '../../__test-utils__';
+import { CalendarConfigProviderTemporal, useCalendarContext } from './';
+
+afterEach(cleanup);
+
+function ContextProbe() {
+  const ctx = useCalendarContext();
+  return (
+    <div>
+      <span data-testid="locale">{ctx.locale}</span>
+      <span data-testid="iso-now">{ctx.getNow()}</span>
+      <span data-testid="formatted">
+        {ctx.formatToString(ctx.locale, '2026-05-05T12:00:00Z', 'YYYY-MM-DD')}
+      </span>
+    </div>
+  );
+}
+
+describe('CalendarConfigProviderTemporal', () => {
+  it('injects Temporal-backed CalendarMethods into context', () => {
+    const { getByTestId } = render(
+      <CalendarConfigProviderTemporal locale={CalendarLocale.ZH_TW}>
+        <ContextProbe />
+      </CalendarConfigProviderTemporal>,
+    );
+
+    expect(getByTestId('locale').textContent).toBe('zh-tw');
+    // ISO 8601 string from getNow().
+    expect(getByTestId('iso-now').textContent).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    );
+    // formatToString uses the moment-style YYYY-MM-DD token.
+    expect(getByTestId('formatted').textContent).toMatch(/^2026-05-/);
+  });
+
+  it('applies custom defaultDateFormat / defaultTimeFormat', () => {
+    function FormatProbe() {
+      const ctx = useCalendarContext();
+      return (
+        <>
+          <span data-testid="date-fmt">{ctx.defaultDateFormat}</span>
+          <span data-testid="time-fmt">{ctx.defaultTimeFormat}</span>
+        </>
+      );
+    }
+
+    const { getByTestId } = render(
+      <CalendarConfigProviderTemporal
+        defaultDateFormat="YYYY/MM/DD"
+        defaultTimeFormat="HH:mm"
+      >
+        <FormatProbe />
+      </CalendarConfigProviderTemporal>,
+    );
+
+    expect(getByTestId('date-fmt').textContent).toBe('YYYY/MM/DD');
+    expect(getByTestId('time-fmt').textContent).toBe('HH:mm');
+  });
+});

--- a/packages/react/src/Calendar/CalendarConfigProviderTemporal.tsx
+++ b/packages/react/src/Calendar/CalendarConfigProviderTemporal.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { CalendarLocaleValue } from '@mezzanine-ui/core/calendar';
+import CalendarMethodsTemporal from '@mezzanine-ui/core/calendarMethodsTemporal';
+import CalendarConfigProvider from './CalendarContext';
+
+export type CalendarConfigProviderTemporalProps = {
+  children?: ReactNode;
+  defaultDateFormat?: string;
+  defaultTimeFormat?: string;
+  /**
+   * The unified locale for all calendar display and value processing.
+   * This determines the first day of week, month names, weekday names, etc.
+   * Use CalendarLocale enum for type-safe locale values.
+   * @example CalendarLocale.EN_US, CalendarLocale.ZH_TW, CalendarLocale.DE_DE
+   * @default CalendarLocale.EN_US
+   */
+  locale?: CalendarLocaleValue;
+};
+
+/**
+ * Pre-configured CalendarConfigProvider backed by the JS-native Temporal API.
+ *
+ * Requires `globalThis.Temporal` to be present **on the client** before any
+ * code imports `CalendarMethodsTemporal`. On runtimes that lack native
+ * support (Safari, Node 22), install `@js-temporal/polyfill` as a peer
+ * dependency.
+ *
+ * IMPORTANT: in Next.js App Router (and other RSC frameworks), default
+ * layouts are Server Components — registering the polyfill at module level
+ * in such a layout only runs on the server, leaving the browser without
+ * `globalThis.Temporal`. Use a Client Component wrapper instead. See the
+ * Calendar story docs for full setup examples (Vite/CRA vs App Router).
+ *
+ * @example
+ * ```tsx
+ * // app/temporal-polyfill.tsx (Client Component)
+ * 'use client';
+ * import { Temporal } from '@js-temporal/polyfill';
+ * (globalThis as { Temporal?: unknown }).Temporal = Temporal;
+ * export function TemporalPolyfill() { return null; }
+ *
+ * // app/layout.tsx
+ * import { TemporalPolyfill } from './temporal-polyfill';
+ * import { CalendarConfigProviderTemporal, CalendarLocale } from '@mezzanine-ui/react/temporal';
+ *
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <html><body>
+ *       <TemporalPolyfill />
+ *       <CalendarConfigProviderTemporal locale={CalendarLocale.ZH_TW}>
+ *         {children}
+ *       </CalendarConfigProviderTemporal>
+ *     </body></html>
+ *   );
+ * }
+ * ```
+ */
+export function CalendarConfigProviderTemporal(
+  props: CalendarConfigProviderTemporalProps,
+) {
+  const { children, defaultDateFormat, defaultTimeFormat, locale } = props;
+
+  return (
+    <CalendarConfigProvider
+      defaultDateFormat={defaultDateFormat}
+      defaultTimeFormat={defaultTimeFormat}
+      locale={locale}
+      methods={CalendarMethodsTemporal}
+    >
+      {children}
+    </CalendarConfigProvider>
+  );
+}
+
+export default CalendarConfigProviderTemporal;

--- a/packages/react/src/Calendar/index.ts
+++ b/packages/react/src/Calendar/index.ts
@@ -21,6 +21,8 @@ export { default as CalendarConfigProviderMoment } from './CalendarConfigProvide
 export type { CalendarConfigProviderMomentProps } from './CalendarConfigProviderMoment';
 export { default as CalendarConfigProviderLuxon } from './CalendarConfigProviderLuxon';
 export type { CalendarConfigProviderLuxonProps } from './CalendarConfigProviderLuxon';
+export { default as CalendarConfigProviderTemporal } from './CalendarConfigProviderTemporal';
+export type { CalendarConfigProviderTemporalProps } from './CalendarConfigProviderTemporal';
 export type { CalendarYearsProps } from './CalendarYears';
 export { default as CalendarYears } from './CalendarYears';
 export type { CalendarQuartersProps } from './CalendarQuarters';

--- a/packages/react/src/temporal.ts
+++ b/packages/react/src/temporal.ts
@@ -1,0 +1,50 @@
+/**
+ * Temporal-specific entry point for Mezzanine UI React.
+ * Import from this path to use the JS-native Temporal API without loading
+ * any other date library (moment / dayjs / luxon).
+ *
+ * Runtime requirement: `globalThis.Temporal` must be available **on the
+ * client** before any import of `CalendarMethodsTemporal`. On runtimes that
+ * lack native support (Safari, Node 22), install `@js-temporal/polyfill` as
+ * a peer dependency and register it from a Client Component side-effect.
+ *
+ * @example Vite / CRA — register at the client entry
+ * ```tsx
+ * // main.tsx
+ * import { Temporal } from '@js-temporal/polyfill';
+ * (globalThis as { Temporal?: unknown }).Temporal = Temporal;
+ *
+ * import { CalendarConfigProviderTemporal, CalendarLocale } from '@mezzanine-ui/react/temporal';
+ * ```
+ *
+ * @example Next.js App Router — Server Component layouts cannot register
+ * the polyfill for the browser, so wrap it in a Client Component module:
+ * ```tsx
+ * // app/temporal-polyfill.tsx
+ * 'use client';
+ * import { Temporal } from '@js-temporal/polyfill';
+ * (globalThis as { Temporal?: unknown }).Temporal = Temporal;
+ * export function TemporalPolyfill() { return null; }
+ *
+ * // app/layout.tsx
+ * import { TemporalPolyfill } from './temporal-polyfill';
+ * import { CalendarConfigProviderTemporal, CalendarLocale } from '@mezzanine-ui/react/temporal';
+ *
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <html><body>
+ *       <TemporalPolyfill />
+ *       <CalendarConfigProviderTemporal locale={CalendarLocale.ZH_TW}>
+ *         {children}
+ *       </CalendarConfigProviderTemporal>
+ *     </body></html>
+ *   );
+ * }
+ * ```
+ */
+
+export { CalendarLocale } from '@mezzanine-ui/core/calendar';
+export type { CalendarLocaleValue } from '@mezzanine-ui/core/calendar';
+
+export { default as CalendarConfigProviderTemporal } from './Calendar/CalendarConfigProviderTemporal';
+export type { CalendarConfigProviderTemporalProps } from './Calendar/CalendarConfigProviderTemporal';

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -61,6 +61,7 @@ const externals = [
   'moment',
   'dayjs',
   'luxon',
+  '@js-temporal/polyfill',
   'events',
 ];
 
@@ -126,7 +127,7 @@ async function run() {
    */
   const indexFiles = await getFilesByGlob(`${packageSrcPath}/**/index.ts`);
   const entryFiles = await getFilesByGlob(
-    `${packageSrcPath}/{dayjs,moment,luxon}.ts`,
+    `${packageSrcPath}/{dayjs,moment,luxon,temporal}.ts`,
   );
   const input = [...indexFiles, ...entryFiles];
 
@@ -159,7 +160,8 @@ async function run() {
         if (
           id.includes('calendarMethodsDayjs') ||
           id.includes('calendarMethodsMoment') ||
-          id.includes('calendarMethodsLuxon')
+          id.includes('calendarMethodsLuxon') ||
+          id.includes('calendarMethodsTemporal')
         ) {
           return true;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5021,6 +5021,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@js-temporal/polyfill@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@js-temporal/polyfill@npm:0.5.1"
+  dependencies:
+    jsbi: "npm:^4.3.0"
+  checksum: 10c0/d9a843e22167e6c98946dc03f8a480d062ece5d01ca850930c8f00af1bd99cfe513a98c3420b24a9920c47e7a61a82e5c8866da47ecdc0e7ee2cd3bf6e440b46
+  languageName: node
+  linkType: hard
+
 "@jsonjoy.com/base64@npm:17.67.0":
   version: 17.67.0
   resolution: "@jsonjoy.com/base64@npm:17.67.0"
@@ -5431,17 +5440,21 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mezzanine-ui/core@workspace:packages/core"
   dependencies:
+    "@js-temporal/polyfill": "npm:^0.5.1"
     "@mezzanine-ui/icons": "npm:1.0.2"
     "@mezzanine-ui/system": "npm:1.0.2"
     "@types/luxon": "npm:^3.6.2"
     lodash: "npm:^4.17.21"
     tslib: "npm:^2.8.1"
   peerDependencies:
+    "@js-temporal/polyfill": ">=0.5"
     dayjs: ">=1"
     lodash: ">=4"
     luxon: ">=3"
     moment: ">=2"
   peerDependenciesMeta:
+    "@js-temporal/polyfill":
+      optional: true
     dayjs:
       optional: true
     luxon:
@@ -5462,6 +5475,7 @@ __metadata:
   resolution: "@mezzanine-ui/ng@workspace:packages/ng"
   dependencies:
     "@floating-ui/dom": "npm:^1.7.4"
+    "@js-temporal/polyfill": "npm:^0.5.1"
     "@mezzanine-ui/core": "npm:1.0.4"
     "@mezzanine-ui/icons": "npm:1.0.2"
     "@mezzanine-ui/system": "npm:1.0.2"
@@ -5483,6 +5497,7 @@ __metadata:
     "@floating-ui/dom": "npm:^1.7.4"
     "@floating-ui/react-dom": "npm:^2.1.6"
     "@hello-pangea/dnd": "npm:^18.0.1"
+    "@js-temporal/polyfill": "npm:^0.5.1"
     "@mezzanine-ui/core": "npm:1.0.4"
     "@mezzanine-ui/icons": "npm:1.0.2"
     "@mezzanine-ui/system": "npm:1.0.2"
@@ -16571,6 +16586,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
+  languageName: node
+  linkType: hard
+
+"jsbi@npm:^4.3.0":
+  version: 4.3.2
+  resolution: "jsbi@npm:4.3.2"
+  checksum: 10c0/f8deb4fc1b1828ee9f90b19b778748f23877d63d437a083b4bead36c7b76c8d173b5dbe2a20cc5dc0217be5bde81791b696b104d5a40d7ede5fda34831d9fab6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a new calendar adapter built on the JS-native [Temporal API](https://tc39.es/proposal-temporal/) (ES2026 / Stage 4) — alongside the existing `moment` / `dayjs` / `luxon` adapters. Lets consumers use Mezzanine UI's Calendar/DatePicker without any third-party date library on runtimes with native Temporal support, falling back to `@js-temporal/polyfill` (optional peerDep) for Safari and Node ≤ 23.

## Background

Temporal API reached Stage 4 / ES2026 in March 2026. Native availability:

- Chrome 144+, Firefox 139+, Edge 144+ ✅
- Safari (any version) ❌ — needs polyfill
- Node ≤ 23 ❌ — needs polyfill (Node 24 has it behind `--harmony-temporal`)

Bundle-size comparison:

| Adapter | Bundle cost |
| --- | --- |
| moment | ~70 KB minified+gzipped |
| luxon | ~22 KB |
| dayjs | ~7 KB (without plugins) |
| **Temporal (native)** | **0 KB** (runtime-provided) |
| `@js-temporal/polyfill` | ~50 KB (only for runtimes that need it) |

## Highlights

- **Full `CalendarMethods` contract**: 30+ methods including format/parse with the complete moment-style token set: `YYYY/YY/Y`, `MMMM/MMM/MM/M`, `DDDD/DDD/DD/Do/D`, `dddd/ddd/dd/d/e`, `HH/H/hh/h/kk/k`, `mm/m`, `ss/s`, `SSS/SS/S`, `A/a`, `Q`, `[H]n`, `gggg/GGGG/ww/WW/w/W`, `x/X`.

- **CLDR-correct locale handling**: uses `Intl.Locale#weekInfo` to determine first-day-of-week (any value 1-7, including `fa-IR` Saturday-first) and `minimalDays`. Variant-aware fallback (`de-AT` → `de`) when runtime exposes weekInfo without `minimalDays`. Forces `calendar: 'gregory'` on `Intl.DateTimeFormat` so locales with non-Gregorian defaults (`fa-IR` Persian Hijri) get correct Gregorian month labels.

- **Setter rollover compatible with moment/dayjs**: `setMonth(d, -1)` → previous December; `setDate(d, 0)` → last day of previous month; `setDate(d, 35)` → 4 days into next month; `setYear(d, year)` on Feb 29 → constrains to Feb 28 in non-leap year.

- **Strict `isBetween`**: matches dayjs/moment default `'()'` inclusivity at the requested granularity.

- **Round-trip property test**: covers all default mode formats across 3 locales × 6 modes × 5 fixture dates (~100 cases) — locks the contract that `parse(format(d, fmt), fmt) ≡ d` for every supported token combination.

- **Polyfill guard**: `getTemporal()` is invoked at the entry of every method (including `isValid`, which must surface this error rather than silently return false). Missing-Temporal errors include the full setup guide.

## Polyfill setup

### Vite / CRA / non-RSC

\`\`\`tsx
// main.tsx
import { Temporal } from '@js-temporal/polyfill';
(globalThis as { Temporal?: unknown }).Temporal = Temporal;
\`\`\`

### Next.js App Router (default Server Components)

Layouts run on the server — register the polyfill from a Client Component so its module-level side effect runs in the browser:

\`\`\`tsx
// app/temporal-polyfill.tsx
'use client';
import { Temporal } from '@js-temporal/polyfill';
(globalThis as { Temporal?: unknown }).Temporal = Temporal;
export function TemporalPolyfill() { return null; }

// app/layout.tsx
import { TemporalPolyfill } from './temporal-polyfill';
import { CalendarConfigProviderTemporal } from '@mezzanine-ui/react/temporal';
\`\`\`

Full guide in \`packages/react/src/Calendar/Calendar.mdx\`.

## Commits

1. \`feat(core/calendarMethodsTemporal): add JS-native Temporal adapter\` — main adapter + token engine + 192 tests (~3000 LOC including spec)
2. \`chore(core): wire @js-temporal/polyfill peer dep and Temporal entry\` — package.json, build.js, yarn.lock
3. \`feat(react/temporal): add CalendarConfigProviderTemporal sub-path entry\` — Provider, sub-path entry, integration spec
4. \`feat(ng/calendar): add Temporal column to multi-adapter stories\` — Storybook parity with React
5. \`docs(react/calendar): document Temporal adapter setup\` — adapter selection table + polyfill setup for Vite/CRA and App Router

## Depends on

This PR is based on #441 ("fix(core): align calendar adapter week classification with CLDR weekInfo"). The Temporal adapter expects the static `ISO_WEEK_LOCALES` to match CLDR; without #441 first, en-AU / ro-RO / ar-SA etc. would format vs `getWeek` divergence in mode='week' pickers.

The PR base branch is set to \`fix/calendar-adapters-cldr-alignment\` so this PR's diff shows only the Temporal additions. Once #441 merges, please retarget this PR to \`main\`.

## Test plan

- [x] \`yarn test\` in \`@mezzanine-ui/core\`: 207 tests pass (192 Temporal + 15 existing)
- [x] \`yarn test\` in \`@mezzanine-ui/react\`: 3037 tests pass
- [ ] Storybook visual: open Calendar story; verify Temporal column matches Moment / Dayjs / Luxon columns for various dates and modes
- [ ] Polyfill missing: in unpolyfilled environment (Safari, vanilla Node 22), verify error message displays correct setup instructions
- [ ] DST: pick a date during March DST forward in a Temporal-backed picker; verify time math is consistent across columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)