### PR TITLE
feat(table): use last column as resize donor across React and Angular

### DIFF
--- a/packages/ng/table/table.component.ts
+++ b/packages/ng/table/table.component.ts
@@ -3585,32 +3585,79 @@ export class MznTable {
     const delta = event.clientX - this.resizeStartX();
     const colDefs = this.columns();
     const currentCol = colDefs[colIndex];
+    const nextCol = colDefs[colIndex + 1];
 
-    if (!currentCol) return;
+    // Last column has no resize handle rendered; nothing to compensate against
+    if (!currentCol || !nextCol) return;
+
+    const lastIdx = colDefs.length - 1;
+    const lastCol = colDefs[lastIdx];
+    const isAdjacentToLast = colIndex + 1 === lastIdx;
 
     const startWidths = this.resizeStartWidths();
-    const currentKey = `${currentCol.key}_${colIndex}`;
+    const makeKey = (key: string, idx: number): string => `${key}_${idx}`;
+    const currentKey = makeKey(currentCol.key, colIndex);
+    const nextKey = makeKey(nextCol.key, colIndex + 1);
+    const lastKey = makeKey(lastCol.key, lastIdx);
+
     const currentStartWidth = startWidths.get(currentKey) ?? 100;
-    const minCurrent = (currentCol as { minWidth?: number }).minWidth ?? 40;
-    const newCurrentWidth = Math.max(minCurrent, currentStartWidth + delta);
+    const nextStartWidth = startWidths.get(nextKey) ?? 100;
+    const lastStartWidth = startWidths.get(lastKey) ?? 100;
+
+    const minCurrent = currentCol.minWidth ?? 40;
+    const maxCurrent = currentCol.maxWidth;
+    const minNext = nextCol.minWidth ?? 40;
+    const maxNext = nextCol.maxWidth;
+
+    const newCurrentWidth = currentStartWidth + delta;
+
+    // Current column constraint checks — reject instead of clamp so that
+    // total table width stays conserved.
+    if (newCurrentWidth < minCurrent) return;
+    if (maxCurrent !== undefined && newCurrentWidth > maxCurrent) return;
 
     const updated = new Map(this.resizedWidths());
 
-    updated.set(currentKey, newCurrentWidth);
+    if (isAdjacentToLast) {
+      // Donor === N+1 === last; collapse to legacy adjacent compensation
+      // to avoid writing the same key twice.
+      const newNextWidth = nextStartWidth - delta;
 
-    // Adjust next column in opposite direction
-    const nextCol = colDefs[colIndex + 1];
+      if (newNextWidth < minNext) return;
+      if (maxNext !== undefined && newNextWidth > maxNext) return;
 
-    if (nextCol) {
-      const nextKey = `${nextCol.key}_${colIndex + 1}`;
-      const nextStartWidth = startWidths.get(nextKey) ?? 100;
-      const minNext = (nextCol as { minWidth?: number }).minWidth ?? 40;
-      const widthDiff = newCurrentWidth - currentStartWidth;
-      const newNextWidth = Math.max(minNext, nextStartWidth - widthDiff);
-
+      updated.set(currentKey, newCurrentWidth);
       updated.set(nextKey, newNextWidth);
+      this.resizedWidths.set(updated);
+
+      return;
     }
 
+    // Last-column donor strategy:
+    // Project `delta` onto the last column first (clamped to its budget).
+    // Any overflow falls back to the adjacent column (N+1).
+    const minLast = lastCol.minWidth ?? 40;
+    const maxLast = lastCol.maxWidth;
+    const lastShrinkBudget = lastStartWidth - minLast;
+    const lastGrowBudget =
+      maxLast !== undefined ? maxLast - lastStartWidth : Infinity;
+
+    const toLast =
+      delta >= 0
+        ? Math.min(delta, lastShrinkBudget)
+        : Math.max(delta, -lastGrowBudget);
+    const overflow = delta - toLast;
+    const newLastWidth = lastStartWidth - toLast;
+    // Always write N+1 too — when overflow returns to 0 on the return drag,
+    // this restores N+1 to its start width (LIFO donor restoration).
+    const newNextWidth = nextStartWidth - overflow;
+
+    if (newNextWidth < minNext) return;
+    if (maxNext !== undefined && newNextWidth > maxNext) return;
+
+    updated.set(currentKey, newCurrentWidth);
+    updated.set(lastKey, newLastWidth);
+    updated.set(nextKey, newNextWidth);
     this.resizedWidths.set(updated);
   }
 

--- a/packages/ng/table/table.stories.ts
+++ b/packages/ng/table/table.stories.ts
@@ -1539,19 +1539,36 @@ interface ResizableRowType extends TableDataSource {
         <ng-template mznTableCellRender="age" let-record>
           <span mznTypography variant="body-mono">{{ record.age }}</span>
         </ng-template>
-        <ng-template mznTableCellRender="tags" let-record>{{
-          (record.tags ?? []).join(', ')
-        }}</ng-template>
+        <ng-template mznTableCellRender="status" let-record>
+          <span mznTypography variant="body2">{{
+            record.tags?.[0] ?? '-'
+          }}</span>
+        </ng-template>
+        <ng-template mznTableCellRender="role" let-record>
+          <span mznTypography variant="body2">{{
+            record.tags?.[1] ?? '-'
+          }}</span>
+        </ng-template>
+        <ng-template mznTableCellRender="tagsCount" let-record>
+          <span mznTypography variant="body-mono">{{
+            record.tags?.length ?? 0
+          }}</span>
+        </ng-template>
       </div>
     </div>
   `,
 })
 class WithResizableColumnsStoryComponent {
   readonly legendText =
-    'Column 1: minWidth: 120, maxWidth: 220;\n' +
-    '          Column 2: minWidth: 80;\n' +
-    '          Column 3: width 200 minWidth: 140;\n' +
-    '          Column 4: minWidth: 220;';
+    `Resize strategy: drag any column's right handle — the rightmost column (Address) absorbs the change first, so middle columns stay put. Once Address shrinks to its minWidth (200), the next column to the right of the dragged handle starts to compensate.\n\n` +
+    `Try: drag "Name" right → only Address shrinks. Keep dragging until Address hits 200px → "Age" starts shrinking.\n\n` +
+    `Columns:\n` +
+    `  Name      width 120, minWidth 80\n` +
+    `  Age       width  70, minWidth 50\n` +
+    `  Status    width 100, minWidth 80\n` +
+    `  Role      width 100, minWidth 80\n` +
+    `  Tags      width  80, minWidth 60\n` +
+    `  Address   minWidth 200 (donor)`;
 
   readonly dataSource: readonly ResizableRowType[] = [
     {
@@ -1624,22 +1641,18 @@ class WithResizableColumnsStoryComponent {
       key: 'name',
       dataIndex: 'name',
       title: 'Name',
-      minWidth: 120,
-      maxWidth: 220,
+      width: 120,
+      minWidth: 80,
     },
-    { key: 'age', title: 'Age', minWidth: 80 },
-    {
-      key: 'tags',
-      dataIndex: 'tags',
-      title: 'Tags',
-      width: 200,
-      minWidth: 140,
-    },
+    { key: 'age', title: 'Age', width: 70, minWidth: 50 },
+    { key: 'status', title: 'Status', width: 100, minWidth: 80 },
+    { key: 'role', title: 'Role', width: 100, minWidth: 80 },
+    { key: 'tagsCount', title: 'Tags', width: 80, minWidth: 60 },
     {
       key: 'address',
       dataIndex: 'address',
       title: 'Address',
-      minWidth: 220,
+      minWidth: 200,
     },
   ];
 }

--- a/packages/react/src/Table/Table.stories.tsx
+++ b/packages/react/src/Table/Table.stories.tsx
@@ -1233,10 +1233,11 @@ export const WithResizableColumns: Story = {
           dataIndex: 'name',
           key: 'name',
           title: 'Name',
-          minWidth: 120,
-          maxWidth: 220,
+          width: 120,
+          minWidth: 80,
         },
         {
+          align: 'center',
           key: 'age',
           render: (record) => (
             <Typography component="span" variant="body-mono">
@@ -1244,20 +1245,48 @@ export const WithResizableColumns: Story = {
             </Typography>
           ),
           title: 'Age',
+          width: 70,
+          minWidth: 50,
+        },
+        {
+          key: 'status',
+          render: (record) => (
+            <Typography component="span" variant="body2">
+              {record.tags?.[0] ?? '-'}
+            </Typography>
+          ),
+          title: 'Status',
+          width: 100,
           minWidth: 80,
         },
         {
-          dataIndex: 'tags',
-          key: 'tags',
+          key: 'role',
+          render: (record) => (
+            <Typography component="span" variant="body2">
+              {record.tags?.[1] ?? '-'}
+            </Typography>
+          ),
+          title: 'Role',
+          width: 100,
+          minWidth: 80,
+        },
+        {
+          align: 'center',
+          key: 'tagsCount',
+          render: (record) => (
+            <Typography component="span" variant="body-mono">
+              {record.tags?.length ?? 0}
+            </Typography>
+          ),
           title: 'Tags',
-          width: 200,
-          minWidth: 140,
+          width: 80,
+          minWidth: 60,
         },
         {
           dataIndex: 'address',
           key: 'address',
           title: 'Address',
-          minWidth: 220,
+          minWidth: 200,
         },
       ],
       [],
@@ -1273,10 +1302,17 @@ export const WithResizableColumns: Story = {
         }}
       >
         <span style={{ whiteSpace: 'pre-line' }}>
-          {`Column 1: minWidth: 120, maxWidth: 220;
-          Column 2: minWidth: 80;
-          Column 3: width 200 minWidth: 140;
-          Column 4: minWidth: 220;`}
+          {`Resize strategy: drag any column's right handle — the rightmost column (Address) absorbs the change first, so middle columns stay put. Once Address shrinks to its minWidth (200), the next column to the right of the dragged handle starts to compensate.
+
+Try: drag "Name" right → only Address shrinks. Keep dragging until Address hits 200px → "Age" starts shrinking.
+
+Columns:
+  Name      width 120, minWidth 80
+  Age       width  70, minWidth 50
+  Status    width 100, minWidth 80
+  Role      width 100, minWidth 80
+  Tags      width  80, minWidth 60
+  Address   minWidth 200 (donor)`}
         </span>
         <Table<DataType>
           columns={resizableColumns}

--- a/packages/react/src/Table/components/TableResizeHandle.tsx
+++ b/packages/react/src/Table/components/TableResizeHandle.tsx
@@ -81,11 +81,21 @@ export const TableResizeHandle = memo(function TableResizeHandle({
         return;
       }
 
+      const lastColumnIndex = columns.length - 1;
+      const lastColumn = columns[lastColumnIndex];
+      // When resizing the second-to-last column, nextColumn === lastColumn.
+      // We collapse to the legacy adjacent-compensation path to avoid
+      // double-writing the same key.
+      const isAdjacentToLast = columnIndex + 1 === lastColumnIndex;
+
       // Get the actual rendered widths from the DOM
       const currentWidth = getColumnActualWidth(columnIndex);
       const nextWidth = getColumnActualWidth(columnIndex + 1);
+      const lastWidth = isAdjacentToLast
+        ? nextWidth
+        : getColumnActualWidth(lastColumnIndex);
 
-      if (currentWidth === 0 || nextWidth === 0) {
+      if (currentWidth === 0 || nextWidth === 0 || lastWidth === 0) {
         return;
       }
 
@@ -97,42 +107,62 @@ export const TableResizeHandle = memo(function TableResizeHandle({
       const maxWidth = column.maxWidth;
       const nextMinWidth = nextColumn.minWidth;
       const nextMaxWidth = nextColumn.maxWidth;
+      const lastMinWidth = lastColumn.minWidth;
+      const lastMaxWidth = lastColumn.maxWidth;
+
+      // Slack the last column can absorb (signed against `diff`):
+      // - positive `diff` shrinks last → capped by lastShrinkBudget
+      // - negative `diff` grows last → capped by lastGrowBudget
+      const lastShrinkBudget = lastWidth - (lastMinWidth ?? 0);
+      const lastGrowBudget =
+        lastMaxWidth !== undefined ? lastMaxWidth - lastWidth : Infinity;
 
       const handleMouseMove = (moveEvent: MouseEvent) => {
         const diff = moveEvent.clientX - startXRef.current;
-
         const newWidth = startWidthRef.current + diff;
-        const newNextWidth = nextStartWidthRef.current - diff;
 
-        let isConstrained = false;
+        // Current column constraint checks
+        if (minWidth !== undefined && newWidth < minWidth) return;
+        if (maxWidth !== undefined && newWidth > maxWidth) return;
+        if (newWidth < 0) return;
 
-        // Check current column constraints
-        if (minWidth !== undefined && newWidth < minWidth) {
-          isConstrained = true;
-        }
+        if (isAdjacentToLast) {
+          // Legacy adjacent compensation: donor === N+1 === last
+          const newNextWidth = nextStartWidthRef.current - diff;
 
-        if (maxWidth !== undefined && newWidth > maxWidth) {
-          isConstrained = true;
-        }
+          if (nextMinWidth !== undefined && newNextWidth < nextMinWidth) return;
+          if (nextMaxWidth !== undefined && newNextWidth > nextMaxWidth) return;
+          if (newNextWidth < 0) return;
 
-        // Check next column constraints
-        if (nextMinWidth !== undefined && newNextWidth < nextMinWidth) {
-          isConstrained = true;
-        }
+          setResizedColumnWidth?.(column.key, newWidth);
+          setResizedColumnWidth?.(nextColumn.key, newNextWidth);
 
-        if (nextMaxWidth !== undefined && newNextWidth > nextMaxWidth) {
-          isConstrained = true;
-        }
-
-        if (isConstrained) {
           return;
         }
 
-        if (newWidth < 0 || newNextWidth < 0) {
-          return;
+        // Last-column donor strategy:
+        // Project `diff` onto the last column first (clamped to its budget).
+        // Any overflow falls back to the adjacent column (N+1).
+        let toLast: number;
+
+        if (diff >= 0) {
+          toLast = Math.min(diff, lastShrinkBudget);
+        } else {
+          toLast = Math.max(diff, -lastGrowBudget);
         }
+
+        const overflow = diff - toLast;
+        const newLastWidth = lastWidth - toLast;
+        // Always write N+1 too — when overflow returns to 0 on the return
+        // drag, this restores N+1 to its start width (LIFO donor restoration).
+        const newNextWidth = nextStartWidthRef.current - overflow;
+
+        if (nextMinWidth !== undefined && newNextWidth < nextMinWidth) return;
+        if (nextMaxWidth !== undefined && newNextWidth > nextMaxWidth) return;
+        if (newNextWidth < 0) return;
 
         setResizedColumnWidth?.(column.key, newWidth);
+        setResizedColumnWidth?.(lastColumn.key, newLastWidth);
         setResizedColumnWidth?.(nextColumn.key, newNextWidth);
       };
 


### PR DESCRIPTION
## Summary

Changes the column-resize compensation strategy for both `react/table` and `ng/table` so that dragging a column's right handle steals space from the **rightmost column first**, leaving the middle columns untouched. When the last column hits its `minWidth`, the algorithm falls back to the legacy adjacent compensation (donor = N+1).

Previously, resizing the second column in a 5-column table would compress the third column — even when the last column had plenty of slack. Users had to drag through each middle handle to redistribute space from the right. The new behavior matches the intuitive "absorb the empty space on the right" mental model.

## What changed

### React (`feat(react/table)` — 6d6255b0)
- `TableResizeHandle.tsx`: rewrote `handleMouseDown`/`handleMouseMove` to use last-column donor with N+1 fallback. Always writes all three columns on every frame so that the return drag restores N+1 to its start width (LIFO donor restoration — fixes "Age stays compressed even after dragging back" bug).
- `Table.stories.tsx`: `WithResizableColumns` story now uses six narrow columns plus a wide `Address` donor to showcase the new behavior.

### Angular (`fix(ng/table)` — bc3e604f)
Mirrors the React algorithm, and on the way fixes two pre-existing Angular-only defects revealed by the rewrite:
1. **Total width drift** — `onResizeMove` used `Math.max(min, ...)` to clamp instead of rejecting. After the donor pinned at `minWidth`, the current column kept growing, so the colgroup total drifted from the container width.
2. **`maxWidth` ignored** — `TableColumn.maxWidth` was already in the type but never enforced during resize.
3. **LIFO restoration** — three-column write on every frame, same fix as React.

Story (`WithResizableColumnsStoryComponent`) updated to the same six-column shape for parity tooling.

## Algorithm sketch

```
on mousemove:
  delta = clientX - startX
  reject if newCurrent violates current min/max
  if column is second-to-last:
    legacy adjacent compensation (donor === N+1 === last)
  else:
    toLast = clamp(delta, -lastGrowBudget, lastShrinkBudget)
    overflow = delta - toLast
    write current = start + delta
    write last    = start - toLast
    write N+1     = start - overflow   ← always written, restores on return drag
```

Budgets are computed once at mousedown and frozen for the duration of the drag.

## Test plan

- [x] React unit: `yarn nx test react --testPathPatterns=TableResizeHandle` — 3/3 pass
- [x] ESLint on changed files — clean
- [ ] Manual: open both Storybooks side by side (`yarn react:storybook` :6006, `yarn ng:storybook` :6007) and walk through:
  1. Drag `Name` right → only `Address` shrinks, middle columns stay put
  2. Keep dragging until `Address` hits 200px → `Age` (N+1) starts shrinking
  3. Drag `Name` back left → `Age` restores to its start width *first*, then `Address` grows back
  4. Drag the second-to-last column → behavior identical to old adjacent compensation
  5. Confirm total table width stays in sync with the container throughout

## Notes for reviewers

- Public API of `<Table resizable>` is unchanged; no codegen or type updates needed.
- `useTableResizedColumns` / `TableColGroup` / `calculateColumnWidths` are untouched — they index by `column.key`, so cross-column writes were already supported.
- Angular keeps its `${key}_${idx}` Map key format; a small `makeKey` helper isolates that detail.
- Performance: each move now writes three Map entries instead of two. React 18 automatic batching collapses this into a single render, so render cost is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)