### PR TITLE
feat(select): enable dropdown menu flip when overflowing the viewport (React + Angular)

### DIFF
--- a/packages/ng/_internal/input-trigger-popper/input-trigger-popper.component.spec.ts
+++ b/packages/ng/_internal/input-trigger-popper/input-trigger-popper.component.spec.ts
@@ -11,6 +11,7 @@ import { MznInputTriggerPopper } from './input-trigger-popper.component';
       [anchor]="anchorEl()"
       [open]="open"
       [sameWidth]="sameWidth"
+      [flip]="flip"
     >
       <div class="dropdown-content">Options</div>
     </mzn-input-trigger-popper>
@@ -20,10 +21,13 @@ class TestHostComponent {
   readonly anchorEl = viewChild.required<ElementRef<HTMLElement>>('anchor');
   open = false;
   sameWidth = false;
+  flip = false;
 }
 
 function createFixture(
-  overrides: Partial<Pick<TestHostComponent, 'open' | 'sameWidth'>> = {},
+  overrides: Partial<
+    Pick<TestHostComponent, 'open' | 'sameWidth' | 'flip'>
+  > = {},
 ): {
   fixture: ReturnType<typeof TestBed.createComponent<TestHostComponent>>;
   host: TestHostComponent;
@@ -62,6 +66,12 @@ describe('MznInputTriggerPopper', () => {
 
   it('should render content', () => {
     const { getHostElement } = createFixture({ open: true });
+
+    expect(getHostElement().querySelector('.dropdown-content')).toBeTruthy();
+  });
+
+  it('should render content when flip is enabled', () => {
+    const { getHostElement } = createFixture({ open: true, flip: true });
 
     expect(getHostElement().querySelector('.dropdown-content')).toBeTruthy();
   });

--- a/packages/ng/_internal/input-trigger-popper/input-trigger-popper.component.ts
+++ b/packages/ng/_internal/input-trigger-popper/input-trigger-popper.component.ts
@@ -5,6 +5,7 @@ import {
   effect,
   ElementRef,
   input,
+  output,
   signal,
   viewChild,
 } from '@angular/core';
@@ -46,6 +47,7 @@ let popperOpenSequence = 0;
     '(touchmove)': '$event.stopPropagation()',
     '(touchend)': '$event.stopPropagation()',
     '[attr.anchor]': 'null',
+    '[attr.flip]': 'null',
     '[attr.globalPortal]': 'null',
     '[attr.open]': 'null',
     '[attr.sameWidth]': 'null',
@@ -56,11 +58,13 @@ let popperOpenSequence = 0;
         #popperEl
         mznPopper
         [anchor]="anchor()"
+        [disableFlip]="!flip()"
         [open]="open()"
         [placement]="placement"
         [offsetOptions]="offsetOpts"
         [middleware]="resolvedMiddleware()"
         [style.z-index]="zIndex()"
+        (positionUpdated)="placementChange.emit($event)"
       >
         <ng-content />
       </div>
@@ -83,6 +87,13 @@ export class MznInputTriggerPopper {
   readonly globalPortal = input(true);
 
   /**
+   * 是否啟用 floating-ui `flip` middleware。設為 `true` 時,當浮層於下方空間
+   * 不足會沿主軸自動翻轉到對側。預設關閉,維持固定 `bottom-start` 定位。
+   * @default false
+   */
+  readonly flip = input(false);
+
+  /**
    * 是否顯示。
    * @default false
    */
@@ -100,6 +111,12 @@ export class MznInputTriggerPopper {
    * 被誤判為 click-outside 而關閉元件。
    */
   readonly popperElRef = viewChild<ElementRef<HTMLElement>>('popperEl');
+
+  /**
+   * 轉發內層 MznPopper 解析(含 flip 翻轉)後的實際 placement,供父元件
+   * (如 Select)調整進場動畫方向。
+   */
+  readonly placementChange = output<PopperPlacement>();
 
   protected readonly hostClass = classes.host;
   protected readonly placement: PopperPlacement = 'bottom-start';

--- a/packages/ng/dropdown/dropdown.component.spec.ts
+++ b/packages/ng/dropdown/dropdown.component.spec.ts
@@ -21,6 +21,7 @@ const MOCK_OPTIONS: DropdownOption[] = [
       [options]="options"
       [value]="value"
       [disableClickAway]="true"
+      [flip]="flip"
       (selected)="onSelect($event)"
       (closed)="open = false"
     />
@@ -31,6 +32,7 @@ class TestHostComponent {
   open = false;
   options = MOCK_OPTIONS;
   value = '';
+  flip = false;
   lastSelected: DropdownOption | null = null;
 
   onSelect(option: DropdownOption): void {
@@ -68,6 +70,20 @@ describe('MznDropdown', () => {
     const { fixture, host } = createFixture(TestHostComponent);
 
     host.open = true;
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('[role="option"]');
+
+    expect(items.length).toBe(3);
+  });
+
+  it('should render options when open and flip is enabled', () => {
+    const { fixture, host } = createFixture(TestHostComponent);
+
+    host.open = true;
+    host.flip = true;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     fixture.detectChanges();

--- a/packages/ng/dropdown/dropdown.component.ts
+++ b/packages/ng/dropdown/dropdown.component.ts
@@ -230,12 +230,13 @@ export interface DropdownActionConfig {
           data-mzn-dropdown-popper="true"
           [anchor]="anchor()!"
           [class]="popperWithPortalClass()"
-          [disableFlip]="true"
+          [disableFlip]="!flip()"
           [open]="popperOpen()"
           [placement]="resolvedPlacement()"
           [offsetOptions]="{ mainAxis: 4 }"
           [middleware]="popperMiddleware()"
           [style.z-index]="resolvedZIndex()"
+          (positionUpdated)="onPositionUpdated($event)"
         >
           <div
             mznTranslate
@@ -440,6 +441,15 @@ export class MznDropdown {
   readonly placement = input<Placement>('bottom-start');
 
   /**
+   * 是否啟用 floating-ui `flip` middleware。設為 `true` 時,當選單於下方空間
+   * 不足會沿主軸自動翻轉到對側(例如 `bottom-start` → `top-start`),且進場
+   * 動畫方向會跟隨實際翻轉後的 placement。預設關閉以保留既有 placement 行為。
+   * 鏡像 React `Dropdown` 的 `flip` prop。
+   * @default false
+   */
+  readonly flip = input(false);
+
+  /**
    * 是否在操作區頂部顯示分隔線。
    * @default false
    */
@@ -587,10 +597,24 @@ export class MznDropdown {
   protected readonly translateFrom = computed((): 'top' | 'bottom' => {
     if (this.inputPosition() === 'inside') return 'bottom';
 
-    const placementBase = this.resolvedPlacement().split('-')[0];
+    // 啟用 flip 時跟隨 floating-ui 實際翻轉後的 placement,讓進場動畫從正確
+    // 的方向滑入;未啟用時維持靜態 placement,保留既有 consumer 行為。
+    const placementBase = (
+      this.flip() ? this.flippedPlacement() : this.resolvedPlacement()
+    ).split('-')[0];
 
     return placementBase === 'top' ? 'top' : 'bottom';
   });
+
+  /**
+   * floating-ui 實際解析(含 flip 翻轉)後的 placement,僅在 `flip` 啟用時用於
+   * 決定進場動畫方向。由 MznPopper 的 `positionUpdated` 輸出驅動。
+   */
+  private readonly flippedPlacement = signal<Placement>('bottom-start');
+
+  protected onPositionUpdated(placement: Placement): void {
+    this.flippedPlacement.set(placement);
+  }
 
   /**
    * Build the unified DropdownActionProps passed to MznDropdownItem.

--- a/packages/ng/select/select.component.spec.ts
+++ b/packages/ng/select/select.component.spec.ts
@@ -18,6 +18,7 @@ const MOCK_OPTIONS: DropdownOption[] = [
     <mzn-select
       [options]="options"
       [(ngModel)]="selected"
+      [flip]="flip"
       placeholder="Choose"
     />
   `,
@@ -25,6 +26,7 @@ const MOCK_OPTIONS: DropdownOption[] = [
 class TestHostComponent {
   options = MOCK_OPTIONS;
   selected = '';
+  flip = false;
 }
 
 function createFixture<T>(component: new () => T): {
@@ -85,6 +87,22 @@ describe('MznSelect', () => {
     const items = fixture.nativeElement.querySelectorAll('[role="option"]');
 
     expect(items.length).toBe(3);
+  });
+
+  it('should open dropdown when flip is enabled', () => {
+    const { fixture, host } = createFixture(TestHostComponent);
+    host.flip = true;
+    fixture.detectChanges();
+
+    const trigger = fixture.nativeElement.querySelector('.mzn-select-trigger');
+
+    trigger.click();
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const listbox = fixture.nativeElement.querySelector('[role="listbox"]');
+
+    expect(listbox).toBeTruthy();
   });
 
   it('should select option and close', async () => {

--- a/packages/ng/select/select.component.ts
+++ b/packages/ng/select/select.component.ts
@@ -146,11 +146,13 @@ interface FlatOption {
       #triggerPopper
       mznInputTriggerPopper
       [anchor]="triggerElRef()!"
+      [flip]="flip()"
       [open]="isOpen()"
       [sameWidth]="true"
       [globalPortal]="globalPortal()"
+      (placementChange)="onPlacementChange($event)"
     >
-      <div mznTranslate [in]="isOpen()" from="top">
+      <div mznTranslate [in]="isOpen()" [from]="translateFrom()">
         <ul
           [class]="listClass"
           [style.max-height.px]="menuMaxHeight()"
@@ -251,6 +253,13 @@ export class MznSelect implements ControlValueAccessor {
   /** 是否啟用全域 Portal。 */
   readonly globalPortal = input(true);
 
+  /**
+   * 空間不足時下拉選單是否自動向上翻轉(沿主軸 flip,保持與輸入框同寬與水平
+   * 對齊),並讓進場動畫方向跟隨翻轉後的位置。鏡像 React `Select` 的 `flip` prop。
+   * @default false
+   */
+  readonly flip = input(false);
+
   /** 下拉選單 Z軸層級。 */
   readonly dropdownZIndex = input<number>();
 
@@ -286,6 +295,30 @@ export class MznSelect implements ControlValueAccessor {
   protected readonly loadingIcon = SpinnerIcon;
 
   protected readonly isOpen = signal(false);
+
+  /**
+   * MznInputTriggerPopper 內層 popper 解析(含 flip 翻轉)後的實際 placement,
+   * 僅在 flip 啟用時用於決定進場動畫方向。
+   */
+  private readonly menuPlacement = signal<string>('bottom-start');
+
+  /**
+   * mznTranslate 的 from 方向:
+   * - 未啟用 flip → 維持 'top'(選單在下方,由上往下滑入,既有行為)。
+   * - 啟用 flip 且實際翻轉到上方 → 'bottom'(選單在上方,由下往上浮現)。
+   */
+  protected readonly translateFrom = computed((): 'top' | 'bottom' => {
+    if (!this.flip()) return 'top';
+
+    const placementBase = this.menuPlacement().split('-')[0];
+
+    return placementBase === 'top' ? 'bottom' : 'top';
+  });
+
+  protected onPlacementChange(placement: string): void {
+    this.menuPlacement.set(placement);
+  }
+
   private readonly internalValue = signal<ReadonlyArray<string>>([]);
   private readonly expandedNodes = signal<ReadonlySet<string>>(new Set());
   private wasAtBottom = false;

--- a/packages/ng/select/select.stories.ts
+++ b/packages/ng/select/select.stories.ts
@@ -28,6 +28,12 @@ export default {
       description: '是否為錯誤狀態',
       table: { defaultValue: { summary: 'false' } },
     },
+    flip: {
+      control: { type: 'boolean' },
+      description:
+        '空間不足時下拉選單是否自動向上翻轉（沿主軸 flip，保持與輸入框同寬與水平對齊）',
+      table: { defaultValue: { summary: 'false' } },
+    },
     fullWidth: {
       control: { type: 'boolean' },
       description: '是否撐滿父容器寬度',
@@ -411,5 +417,25 @@ export const WithTree: Story = {
   ],
   render: () => ({
     template: `<story-select-with-tree />`,
+  }),
+};
+
+export const WithFlip: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => ({
+    props: {
+      options: simpleOptions,
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 8px; justify-content: flex-end; min-height: calc(100vh - 48px); max-width: 300px;">
+        <p mznTypography variant="body">flip = true：靠近視窗底部，開啟時自動向上翻轉</p>
+        <div mznSelect
+          [flip]="true"
+          [fullWidth]="true"
+          [options]="options"
+          placeholder="請選擇"
+        ></div>
+      </div>
+    `,
   }),
 };

--- a/packages/react/src/Dropdown/Dropdown.spec.tsx
+++ b/packages/react/src/Dropdown/Dropdown.spec.tsx
@@ -268,6 +268,23 @@ describe('<Dropdown />', () => {
     });
   });
 
+  describe('prop: flip', () => {
+    it('should render popper when flip is enabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <Dropdown options={mockOptions} flip inputPosition="outside">
+          <Button>Trigger</Button>
+        </Dropdown>,
+      );
+      const trigger = screen.getByText('Trigger');
+      await user.click(trigger);
+      await waitFor(() => {
+        const popper = getPopperContainer();
+        expect(popper).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('prop: sameWidth', () => {
     it('should apply sameWidth middleware', async () => {
       const user = userEvent.setup();

--- a/packages/react/src/Dropdown/Dropdown.tsx
+++ b/packages/react/src/Dropdown/Dropdown.tsx
@@ -185,8 +185,12 @@ export interface DropdownProps extends DropdownItemSharedProps {
   sameWidth?: boolean;
   /**
    * Whether to enable floating-ui `flip` middleware.
-   * When `true`, the dropdown automatically flips to the opposite side
-   * (e.g. `bottom-start` → `top-start`) if it would overflow the viewport.
+   * When `true`, the dropdown automatically flips to the opposite side along
+   * the main axis (e.g. `bottom-start` → `top-start`) if it would overflow the
+   * viewport, and the enter transition slides from the resolved side. The flip
+   * is main-axis only (no `shift`/`crossAxis`), so a `sameWidth` menu stays
+   * horizontally aligned with its anchor — matching the `InputTriggerPopper`
+   * behavior used by the DatePicker/TimePicker menus.
    * Off by default to preserve existing placement behavior across consumers.
    * @default false
    */
@@ -520,6 +524,11 @@ export default function Dropdown(props: DropdownProps) {
     return 'bottom';
   }, [inputPosition, placement]);
 
+  // Tracks the placement actually resolved by floating-ui. Only meaningful when
+  // `flip` is enabled, where it may differ from `popoverPlacement` after a flip.
+  const [resolvedPlacement, setResolvedPlacement] =
+    useState<PopperPlacement>(popoverPlacement);
+
   const customWidthMiddleware = useMemo(() => {
     if (!customWidth) {
       return null;
@@ -561,8 +570,11 @@ export default function Dropdown(props: DropdownProps) {
   const flipMiddleware = useMemo(() => {
     if (!flip) return null;
 
+    // Main-axis flip only (bottom <-> top), aligned with `InputTriggerPopper`.
+    // No `shift`/`crossAxis` so a sameWidth menu keeps its horizontal alignment
+    // with the anchor instead of being pushed sideways.
     return flipMiddlewareFn({
-      fallbackStrategy: 'bestFit',
+      fallbackAxisSideDirection: 'end',
       padding: 8,
     });
   }, [flip]);
@@ -596,9 +608,14 @@ export default function Dropdown(props: DropdownProps) {
       return 'bottom';
     }
 
-    const placementBase = popoverPlacement.split('-')[0];
+    // When flip is enabled, follow the placement resolved by floating-ui so the
+    // enter transition slides from the correct side after a flip. Otherwise keep
+    // the static placement to preserve existing behavior for non-flip consumers.
+    const placementBase = (flip ? resolvedPlacement : popoverPlacement).split(
+      '-',
+    )[0];
     return placementBase === 'top' ? 'top' : 'bottom';
-  }, [isInline, popoverPlacement]);
+  }, [flip, isInline, popoverPlacement, resolvedPlacement]);
 
   const setOpen = useCallback(
     (next: boolean | ((prev: boolean) => boolean)) => {
@@ -1015,6 +1032,7 @@ export default function Dropdown(props: DropdownProps) {
           anchor={anchorRef}
           className={dropdownClasses.popperWithPortal}
           controllerRef={popperControllerRef}
+          onPlacementChange={setResolvedPlacement}
           open={isOpen}
           disablePortal={!globalPortal}
           options={{

--- a/packages/react/src/Popper/Popper.spec.tsx
+++ b/packages/react/src/Popper/Popper.spec.tsx
@@ -97,6 +97,27 @@ describe('<Popper />', () => {
     });
   });
 
+  describe('prop: onPlacementChange', () => {
+    it('should be called with the resolved placement when open', async () => {
+      const onPlacementChange = jest.fn();
+
+      await act(async () => {
+        await render(
+          <Popper
+            anchor={document.body}
+            open
+            onPlacementChange={onPlacementChange}
+            options={{ placement: 'top-start' }}
+          >
+            <div />
+          </Popper>,
+        );
+      });
+
+      expect(onPlacementChange).toHaveBeenCalledWith('top-start');
+    });
+  });
+
   describe('prop: options', () => {
     describe('middleware', () => {
       it('should pass middleware to useFloating', async () => {

--- a/packages/react/src/Popper/Popper.tsx
+++ b/packages/react/src/Popper/Popper.tsx
@@ -48,6 +48,13 @@ export interface PopperProps
    */
   controllerRef?: Ref<PopperController>;
   /**
+   * Callback fired whenever the resolved placement changes, including when
+   * floating-ui middleware (e.g. `flip`) flips the popper to the opposite
+   * side. Receives the actual placement after all middleware run, which may
+   * differ from `options.placement`.
+   */
+  onPlacementChange?: (placement: PopperPlacement) => void;
+  /**
    * The portal element will show if open=true
    * @default false
    */
@@ -67,6 +74,7 @@ const Popper = forwardRef<HTMLDivElement, PopperProps>(
       container,
       controllerRef,
       disablePortal,
+      onPlacementChange,
       open = false,
       options,
       style,
@@ -108,6 +116,12 @@ const Popper = forwardRef<HTMLDivElement, PopperProps>(
         update();
       }
     }, [open, update]);
+
+    // Notify consumers of the resolved placement so they can react to
+    // middleware-driven flips (e.g. adjusting enter-transition direction).
+    useEffect(() => {
+      onPlacementChange?.(floatingReturn.placement);
+    }, [floatingReturn.placement, onPlacementChange]);
 
     // 計算箭頭的位置和旋轉角度
     const arrowX = floatingReturn.middlewareData.arrow?.x;

--- a/packages/react/src/Select/Select.spec.tsx
+++ b/packages/react/src/Select/Select.spec.tsx
@@ -3,7 +3,13 @@
 import { DropdownOption } from '@mezzanine-ui/core/dropdown/dropdown';
 import { PlusIcon } from '@mezzanine-ui/icons';
 import { createRef, RefObject } from 'react';
-import { act, cleanupHook, fireEvent, render, waitFor } from '../../__test-utils__';
+import {
+  act,
+  cleanupHook,
+  fireEvent,
+  render,
+  waitFor,
+} from '../../__test-utils__';
 import { describeForwardRefToHTMLElement } from '../../__test-utils__/common';
 import Icon from '../Icon';
 import Select from './Select';
@@ -12,9 +18,9 @@ import { SelectValue } from './typings';
 // Mock ResizeObserver - jsdom 不支援此 API
 const originalResizeObserver = (global as typeof globalThis).ResizeObserver;
 class ResizeObserverMock {
-  observe() { }
-  unobserve() { }
-  disconnect() { }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
 }
 
 beforeAll(() => {
@@ -78,17 +84,38 @@ describe('<Select />', () => {
       const { getHostHTMLElement } = render(<Select />);
       const element = getHostHTMLElement();
 
-      expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeNull();
+      expect(
+        document.querySelector('.mzn-dropdown-popper--with-portal'),
+      ).toBeNull();
 
       await testTextFieldClicked(element);
 
       await waitFor(() => {
-        expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeInstanceOf(
-          HTMLDivElement,
-        );
+        expect(
+          document.querySelector('.mzn-dropdown-popper--with-portal'),
+        ).toBeInstanceOf(HTMLDivElement);
         expect(document.querySelector('.mzn-dropdown-list')).toBeInstanceOf(
           HTMLUListElement,
         );
+      });
+    });
+  });
+
+  describe('prop: flip', () => {
+    it('should open dropdown and forward flip to the underlying Dropdown', async () => {
+      const { getHostHTMLElement } = render(<Select flip />);
+      const element = getHostHTMLElement();
+
+      await testTextFieldClicked(element);
+
+      await waitFor(() => {
+        const popper = document.querySelector(
+          '.mzn-dropdown-popper--with-portal',
+        );
+        expect(popper).toBeInstanceOf(HTMLDivElement);
+        expect(
+          (popper as HTMLElement).hasAttribute('data-popper-placement'),
+        ).toBe(true);
       });
     });
   });
@@ -266,9 +293,7 @@ describe('<Select />', () => {
 
   describe('mode: single', () => {
     const defaultValue: SelectValue = { id: '1', name: 'foo' };
-    const singleOptions: DropdownOption[] = [
-      { id: '1', name: 'foo' },
-    ];
+    const singleOptions: DropdownOption[] = [{ id: '1', name: 'foo' }];
 
     let element: HTMLElement;
     const onChange = jest.fn();
@@ -316,7 +341,9 @@ describe('<Select />', () => {
       });
 
       await waitFor(() => {
-        expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeNull();
+        expect(
+          document.querySelector('.mzn-dropdown-popper--with-portal'),
+        ).toBeNull();
       });
     });
 
@@ -372,16 +399,24 @@ describe('<Select />', () => {
 
     it('should remove tag when close icon is clicked', async () => {
       // Wait for tags to render and ResizeObserver to complete
-      await waitFor(() => {
-        const tags = element.querySelector('.mzn-select-trigger__tags');
-        expect(tags).toBeTruthy();
-        expect(tags?.children.length).toBeGreaterThan(0);
-      }, { timeout: 5000 });
+      await waitFor(
+        () => {
+          const tags = element.querySelector('.mzn-select-trigger__tags');
+          expect(tags).toBeTruthy();
+          expect(tags?.children.length).toBeGreaterThan(0);
+        },
+        { timeout: 5000 },
+      );
 
-      await waitFor(() => {
-        const tagCloseIcons = element.querySelectorAll('.mzn-tag__close-button');
-        expect(tagCloseIcons.length).toBeGreaterThan(0);
-      }, { timeout: 5000 });
+      await waitFor(
+        () => {
+          const tagCloseIcons = element.querySelectorAll(
+            '.mzn-tag__close-button',
+          );
+          expect(tagCloseIcons.length).toBeGreaterThan(0);
+        },
+        { timeout: 5000 },
+      );
 
       const tagCloseIcons = element.querySelectorAll('.mzn-tag__close-button');
 
@@ -440,7 +475,9 @@ describe('<Select />', () => {
       });
 
       await waitFor(() => {
-        expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeTruthy();
+        expect(
+          document.querySelector('.mzn-dropdown-popper--with-portal'),
+        ).toBeTruthy();
       });
     });
   });
@@ -487,21 +524,32 @@ describe('<Select />', () => {
       const element = getHostHTMLElement();
 
       // Wait for tags to render and ResizeObserver to complete
-      await waitFor(() => {
-        const tags = element.querySelector('.mzn-select-trigger__tags');
-        expect(tags).toBeTruthy();
-      }, { timeout: 5000 });
+      await waitFor(
+        () => {
+          const tags = element.querySelector('.mzn-select-trigger__tags');
+          expect(tags).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
 
       // In multiple mode, clearable shows when value array is not empty
-      await waitFor(() => {
-        const textField = element.querySelector('.mzn-text-field--clearable');
-        expect(textField).toBeTruthy();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          const textField = element.querySelector('.mzn-text-field--clearable');
+          expect(textField).toBeTruthy();
+        },
+        { timeout: 3000 },
+      );
 
-      await waitFor(() => {
-        const clearIcon = element.querySelector('.mzn-text-field__clear-icon');
-        expect(clearIcon).toBeTruthy();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          const clearIcon = element.querySelector(
+            '.mzn-text-field__clear-icon',
+          );
+          expect(clearIcon).toBeTruthy();
+        },
+        { timeout: 3000 },
+      );
 
       const clearIcon = element.querySelector('.mzn-text-field__clear-icon');
 
@@ -524,7 +572,9 @@ describe('<Select />', () => {
 
       await testTextFieldClicked(element);
 
-      expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeNull();
+      expect(
+        document.querySelector('.mzn-dropdown-popper--with-portal'),
+      ).toBeNull();
     });
 
     it('should not open dropdown via keyboard when readOnly is true', async () => {
@@ -541,7 +591,9 @@ describe('<Select />', () => {
       });
 
       expect(onFocus).toHaveBeenCalledTimes(0);
-      expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeNull();
+      expect(
+        document.querySelector('.mzn-dropdown-popper--with-portal'),
+      ).toBeNull();
     });
   });
 
@@ -578,9 +630,7 @@ describe('<Select />', () => {
     });
 
     it('should render only options from options prop', async () => {
-      const { getHostHTMLElement } = render(
-        <Select options={flatOptions} />,
-      );
+      const { getHostHTMLElement } = render(<Select options={flatOptions} />);
       const element = getHostHTMLElement();
 
       await testTextFieldClicked(element);
@@ -750,7 +800,9 @@ describe('<Select />', () => {
       await testTextFieldClicked(element);
 
       await waitFor(() => {
-        expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeTruthy();
+        expect(
+          document.querySelector('.mzn-dropdown-popper--with-portal'),
+        ).toBeTruthy();
       });
 
       await waitFor(() => {
@@ -764,7 +816,9 @@ describe('<Select />', () => {
       await waitFor(() => {
         expect(onChange).toHaveBeenCalled();
         const calledWith = onChange.mock.calls[0][0] as SelectValue[];
-        expect(calledWith.find((v) => String(v.id) === 'parent')).toBeUndefined();
+        expect(
+          calledWith.find((v) => String(v.id) === 'parent'),
+        ).toBeUndefined();
         expect(calledWith.find((v) => String(v.id) === 'leaf-a')).toBeDefined();
         expect(calledWith.find((v) => String(v.id) === 'leaf-b')).toBeDefined();
       });
@@ -789,7 +843,9 @@ describe('<Select />', () => {
       await testTextFieldClicked(element);
 
       await waitFor(() => {
-        expect(document.querySelector('.mzn-dropdown-popper--with-portal')).toBeTruthy();
+        expect(
+          document.querySelector('.mzn-dropdown-popper--with-portal'),
+        ).toBeTruthy();
       });
 
       await waitFor(() => {

--- a/packages/react/src/Select/Select.stories.tsx
+++ b/packages/react/src/Select/Select.stories.tsx
@@ -23,6 +23,12 @@ export default {
       description: '是否為錯誤狀態',
       table: { defaultValue: { summary: 'false' } },
     },
+    flip: {
+      control: { type: 'boolean' },
+      description:
+        '空間不足時下拉選單是否自動向上翻轉（沿主軸 flip，保持與輸入框同寬與水平對齊）',
+      table: { defaultValue: { summary: 'false' } },
+    },
     fullWidth: {
       control: { type: 'boolean' },
       description: '是否撐滿父容器寬度',
@@ -428,4 +434,35 @@ const WithTreeComponent = () => {
 
 export const WithTree: StoryObj<typeof Select> = {
   render: () => <WithTreeComponent />,
+};
+
+const WithFlipComponent = () => {
+  const flipOptions: DropdownOption[] = Array.from({ length: 6 }, (_, i) => ({
+    id: String(i + 1),
+    name: `item${i + 1}`,
+  }));
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        // Push the trigger near the bottom of the viewport so there is not
+        // enough room below — opening the menu should flip it above the input.
+        justifyContent: 'flex-end',
+        minHeight: 'calc(100vh - 48px)',
+        maxWidth: '300px',
+      }}
+    >
+      <Typography variant="body">
+        flip = true：靠近視窗底部，開啟時自動向上翻轉
+      </Typography>
+      <Select flip fullWidth options={flipOptions} placeholder="請選擇" />
+    </div>
+  );
+};
+
+export const WithFlip: StoryObj<typeof Select> = {
+  render: () => <WithFlipComponent />,
 };

--- a/packages/react/src/Select/Select.tsx
+++ b/packages/react/src/Select/Select.tsx
@@ -117,6 +117,14 @@ export interface SelectBaseProps
    */
   dropdownZIndex?: number | string;
   /**
+   * Whether to enable floating-ui `flip` middleware for the dropdown menu.
+   * When `true`, the menu flips from below to above the input (and back) along
+   * the main axis if it would overflow the viewport, keeping its width and
+   * horizontal alignment with the input. Forwarded to the underlying `Dropdown`.
+   * @default false
+   */
+  flip?: boolean;
+  /**
    * Whether to enable portal for the dropdown.
    * @default true
    */
@@ -268,6 +276,7 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
       type = 'default',
       value: valueProp,
       dropdownZIndex,
+      flip = false,
       globalPortal = true,
     } = props;
 
@@ -568,6 +577,7 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
         >
           <Dropdown
             disabled={readOnly || disabled}
+            flip={flip}
             globalPortal={globalPortal}
             loadingPosition={loadingPosition}
             loadingText={loadingText}


### PR DESCRIPTION
# feat(select): enable dropdown menu flip when overflowing the viewport (React + Angular)

## Is your feature request related to a problem?

`Select` 的下拉選單固定向下展開,且沒有開啟 flip 的途徑。當 `Select` 靠近視窗底部時,選單會往下溢出視窗,使用者必須捲動才能看到選項。底層其實已具備 flip 能力(floating-ui),缺口在於 `Select` 層沒有把它接出來。

## Describe the solution you'd like

為 `Select` 新增 opt-in 的 `flip` prop(`@default false`),React 與 Angular **prop-for-prop 對齊**。啟用後,當下方空間不足時,選單沿主軸自動翻到輸入框上方(`bottom-start` ↔ `top-start`),並保持與輸入框同寬與水平對齊。

設計上刻意**只做主軸翻轉,不加 `shift`/`crossAxis`**,與專案中場景最相近的 `InputTriggerPopper`(DatePicker / TimePicker 等選單浮層)一致 —— `shift` 對 bottom/top placement 是沿水平軸滑動,會破壞 sameWidth 選單與輸入框的左右對齊。

---

## React 端

React 的資料流是 `Select → Dropdown → Popper`。`Dropdown` 已有 `flip` middleware 但 `@default false`,且 `Select` 既不傳 `flip` 也無逃生口。

- **`Popper`**:新增 `onPlacementChange` callback,回報 floating-ui 解析(含翻轉)後的實際 placement。
- **`Dropdown`**:flip middleware 對齊 `InputTriggerPopper`(`fallbackAxisSideDirection: 'end'`, `padding: 8`,取代原本 `bestFit`);新增 `resolvedPlacement` state,進場動畫 `translateFrom` 在 flip 時跟隨實際 placement(`Dropdown` 用方向性的 `Translate` 動畫,翻轉後需修正方向)。
- **`Select`**:新增 opt-in `flip` prop,透傳給 `Dropdown`。

## Angular 端

Angular 的資料流不同:`MznSelect → MznInputTriggerPopper → MznPopper`(**不經 `MznDropdown`**)。且 `MznPopper` 的內建 `flip()` 預設啟用,`MznInputTriggerPopper` 未禁用它 —— 因此 **Angular Select 先前其實預設就會 flip**,與 React 行為相反。

本 PR 讓 Angular 對齊 React 的 opt-in 語義:

- **`MznDropdown`**:新增 `flip` input(鏡像 React `Dropdown.flip`),驅動 `MznPopper` 的 `disableFlip`(原本寫死 `true`);接 `positionUpdated` 追蹤實際 placement,`translateFrom` 在 flip 時跟隨。
- **`MznInputTriggerPopper`**(internal):新增 `flip` input 控制 `disableFlip`,並新增 `placementChange` output 轉發實際 placement。
- **`MznSelect`**:新增 `flip` input(鏡像 React `Select.flip`),透傳給 `MznInputTriggerPopper`;依轉發的 placement 驅動 `mznTranslate` 的 `from` 方向,翻轉到上方時改由下往上浮現。**預設 `false`,使選單預設不再 flip,與 React 對齊**(行為變更:先前 Angular Select 預設會 flip)。

## 變更內容

| 檔案 | 變更 |
|------|------|
| `packages/react/src/Popper/Popper.tsx` | 新增 `onPlacementChange` |
| `packages/react/src/Dropdown/Dropdown.tsx` | flip 設定對齊 InputTriggerPopper;`resolvedPlacement` 驅動 translateFrom |
| `packages/react/src/Select/Select.tsx` | 新增 opt-in `flip` 並透傳 |
| `packages/ng/dropdown/dropdown.component.ts` | 新增 `flip` input;`disableFlip` 改動態;`positionUpdated` 驅動 translateFrom |
| `packages/ng/_internal/input-trigger-popper/input-trigger-popper.component.ts` | 新增 `flip` input 與 `placementChange` output |
| `packages/ng/select/select.component.ts` | 新增 `flip` input 並透傳;依實際 placement 驅動 `mznTranslate` from |
| `*.spec.tsx` / `*.spec.ts` | 兩端各新增 flip 相關測試 |
| `Select.stories.tsx` / `select.stories.ts` | 兩端各新增 `flip` argType 與 `WithFlip` story |

> Commit 依相依層次與 scope 拆分:`react/popper` → `react/dropdown` → `react/select` → `ng/dropdown` → `ng/select`。

## 平台差異(刻意保留,非 bug)

- **進場動畫**:React `Select` 底層用 `Fade`(無方向,翻轉無需修正);Angular `Select` 用 `mznTranslate`(方向性),故額外依實際 placement 切換 `from`。此為兩端既有的動畫抽象差異(react-transition-group vs CSS transition)。
- **flip middleware 細節**:React 用 `flip({ fallbackAxisSideDirection: 'end', padding: 8 })`;Angular 沿用 `MznPopper` 共用的內建 `flip()`(無選項,不便為單一 consumer 改動共用 middleware)。兩者在一般情境(下方不足→翻上方)行為一致,差異僅在觸發邊距與罕見的雙側皆不足後備策略。

## 驗證

1. **React 單元測試**:`Popper.spec` / `Dropdown.spec` / `Select.spec` 全綠(101 passed,含新增 3 項)。
2. **React build**:`nx build @mezzanine-ui/react` 成功。
3. **Angular build**:`ng-packagr` 全 entry points 編譯成功(AOT template 型別檢查涵蓋所有新 binding:`disableFlip`、`positionUpdated`、`flip`、`placementChange`、`[from]`)。
4. **ESLint**:全部變更檔(React + Angular)0 error。
5. **Angular 單元測試**:本地 repo 未提供 `packages/ng/jest.config.js`(test script 引用但檔案不存在),改由 CI 環境執行;新增測試採與既有測試相同的 TestBed 模式。

## 相容性

- **React**:純 opt-in(`@default false`),既有 consumer 零影響。
- **Angular**:`flip` `@default false`。注意 `MznSelect` 預設行為由「會 flip」改為「不 flip」以對齊 React opt-in 語義;需要原行為者顯式設定 `[flip]="true"`。
- 兩端皆不移除或變更既有 public API。

## 待驗證(需 reviewer 或後續)

- **Parity runtime 比對**:`npm run parity -- select` 需同時起 React(:6006)與 Angular(:6007)Storybook。prop 介面已 prop-for-prop 對齊(parity API extractor 以 prop 名稱比對應歸零);runtime DOM/style 比對待在 storybook 環境執行確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
