### PR TITLE
fix(react): avoid React 18 ref-is-not-a-prop warning when Dropdown reads child ref

### DIFF
--- a/packages/react/src/Dropdown/Dropdown.spec.tsx
+++ b/packages/react/src/Dropdown/Dropdown.spec.tsx
@@ -466,6 +466,24 @@ describe('<Dropdown />', () => {
       expect(childRef.current?.textContent).toBe('Trigger');
     });
 
+    it('should not log a ref warning when children has ref', () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      try {
+        const childRef = React.createRef<HTMLButtonElement>();
+        render(
+          <Dropdown options={mockOptions} inputPosition="outside">
+            <Button ref={childRef}>Trigger</Button>
+          </Dropdown>,
+        );
+        // 驗證沒有觸發 React dev mode 的 ref 警告
+        // （React 18: "`ref` is not a prop" / React 19: "Accessing element.ref was removed"）
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
     it('should call original onClick handler from children', async () => {
       const user = userEvent.setup();
       const handleClick = jest.fn();

--- a/packages/react/src/Dropdown/Dropdown.spec.tsx
+++ b/packages/react/src/Dropdown/Dropdown.spec.tsx
@@ -23,7 +23,7 @@ describe('<Dropdown />', () => {
       render(
         <Dropdown options={mockOptions}>
           <Button>Click me</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       expect(screen.getByText('Click me')).toBeInTheDocument();
     });
@@ -34,7 +34,7 @@ describe('<Dropdown />', () => {
           <TextField>
             <input placeholder="Search" />
           </TextField>
-        </Dropdown>
+        </Dropdown>,
       );
       const input = screen.getByPlaceholderText('Search');
       expect(input).toBeInTheDocument();
@@ -47,7 +47,7 @@ describe('<Dropdown />', () => {
         render(
           <Dropdown options={mockOptions} inputPosition="outside">
             <Button>Trigger</Button>
-          </Dropdown>
+          </Dropdown>,
         );
         expect(screen.getByText('Trigger')).toBeInTheDocument();
       });
@@ -57,7 +57,7 @@ describe('<Dropdown />', () => {
         render(
           <Dropdown options={mockOptions} inputPosition="outside">
             <Button>Trigger</Button>
-          </Dropdown>
+          </Dropdown>,
         );
         const trigger = screen.getByText('Trigger');
         await user.click(trigger);
@@ -75,7 +75,7 @@ describe('<Dropdown />', () => {
             <TextField>
               <input placeholder="Search" />
             </TextField>
-          </Dropdown>
+          </Dropdown>,
         );
         const input = screen.getByPlaceholderText('Search');
         expect(input).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('<Dropdown />', () => {
             <TextField>
               <input placeholder="Search" />
             </TextField>
-          </Dropdown>
+          </Dropdown>,
         );
         const input = screen.getByPlaceholderText('Search');
         await user.click(input);
@@ -107,7 +107,7 @@ describe('<Dropdown />', () => {
               </TextField>
             </Dropdown>
             <button>Outside</button>
-          </div>
+          </div>,
         );
         const input = screen.getByPlaceholderText('Search');
         await user.click(input);
@@ -130,7 +130,7 @@ describe('<Dropdown />', () => {
       render(
         <Dropdown options={mockOptions} onOpen={onOpen} inputPosition="outside">
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -144,11 +144,15 @@ describe('<Dropdown />', () => {
       const onClose = jest.fn();
       render(
         <div>
-          <Dropdown options={mockOptions} onClose={onClose} inputPosition="outside">
+          <Dropdown
+            options={mockOptions}
+            onClose={onClose}
+            inputPosition="outside"
+          >
             <Button>Trigger</Button>
           </Dropdown>
           <button>Outside</button>
-        </div>
+        </div>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -168,9 +172,13 @@ describe('<Dropdown />', () => {
       const user = userEvent.setup();
       const onSelect = jest.fn();
       render(
-        <Dropdown options={mockOptions} onSelect={onSelect} inputPosition="outside">
+        <Dropdown
+          options={mockOptions}
+          onSelect={onSelect}
+          inputPosition="outside"
+        >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -186,13 +194,9 @@ describe('<Dropdown />', () => {
   describe('prop: activeIndex', () => {
     it('should use controlled activeIndex', () => {
       render(
-        <Dropdown
-          options={mockOptions}
-          activeIndex={1}
-          inputPosition="outside"
-        >
+        <Dropdown options={mockOptions} activeIndex={1} inputPosition="outside">
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       // Active index should be controlled
       expect(screen.getByText('Trigger')).toBeInTheDocument();
@@ -211,7 +215,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -236,7 +240,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -251,13 +255,9 @@ describe('<Dropdown />', () => {
     it('should use placement for popper', async () => {
       const user = userEvent.setup();
       render(
-        <Dropdown
-          options={mockOptions}
-          placement="top"
-          inputPosition="outside"
-        >
+        <Dropdown options={mockOptions} placement="top" inputPosition="outside">
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -278,7 +278,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -307,7 +307,7 @@ describe('<Dropdown />', () => {
               />
             )}
           </TextField>
-        </Dropdown>
+        </Dropdown>,
       );
       const input = screen.getByPlaceholderText('Search');
       await user.click(input);
@@ -338,7 +338,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -360,7 +360,7 @@ describe('<Dropdown />', () => {
       render(
         <Dropdown options={treeOptions} type="tree" inputPosition="outside">
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -391,7 +391,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       await user.click(screen.getByText('Trigger'));
       await waitFor(() => {
@@ -399,7 +399,9 @@ describe('<Dropdown />', () => {
       });
 
       await user.click(screen.getByText('Parent'));
-      expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }));
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ id: '1' }),
+      );
     });
   });
 
@@ -414,7 +416,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -436,7 +438,7 @@ describe('<Dropdown />', () => {
             <Button>Trigger</Button>
           </Dropdown>
           <button>Outside</button>
-        </div>
+        </div>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -457,7 +459,7 @@ describe('<Dropdown />', () => {
       render(
         <Dropdown options={mockOptions} inputPosition="outside">
           <Button ref={childRef}>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       // 驗證 ref 被正確設置
       expect(childRef.current).toBeInstanceOf(HTMLButtonElement);
@@ -470,7 +472,7 @@ describe('<Dropdown />', () => {
       render(
         <Dropdown options={mockOptions} inputPosition="outside">
           <Button onClick={handleClick}>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -497,7 +499,7 @@ describe('<Dropdown />', () => {
             </TextField>
           </Dropdown>
           <button>Outside</button>
-        </div>
+        </div>,
       );
       const input = screen.getByTestId('test-input');
       await user.click(input);
@@ -523,7 +525,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -546,7 +548,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -558,7 +560,9 @@ describe('<Dropdown />', () => {
       });
       // 驗證底部 loading 存在（通過查找 loading-more class）
       await waitFor(() => {
-        const loadingMore = document.querySelector('.mzn-dropdown-loading-more');
+        const loadingMore = document.querySelector(
+          '.mzn-dropdown-loading-more',
+        );
         expect(loadingMore).toBeInTheDocument();
         // 驗證底部 loading 中有 loading 文字
         expect(screen.getByText('Loading...')).toBeInTheDocument();
@@ -575,7 +579,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -588,7 +592,9 @@ describe('<Dropdown />', () => {
         );
         expect(fullStatus).not.toBeInTheDocument();
         // 應顯示底部 loading，避免空白狀態
-        const loadingMore = document.querySelector('.mzn-dropdown-loading-more');
+        const loadingMore = document.querySelector(
+          '.mzn-dropdown-loading-more',
+        );
         expect(loadingMore).toBeInTheDocument();
         expect(screen.getByText('Loading...')).toBeInTheDocument();
       });
@@ -597,13 +603,9 @@ describe('<Dropdown />', () => {
     it('should use full as default loadingPosition', async () => {
       const user = userEvent.setup();
       render(
-        <Dropdown
-          options={[]}
-          status="loading"
-          inputPosition="outside"
-        >
+        <Dropdown options={[]} status="loading" inputPosition="outside">
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);
@@ -625,7 +627,7 @@ describe('<Dropdown />', () => {
           inputPosition="outside"
         >
           <Button>Trigger</Button>
-        </Dropdown>
+        </Dropdown>,
       );
       const trigger = screen.getByText('Trigger');
       await user.click(trigger);

--- a/packages/react/src/Dropdown/Dropdown.tsx
+++ b/packages/react/src/Dropdown/Dropdown.tsx
@@ -34,35 +34,14 @@ import { InputProps } from '../Input';
 import Popper, { PopperPlacement } from '../Popper';
 import Translate, { TranslateFrom } from '../Transition/Translate';
 import { composeRefs } from '../utils/composeRefs';
+import { getElementRef, ReactElementWithRef } from '../utils/getElementRef';
 
 import { IconDefinition } from '@mezzanine-ui/icons';
 import DropdownItem from './DropdownItem';
 
-// Helper type to extract ref from a ReactElement.
-// Models `ref` on the element itself, which is compatible with React 18 and 19.
-type ReactElementWithRef<
-  P,
-  E extends Element = HTMLElement,
-> = ReactElement<P> & {
-  ref?: Ref<E>;
-};
-
 type TriggerElementProps = Partial<ButtonProps & InputProps> & {
   ref?: Ref<HTMLElement>;
 };
-
-/**
- * Extracts ref from a ReactElement, supporting both React 18 and 19.
- * In React 18, ref is on the element itself; in React 19, ref is in props.
- */
-function getElementRef<E extends Element = HTMLElement>(
-  element: ReactElementWithRef<unknown, E>,
-): Ref<E> | undefined {
-  // React 19: ref is in props
-  const propsRef = (element.props as { ref?: Ref<E> })?.ref;
-  // React 18: ref is on the element itself
-  return propsRef ?? element.ref;
-}
 
 export interface DropdownProps extends DropdownItemSharedProps {
   /**

--- a/packages/react/src/utils/getElementRef.spec.ts
+++ b/packages/react/src/utils/getElementRef.spec.ts
@@ -1,0 +1,133 @@
+import { createElement, createRef, Ref } from 'react';
+import { getElementRef, ReactElementWithRef } from './getElementRef';
+
+/**
+ * Builds a fake element shaped like a React 18 dev-mode element created
+ * with a ref: the actual ref lives on `element.ref`, and `props.ref` is a
+ * warning getter marked with `isReactWarning` (see
+ * `defineRefPropWarningGetter` in the React 18 source). Accessing it logs
+ * "`ref` is not a prop."
+ */
+function createReact18DevElementWithRef(
+  ref: Ref<HTMLElement>,
+  onWarningAccess: () => void,
+): ReactElementWithRef<unknown, HTMLElement> {
+  const props = {};
+  const warnAboutAccessingRef = () => {
+    onWarningAccess();
+    return undefined;
+  };
+  warnAboutAccessingRef.isReactWarning = true;
+  Object.defineProperty(props, 'ref', {
+    get: warnAboutAccessingRef,
+    configurable: true,
+  });
+
+  return { props, ref } as unknown as ReactElementWithRef<unknown, HTMLElement>;
+}
+
+/**
+ * Builds a fake element shaped like a React 19 dev-mode element created
+ * with a ref: the actual ref lives in `props.ref` as a regular property,
+ * and `element.ref` is a deprecation warning getter. Accessing it logs
+ * "Accessing element.ref was removed in React 19."
+ */
+function createReact19DevElementWithRef(
+  ref: Ref<HTMLElement>,
+  onWarningAccess: () => void,
+): ReactElementWithRef<unknown, HTMLElement> {
+  const props = { ref };
+  const element = { props };
+  const elementRefGetterWithDeprecationWarning = function getRef(
+    this: typeof element,
+  ) {
+    onWarningAccess();
+    return this.props.ref;
+  };
+  // React 19.0 does not mark this getter with `isReactWarning`, so model
+  // the worst case (no flag) — getElementRef must not read it anyway.
+  Object.defineProperty(element, 'ref', {
+    enumerable: false,
+    get: elementRefGetterWithDeprecationWarning,
+  });
+
+  return element as unknown as ReactElementWithRef<unknown, HTMLElement>;
+}
+
+describe('getElementRef()', () => {
+  describe('React 18 dev-mode element shape', () => {
+    it('should return element.ref without touching the props.ref warning getter', () => {
+      const ref = createRef<HTMLElement>();
+      const onWarningAccess = jest.fn();
+      const element = createReact18DevElementWithRef(ref, onWarningAccess);
+
+      expect(getElementRef(element)).toBe(ref);
+      expect(onWarningAccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('React 19 dev-mode element shape', () => {
+    it('should return props.ref without touching the element.ref deprecation getter', () => {
+      const ref = createRef<HTMLElement>();
+      const onWarningAccess = jest.fn();
+      const element = createReact19DevElementWithRef(ref, onWarningAccess);
+
+      expect(getElementRef(element)).toBe(ref);
+      expect(onWarningAccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('production-like element shapes (no warning getters)', () => {
+    it('should return props.ref when ref lives in props (React 19)', () => {
+      const ref = createRef<HTMLElement>();
+      const element = {
+        props: { ref },
+      } as unknown as ReactElementWithRef<unknown, HTMLElement>;
+
+      expect(getElementRef(element)).toBe(ref);
+    });
+
+    it('should return element.ref when ref lives on the element (React 18)', () => {
+      const ref = createRef<HTMLElement>();
+      const element = {
+        props: {},
+        ref,
+      } as unknown as ReactElementWithRef<unknown, HTMLElement>;
+
+      expect(getElementRef(element)).toBe(ref);
+    });
+  });
+
+  describe('with the installed React version', () => {
+    it('should extract the ref from a real element without logging any warning', () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      try {
+        const ref = createRef<HTMLButtonElement>();
+        const element = createElement('button', { ref });
+
+        expect(
+          getElementRef(
+            element as unknown as ReactElementWithRef<
+              unknown,
+              HTMLButtonElement
+            >,
+          ),
+        ).toBe(ref);
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('should return a nullish value for an element created without ref', () => {
+      const element = createElement('button');
+
+      expect(
+        getElementRef(
+          element as unknown as ReactElementWithRef<unknown, HTMLElement>,
+        ),
+      ).toBeFalsy();
+    });
+  });
+});

--- a/packages/react/src/utils/getElementRef.ts
+++ b/packages/react/src/utils/getElementRef.ts
@@ -1,0 +1,72 @@
+import { ReactElement, Ref } from 'react';
+
+/**
+ * Helper type to extract ref from a ReactElement.
+ * Models `ref` on the element itself, which is compatible with React 18 and 19.
+ */
+export type ReactElementWithRef<
+  P,
+  E extends Element = HTMLElement,
+> = ReactElement<P> & {
+  ref?: Ref<E>;
+};
+
+/**
+ * Whether the given property getter is a React dev-mode warning getter.
+ * React marks them with `isReactWarning = true`
+ * (see `defineRefPropWarningGetter` in the React source).
+ */
+function isReactWarningGetter(getter: unknown): boolean {
+  return (
+    typeof getter === 'function' &&
+    Boolean((getter as { isReactWarning?: boolean }).isReactWarning)
+  );
+}
+
+/**
+ * Extracts ref from a ReactElement, supporting both React 18 and 19.
+ * In React 18, ref is on the element itself; in React 19, ref is in props.
+ *
+ * Reading the "wrong" location in dev mode triggers React warning getters:
+ *
+ * - React 18 installs a warning getter on `props.ref` when the element was
+ *   created with a ref — accessing it logs
+ *   "`ref` is not a prop. Trying to access it will result in `undefined` being returned."
+ * - React 19 installs a deprecation getter on `element.ref` when the element
+ *   was created with a ref — accessing it logs
+ *   "Accessing element.ref was removed in React 19."
+ *
+ * So instead of unconditionally reading `props.ref` first, detect the
+ * dev-mode warning getters (marked with `isReactWarning`) and read the ref
+ * from the location where it actually lives. Same approach as
+ * `getElementRef` in radix-ui/primitives.
+ */
+export function getElementRef<E extends Element = HTMLElement>(
+  element: ReactElementWithRef<unknown, E>,
+): Ref<E> | undefined {
+  const props = element.props as { ref?: Ref<E> } | null | undefined;
+
+  // React 18 dev mode: `props.ref` is a warning getter; the actual ref
+  // lives on the element itself.
+  const propsRefGetter = props
+    ? Object.getOwnPropertyDescriptor(props, 'ref')?.get
+    : undefined;
+
+  if (isReactWarningGetter(propsRefGetter)) {
+    return element.ref;
+  }
+
+  // React 19 dev mode: `element.ref` may be a deprecation warning getter;
+  // the actual ref lives in props as a regular property.
+  const elementRefGetter = Object.getOwnPropertyDescriptor(element, 'ref')?.get;
+
+  if (isReactWarningGetter(elementRefGetter)) {
+    return props?.ref;
+  }
+
+  // No warning getters (production builds, or no ref was given):
+  // prefer `props.ref` (React 19), fall back to `element.ref` (React 18).
+  // Safe on React 19 dev — its `element.ref` deprecation getter is only
+  // installed when a ref exists, in which case `props.ref` is returned here.
+  return props?.ref ?? element.ref;
+}


### PR DESCRIPTION
# fix(react): avoid React 18 `ref is not a prop` warning when Dropdown reads child ref

## ⚠️ 根因聲明：不是 forwardRef 問題

乍看像「Dropdown 沒用 forwardRef、ref 用 prop 傳遞」的問題，實際調查結果：**Dropdown 本身不接收外部 ref，不需要 forwardRef**。真正根因是 Dropdown 內部 `getElementRef()`（讀取 child element 的 ref 以便 `composeRefs` 與 `anchorRef` 合併）**先讀 `element.props.ref`**，在 React 18 dev mode 踩到 React 的警告 getter。本 PR 修的是 ref 讀取方式，不是 forwardRef。

## 問題

在 **React 18** dev mode 下（實測環境：a production Next.js app on react@18.3.1），任何 `Select`／`AutoComplete`（或直接使用 `<Dropdown>` 且 child 帶 ref）都會在 console 噴：

```
Warning: SelectTrigger: `ref` is not a prop. Trying to access it will result
in `undefined` being returned. If you need to access the same value within
the child component, you should pass it as a different prop.
    at Dropdown (…/@mezzanine-ui/react/Dropdown/Dropdown.js:92:26)
    at Select (…)
```

- 警告**每頁只出現一次**（React 內部 `specialPropRefWarningShown` 全域旗標）——matches the single-warning-per-page behaviour observed in a downstream React 18 app。
- **功能不受影響**（警告 getter 回傳 `undefined` 後 fallback 到 `element.ref` 拿到正確 ref），屬良性但污染 console、嚇唬下游開發者。
- React 19 consumer 不受影響（`props.ref` 在 19 是一般 data property）；上游 repo 自身測試環境是 React 19.2，所以 CI 不會抓到。
- prod build 不顯示（警告 getter 只在 dev 安裝）。

## 重現

React 18 專案 dev mode 下渲染任一 `<Select>`（或 `<Dropdown>{<Button ref={r}>…</Button>}</Dropdown>`）→ console 出現上述警告，stack 指向 `Dropdown.js` 的 `getElementRef`。

## 根因

`packages/react/src/Dropdown/Dropdown.tsx` 的 helper：

```ts
function getElementRef(element) {
  // React 19: ref is in props
  const propsRef = (element.props as { ref?: Ref<E> })?.ref; // ← React 18 dev 在這裡觸發警告
  // React 18: ref is on the element itself
  return propsRef ?? element.ref;
}
```

React 18 的 `createElement` 在 dev mode 下，**只要 element 建立時帶 ref**，就會在 `props.ref` 安裝警告 getter（`defineRefPropWarningGetter`，源碼實證 react@18.3.1 `react.development.js:683` `warnAboutAccessingRef.isReactWarning = true`）。`Select` 永遠對 child `SelectTrigger` 掛 `ref={composedRef}`，所以 React 18 下必中。

React 19 對稱地在 `element.ref` 安裝棄用警告 getter（`elementRefGetterWithDeprecationWarning`，react@19.2.0 實證：**只在有 ref 時**安裝；無 ref 時 `element.ref` 是 plain `null`）——所以「先讀 props 再 fallback element.ref」在 19 安全、在 18 必噴；反過來寫則 18 安全、19 必噴。**唯一雙版本安全的方式是偵測警告 getter**。

## 修法

偵測 React dev-mode 警告 getter 的 `isReactWarning` 旗標，從 ref 實際所在位置讀取——與 radix-ui/primitives 的 `getElementRef` 同手法（MUI `getReactElementRef` 為等效的版本偵測法）：

```ts
export function getElementRef<E extends Element = HTMLElement>(
  element: ReactElementWithRef<unknown, E>,
): Ref<E> | undefined {
  const props = element.props as { ref?: Ref<E> } | null | undefined;

  // React 18 dev mode: `props.ref` is a warning getter; the actual ref
  // lives on the element itself.
  const propsRefGetter = props
    ? Object.getOwnPropertyDescriptor(props, 'ref')?.get
    : undefined;

  if (isReactWarningGetter(propsRefGetter)) {
    return element.ref;
  }

  // React 19 dev mode: `element.ref` may be a deprecation warning getter;
  // the actual ref lives in props as a regular property.
  const elementRefGetter = Object.getOwnPropertyDescriptor(element, 'ref')?.get;

  if (isReactWarningGetter(elementRefGetter)) {
    return props?.ref;
  }

  // No warning getters (production builds, or no ref was given):
  // prefer `props.ref` (React 19), fall back to `element.ref` (React 18).
  return props?.ref ?? element.ref;
}
```

行為矩陣（皆實證於單元測試）：

| 環境 | child 有 ref | 讀取路徑 | 警告 |
|------|------|----------|------|
| React 18 dev | 有 | 偵測到 `props.ref` 警告 getter → 讀 `element.ref` | 無（修正前：噴） |
| React 18 dev | 無 | fallback：`props.ref` 不存在 → `element.ref`(null) | 無 |
| React 19 dev | 有 | fallback：`props.ref` 為一般屬性直接命中，不碰 `element.ref` | 無 |
| React 19 dev | 無 | fallback：`element.ref` 是 plain `null`（19 只在有 ref 時裝 getter） | 無 |
| 18/19 prod | — | 一般屬性讀取 | 無 |

### 變更內容

| 檔案 | 變更 |
|------|------|
| `packages/react/src/utils/getElementRef.ts` | **新增**：helper 移出 Dropdown 成獨立 util（同 `composeRefs` 慣例），含 `isReactWarningGetter` 偵測與完整 JSDoc |
| `packages/react/src/Dropdown/Dropdown.tsx` | 移除本地 helper／型別，改 import util（功能等價、僅讀取順序修正） |
| `packages/react/src/utils/getElementRef.spec.ts` | **新增** 6 測試：React 18 dev shape（警告 getter 不被觸碰＋回傳正確 ref）、React 19 dev shape（棄用 getter 不被觸碰）、18/19 production shape、安裝版 React 真實 element 零 console.error、無 ref 回傳 nullish |
| `packages/react/src/Dropdown/Dropdown.spec.tsx` | **新增** 1 回歸測試：child 帶 ref 渲染時零 console.error；其餘 100 行為既有 prettier drift（已拆成獨立 style commit `aae47f0`，fix commit `cfef09b` 對此檔僅 +18） |

> commit 拆分：`aae47f0` = 純 prettier 格式化（repo 的 lint-staged pre-commit 對 staged tsx 強制 `prettier --write`，整檔重排無法避免，故獨立成 style commit 保持 fix commit 可讀）；`cfef09b` = 修正本體。

## 驗證

1. **單元測試**：`nx run @mezzanine-ui/react:test` 全綠 — **174 suites / 3044 tests**（含新增 7 測試）。
2. **Build**：`nx run @mezzanine-ui/react:build` 成功（僅既有 Tag/Table 循環依賴警告，與本修無關）。
3. **ESLint**：4 個變更檔 0 error。
4. **Real-app before/after（a downstream Next.js app，react@18.3.1，dist-patch 法）**：
   - **Before**（已發版 1.3.0 原樣）：an internal component showcase page 的 console 出現 `ref is not a prop` 警告，stack 指向 `Dropdown.js:92`（via a Select wrapper）。
   - **After**（灌入本 branch build 的 `dist/Dropdown/Dropdown.js`＋`dist/utils/getElementRef.js`、清 `.next` cache 重啟）：警告**消失**；console 僅餘與本修無關的既有項目（1 個 404 資源、a11y label issues——baseline 同樣存在）。
   - **功能回歸**：Select 點擊展開（Popper portal 定位正常 = `anchorRef` 組合有效）、選取選項成功、互動後 console 零新增錯誤。
   - 驗畢已還原：強制重抽 `@mezzanine-ui/react`（`rm -rf node_modules/@mezzanine-ui/react && npm i`，注：npm 同版本不重抽，需先刪包目錄）、確認 dist 回到已發版 1.3.0、smoke `curl :3100` = 200 後關閉 dev server。
5. **新 build dist 與已發版 1.3.0 dist 逐檔 diff**：除本修（import util＋移除舊 helper）外**零差異**，確認 repo main = 1.3.0 tag、dist-patch 驗證有效。

## 影響範圍

- 僅 dev-mode console 行為；runtime 邏輯（ref 解析結果）在所有矩陣組合下與修正前相同。
- 不改任何 public API；`getElementRef` 為內部 util（`src/utils/` 無 barrel export）。
- React 18 與 19 consumer 皆受益；上游若日後升 peer 至 19-only 此修法仍正確。
