### PR TITLE
fix(ng/input): throw on native input host to prevent silent CVA failure

### DIFF
--- a/packages/ng/input/input.component.ts
+++ b/packages/ng/input/input.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   computed,
   ElementRef,
+  inject,
   input,
   OnInit,
   output,
@@ -46,6 +47,11 @@ export type InputVariant =
  * 實作 `ControlValueAccessor`，可搭配 Angular Reactive Forms 或 Template-driven Forms。
  * `search` 變體預設帶搜尋圖示與清除按鈕；`password` 變體提供密碼可見性切換及強度指示器；
  * `measure` 變體支援 Spinner 微調按鈕；`action` 變體支援外部動作按鈕。
+ *
+ * ⚠️ **務必套在容器元素上**（如 `<div mznInput>`），本元件會自行渲染 `<input>`。
+ * **切勿**把 `mznInput` 加在原生 `<input>` / `<textarea>` 上——那會讓 host 與元件內部的 CVA
+ * 脫鉤、`ngModel` 靜默失敗（誤用時元件會於初始化 throw 明確錯誤）。表單請在 host div 綁
+ * `[(ngModel)]`、`[formControl]` 或 `[value]` + `(valueChange)`。
  *
  * @example
  * ```html
@@ -274,6 +280,8 @@ export class MznInput implements ControlValueAccessor, OnInit {
   protected readonly eyeInvisibleIcon = EyeInvisibleIcon;
 
   private readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputEl');
+
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   private onChangeFn: (value: string) => void = () => {};
   private onTouchedFn: () => void = () => {};
@@ -644,6 +652,21 @@ export class MznInput implements ControlValueAccessor, OnInit {
   }
 
   ngOnInit(): void {
+    // Guard against misuse: mznInput is a Component that renders its own
+    // <input>; it must be placed on a container element (e.g. <div mznInput>).
+    // Putting it on a native <input>/<textarea> decouples the host from the
+    // internal CVA and makes ngModel silently fail with no error — so we throw
+    // an actionable error to surface the mistake at init time.
+    const tag = (this.elementRef.nativeElement.tagName ?? '').toUpperCase();
+
+    if (tag === 'INPUT' || tag === 'TEXTAREA') {
+      throw new Error(
+        `[mznInput] 必須套在容器元素上（例如 <div mznInput>），它會自行渲染 <input>。` +
+          `偵測到 host 為 <${tag.toLowerCase()}>，此時 ngModel / CVA 會靜默失敗。` +
+          `請改用 <div mznInput [(ngModel)]="..."> 或 <div mznInput [value]="..." (valueChange)="...">。`,
+      );
+    }
+
     // Set internalValue from defaultValue if no external value is bound
     const dv = this.defaultValue();
 

--- a/packages/ng/input/input.component.ts
+++ b/packages/ng/input/input.component.ts
@@ -283,6 +283,25 @@ export class MznInput implements ControlValueAccessor, OnInit {
 
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
+  constructor() {
+    // mznInput is a Component that renders its own <input>; placing it on a
+    // native <input>/<textarea> decouples the host from the internal CVA and
+    // makes ngModel silently fail. Throw here (not ngOnInit) so the error fires
+    // before any CVA lifecycle calls (e.g. writeValue from FormControlDirective).
+    const tag = this.elementRef.nativeElement.tagName.toUpperCase();
+
+    if (tag === 'INPUT' || tag === 'TEXTAREA') {
+      throw new Error(
+        `[mznInput] must be applied to a container element (e.g. <div mznInput>) — ` +
+          `the component renders its own <input> internally. ` +
+          `Detected host: <${tag.toLowerCase()}>. ` +
+          `Placing mznInput on a native form element decouples the host from the internal CVA, ` +
+          `causing ngModel / formControl bindings to silently fail. ` +
+          `Use <div mznInput [(ngModel)]="..."> or <div mznInput [value]="..." (valueChange)="..."> instead.`,
+      );
+    }
+  }
+
   private onChangeFn: (value: string) => void = () => {};
   private onTouchedFn: () => void = () => {};
 
@@ -652,21 +671,6 @@ export class MznInput implements ControlValueAccessor, OnInit {
   }
 
   ngOnInit(): void {
-    // Guard against misuse: mznInput is a Component that renders its own
-    // <input>; it must be placed on a container element (e.g. <div mznInput>).
-    // Putting it on a native <input>/<textarea> decouples the host from the
-    // internal CVA and makes ngModel silently fail with no error — so we throw
-    // an actionable error to surface the mistake at init time.
-    const tag = (this.elementRef.nativeElement.tagName ?? '').toUpperCase();
-
-    if (tag === 'INPUT' || tag === 'TEXTAREA') {
-      throw new Error(
-        `[mznInput] 必須套在容器元素上（例如 <div mznInput>），它會自行渲染 <input>。` +
-          `偵測到 host 為 <${tag.toLowerCase()}>，此時 ngModel / CVA 會靜默失敗。` +
-          `請改用 <div mznInput [(ngModel)]="..."> 或 <div mznInput [value]="..." (valueChange)="...">。`,
-      );
-    }
-
     // Set internalValue from defaultValue if no external value is bound
     const dv = this.defaultValue();
 

--- a/packages/ng/input/input.stories.ts
+++ b/packages/ng/input/input.stories.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 import { CopyIcon, UserIcon } from '@mezzanine-ui/icons';
@@ -370,6 +371,114 @@ class StorySelectInput {
   sizeSubValue = '.com';
 }
 
+/**
+ * Wrapper component for FormBinding story.
+ *
+ * Verifies the *correct* usage of `mznInput`: it is placed on a container
+ * element (`<div mznInput>`) and two-way binds through Angular forms. The live
+ * read-outs beside each field prove that typing updates the bound model — this
+ * is the confirmation that the CVA works when used as designed.
+ */
+@Component({
+  selector: 'story-form-binding',
+  standalone: true,
+  imports: [MznInput, FormsModule, ReactiveFormsModule],
+  template: `
+    <div
+      style="display: flex; flex-direction: column; gap: 24px; max-width: 360px;"
+    >
+      <div>
+        <p style="margin: 0 0 12px 0; font-size: 18px; font-weight: bold;"
+          >Form Binding（正確用法）</p
+        >
+        <p style="margin: 0; color: #475569;"
+          >host 為
+          <code>&lt;div mznInput&gt;</code>，打字時右側即時值會同步更新。</p
+        >
+      </div>
+
+      <div>
+        <p style="margin: 0 0 12px 0;">Template-driven（[(ngModel)]）</p>
+        <div mznInput placeholder="請輸入" [(ngModel)]="ngModelValue"></div>
+        <p style="margin: 8px 0 0 0; color: #1a4d8f;"
+          >Model：<b>{{ ngModelValue || '(空)' }}</b></p
+        >
+      </div>
+
+      <div>
+        <p style="margin: 0 0 12px 0;">Reactive Forms（[formControl]）</p>
+        <div mznInput placeholder="請輸入" [formControl]="ctrl"></div>
+        <p style="margin: 8px 0 0 0; color: #1a4d8f;"
+          >Form value：<b>{{ ctrl.value || '(空)' }}</b></p
+        >
+      </div>
+
+      <div>
+        <p style="margin: 0 0 12px 0;">Number 變體（[(ngModel)]）</p>
+        <div
+          mznInput
+          variant="number"
+          [min]="0"
+          placeholder="0"
+          [(ngModel)]="qtyValue"
+        ></div>
+        <p style="margin: 8px 0 0 0; color: #1a4d8f;"
+          >Quantity：<b>{{ qtyValue || '(空)' }}</b></p
+        >
+      </div>
+
+      <div>
+        <p style="margin: 0 0 12px 0;">Measure 變體（[(ngModel)]）</p>
+        <div
+          mznInput
+          variant="measure"
+          suffixText="px"
+          [(ngModel)]="measureValue"
+        ></div>
+        <p style="margin: 8px 0 0 0; color: #1a4d8f;"
+          >Measure：<b>{{ measureValue || '(空)' }}</b></p
+        >
+      </div>
+    </div>
+  `,
+})
+class StoryFormBinding {
+  ngModelValue = '';
+
+  qtyValue = '';
+
+  measureValue = '';
+
+  ctrl = new FormControl('');
+}
+
+/**
+ * Wrapper component for MisuseGuard story.
+ *
+ * Demonstrates the new dev-time guard: placing `mznInput` on a native
+ * `<input>` now throws an actionable error at init instead of silently failing.
+ * The red error overlay in the canvas is the *expected* behavior.
+ */
+@Component({
+  selector: 'story-misuse-guard',
+  standalone: true,
+  imports: [MznInput, FormsModule],
+  template: `
+    <div
+      style="display: flex; flex-direction: column; gap: 12px; max-width: 360px;"
+    >
+      <p style="margin: 0; color: #7f1d1d;"
+        >⚠️ 此 story 預期會跳出紅色錯誤——那正是新防呆在運作（把
+        <code>mznInput</code> 誤套在原生 <code>&lt;input&gt;</code> 上）。</p
+      >
+      <input mznInput type="text" [(ngModel)]="value" />
+    </div>
+  `,
+})
+class StoryMisuseGuard {
+  value = '';
+}
+
 const meta: Meta<MznInput> = {
   title: 'Data Entry/Input',
   component: MznInput,
@@ -384,6 +493,8 @@ const meta: Meta<MznInput> = {
         StoryPasswordInput,
         StorySelectInput,
         StoryFormatterParser,
+        StoryFormBinding,
+        StoryMisuseGuard,
       ],
     }),
   ],
@@ -645,5 +756,19 @@ export const FormatterAndParser: Story = {
   parameters: { controls: { disable: true } },
   render: () => ({
     template: `<story-formatter-parser />`,
+  }),
+};
+
+export const FormBinding: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => ({
+    template: `<story-form-binding />`,
+  }),
+};
+
+export const MisuseGuard: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => ({
+    template: `<story-misuse-guard />`,
   }),
 };

--- a/packages/ng/input/input.stories.ts
+++ b/packages/ng/input/input.stories.ts
@@ -397,6 +397,25 @@ class StorySelectInput {
         >
       </div>
 
+      <div
+        style="border-left: 4px solid #dc2626; background: #fef2f2; padding: 12px 16px; border-radius: 0 6px 6px 0;"
+      >
+        <p style="margin: 0 0 6px 0; font-weight: bold; color: #991b1b;"
+          >⚠️ 不要把 <code>mznInput</code> 放在原生 <code>&lt;input&gt;</code> /
+          <code>&lt;textarea&gt;</code> 上。</p
+        >
+        <p style="margin: 0; color: #7f1d1d;"
+          ><code>mznInput</code> 是會自行渲染
+          <code>&lt;input&gt;</code> 的元件，套在原生表單元素上會讓 host 與內部
+          CVA 脫鉤、<code>ngModel</code>
+          靜默失敗（此情況元件會於初始化 throw 明確錯誤）。請一律把
+          <code>mznInput</code> 套在容器元素上（如
+          <code>&lt;div mznInput&gt;</code>）， 並在該 host 上綁
+          <code>[(ngModel)]</code>、<code>[formControl]</code> 或
+          <code>[value]</code> + <code>(valueChange)</code>。</p
+        >
+      </div>
+
       <div>
         <p style="margin: 0 0 12px 0;">Template-driven（[(ngModel)]）</p>
         <div mznInput placeholder="請輸入" [(ngModel)]="ngModelValue"></div>

--- a/packages/ng/input/input.stories.ts
+++ b/packages/ng/input/input.stories.ts
@@ -452,33 +452,6 @@ class StoryFormBinding {
   ctrl = new FormControl('');
 }
 
-/**
- * Wrapper component for MisuseGuard story.
- *
- * Demonstrates the new dev-time guard: placing `mznInput` on a native
- * `<input>` now throws an actionable error at init instead of silently failing.
- * The red error overlay in the canvas is the *expected* behavior.
- */
-@Component({
-  selector: 'story-misuse-guard',
-  standalone: true,
-  imports: [MznInput, FormsModule],
-  template: `
-    <div
-      style="display: flex; flex-direction: column; gap: 12px; max-width: 360px;"
-    >
-      <p style="margin: 0; color: #7f1d1d;"
-        >⚠️ 此 story 預期會跳出紅色錯誤——那正是新防呆在運作（把
-        <code>mznInput</code> 誤套在原生 <code>&lt;input&gt;</code> 上）。</p
-      >
-      <input mznInput type="text" [(ngModel)]="value" />
-    </div>
-  `,
-})
-class StoryMisuseGuard {
-  value = '';
-}
-
 const meta: Meta<MznInput> = {
   title: 'Data Entry/Input',
   component: MznInput,
@@ -494,7 +467,6 @@ const meta: Meta<MznInput> = {
         StorySelectInput,
         StoryFormatterParser,
         StoryFormBinding,
-        StoryMisuseGuard,
       ],
     }),
   ],
@@ -763,12 +735,5 @@ export const FormBinding: Story = {
   parameters: { controls: { disable: true } },
   render: () => ({
     template: `<story-form-binding />`,
-  }),
-};
-
-export const MisuseGuard: Story = {
-  parameters: { controls: { disable: true } },
-  render: () => ({
-    template: `<story-misuse-guard />`,
   }),
 };


### PR DESCRIPTION
## What

\`MznInput\` (selector \`[mznInput]\`) is a **Component that renders its own \`<input>\`**, not a directive that decorates a native input. When mistakenly placed on a native \`<input>\`/\`<textarea>\`, the host element decouples from the component's internal \`ControlValueAccessor\`:

- The user types into the **host** \`<input>\`, but the CVA's \`(input)\` handler is wired to the component's **internal** template \`<input>\` (which can't even render as a child of a void \`<input>\`).
- \`[(ngModel)]\` / \`[formControl]\` / \`[value]\` therefore **silently fail** — text appears on screen but the bound model never updates, with **no error or warning** (the "1 builtin + 1 custom CVA" combo doesn't trip Angular's \`More than one custom value accessor\` error).

This was reported from the TYG MES mockup against \`@mezzanine-ui/ng\` 1.0.0-rc.3.

## Changes

- **Guard (\`input.component.ts\`):** \`constructor\` now inspects the host element via \`inject(ElementRef)\`. If the host is \`<input>\`/\`<textarea>\`, it throws an actionable error in English directing the developer to use a container host (\`<div mznInput>\`). Throwing in the constructor (rather than \`ngOnInit\`) ensures the error fires before any CVA lifecycle calls such as \`writeValue\` from \`FormControlDirective\`.
- **JSDoc:** reinforced the component doc to warn against native-input hosts and point to \`[(ngModel)]\` / \`[formControl]\` / \`[value]\`+\`(valueChange)\` on a \`<div mznInput>\` host.
- **Stories (\`input.stories.ts\`):** \`FormBinding\` story verifies the **correct** usage — \`[(ngModel)]\`, \`[formControl]\`, plus \`number\`/\`measure\` variants, each with a live read-out.

## Why this approach

Per the project's "Angular mirrors React prop-for-prop" rule, the intended host is a container (React's \`<Input>\` also renders its own \`<input>\`). A separate real-directive version for native inputs was intentionally **not** added (confirmed with maintainer) to avoid inventing an abstraction React doesn't have.

## How to test

1. \`npm run ng:storybook\` (Storybook on :6007)
2. **Data Entry → Input → Form Binding**: type into each field → the live \`Model:\` / \`Form value:\` text updates in real time ✅
3. Existing stories (Base/Search/Number/Measure/…) still render with no new errors ✅

## Notes for reviewers

- ESLint passes; Storybook webpack compiles clean. The \`yarn check\` type errors are pre-existing package-wide infra issues (\`rootDir\` violations on cross-package imports, missing \`@angular/*/testing\` type decls) unrelated to this change.
- Separately noticed (out of scope): the \`ng\` package has no working \`jest.config.js\`, so \`input.component.spec.ts\` doesn't run and still uses a stale \`<mzn-input>\` element selector. Flagging for a follow-up.