### PR TITLE
fix(react/navigation): leaf NavigationOption with a Badge child renders as anchor leaf, no chevron

### DIFF
--- a/packages/react/src/Navigation/Navigation.stories.tsx
+++ b/packages/react/src/Navigation/Navigation.stories.tsx
@@ -64,6 +64,15 @@ export const Basic: StoryFn<NavigationProps> = (args) => {
           <NavigationOption title={'待處理訂單'} />
           <NavigationOption title={'已完成訂單'} />
         </NavigationOption>
+        {/* Leaf item with only a Badge child: renders an anchor leaf with a
+            right-aligned badge and no chevron (no expandable group). */}
+        <NavigationOption
+          icon={NotificationIcon}
+          title={'通知中心'}
+          href="/notifications"
+        >
+          <Badge count={8} variant="count-alert" />
+        </NavigationOption>
         <NavigationOption icon={UserIcon} title={'會員管理'} />
         <>
           {Array.from(Array(5)).map((_, index) => (
@@ -89,6 +98,51 @@ export const Basic: StoryFn<NavigationProps> = (args) => {
             <NavigationIconButton icon={NotificationIcon} />
           </Badge>
         </NavigationFooter>
+      </Navigation>
+    </div>
+  );
+};
+
+export const LeafWithBadge: StoryFn<NavigationProps> = (args) => {
+  const [activatedPath, setActivatedPath] = useState(['通知中心']);
+
+  return (
+    <div style={{ display: 'grid', height: 'calc(100vh - 32px)' }}>
+      <Navigation
+        activatedPath={activatedPath}
+        onOptionClick={(activePath) => {
+          if (activePath) setActivatedPath(activePath);
+        }}
+        {...args}
+      >
+        <NavigationHeader title="Mezzanine">
+          <span
+            aria-label="logo"
+            style={{
+              backgroundColor: '#5D74E9',
+              borderRadius: '4px',
+              height: '28px',
+              width: '28px',
+            }}
+          />
+        </NavigationHeader>
+        {/* Leaf with a badge → anchor row, right-aligned badge, no chevron. */}
+        <NavigationOption
+          icon={NotificationIcon}
+          title={'通知中心'}
+          href="/notifications"
+        >
+          <Badge count={8} variant="count-alert" />
+        </NavigationOption>
+        <NavigationOption icon={ListIcon} title={'訂單管理'} href="/orders">
+          <Badge count={5} variant="count-brand" />
+        </NavigationOption>
+        {/* Group with a badge → keeps chevron + collapsible sub-options. */}
+        <NavigationOption icon={FileIcon} title={'數據分析'}>
+          <Badge count={2} variant="count-brand" />
+          <NavigationOption title={'流量報表'} />
+          <NavigationOption title={'轉換率分析'} />
+        </NavigationOption>
       </Navigation>
     </div>
   );

--- a/packages/react/src/Navigation/NavigationOption.spec.tsx
+++ b/packages/react/src/Navigation/NavigationOption.spec.tsx
@@ -4,6 +4,7 @@ import { describeForwardRefToHTMLElement } from '../../__test-utils__/common';
 import Navigation from './Navigation';
 import NavigationOption from './NavigationOption';
 import NavigationOptionCategory from './NavigationOptionCategory';
+import Badge from '../Badge';
 
 // Mock ResizeObserver
 class ResizeObserverMock {
@@ -163,6 +164,99 @@ describe('<NavigationOption />', () => {
 
       expect(
         option?.classList.contains('mzn-navigation-option--basic'),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('children: lone Badge (leaf with badge)', () => {
+    it('should render the badge inline', () => {
+      const { getHostHTMLElement } = render(
+        <Navigation>
+          <NavigationOption title="Review" icon={PlusIcon} href="/review">
+            <Badge variant="count-alert" count={5} />
+          </NavigationOption>
+        </Navigation>,
+      );
+      const element = getHostHTMLElement();
+
+      expect(element.querySelector('.mzn-badge')).toBeTruthy();
+    });
+
+    it('should not render a group toggle chevron', () => {
+      const { getHostHTMLElement } = render(
+        <Navigation>
+          <NavigationOption title="Review" icon={PlusIcon} href="/review">
+            <Badge variant="count-alert" count={5} />
+          </NavigationOption>
+        </Navigation>,
+      );
+      const element = getHostHTMLElement();
+
+      expect(
+        element.querySelector('.mzn-navigation-option__toggle-icon'),
+      ).toBeFalsy();
+    });
+
+    it('should stay an anchor with href instead of downgrading to a div', () => {
+      const { getHostHTMLElement } = render(
+        <Navigation>
+          <NavigationOption title="Review" icon={PlusIcon} href="/review">
+            <Badge variant="count-alert" count={5} />
+          </NavigationOption>
+        </Navigation>,
+      );
+      const element = getHostHTMLElement();
+      const content = element.querySelector('.mzn-navigation-option__content');
+
+      expect(content?.tagName.toLowerCase()).toBe('a');
+      expect(content?.getAttribute('href')).toBe('/review');
+    });
+
+    it('should keep the basic leaf styling', () => {
+      const { getHostHTMLElement } = render(
+        <Navigation>
+          <NavigationOption title="Review" icon={PlusIcon} href="/review">
+            <Badge variant="count-alert" count={5} />
+          </NavigationOption>
+        </Navigation>,
+      );
+      const element = getHostHTMLElement();
+      const option = element.querySelector('.mzn-navigation-option');
+
+      expect(
+        option?.classList.contains('mzn-navigation-option--basic'),
+      ).toBeTruthy();
+    });
+
+    it('should not mount a collapsible group', () => {
+      const { getHostHTMLElement } = render(
+        <Navigation>
+          <NavigationOption title="Review" icon={PlusIcon} href="/review">
+            <Badge variant="count-alert" count={5} />
+          </NavigationOption>
+        </Navigation>,
+      );
+      const element = getHostHTMLElement();
+
+      expect(
+        element.querySelector('.mzn-navigation-option__children-wrapper'),
+      ).toBeFalsy();
+    });
+
+    it('should still render chevron and group when a badge sits alongside sub-options', () => {
+      const { getHostHTMLElement } = render(
+        <Navigation>
+          <NavigationOption title="Orders" icon={PlusIcon}>
+            <Badge variant="count-brand" count={5} />
+            <NavigationOption title="Pending" />
+          </NavigationOption>
+        </Navigation>,
+      );
+      const element = getHostHTMLElement();
+
+      expect(element.querySelector('.mzn-badge')).toBeTruthy();
+      expect(
+        element.querySelector('.mzn-navigation-option__toggle-icon'),
       ).toBeTruthy();
     });
   });

--- a/packages/react/src/Navigation/NavigationOption.tsx
+++ b/packages/react/src/Navigation/NavigationOption.tsx
@@ -123,11 +123,6 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
     );
     const currentPathKey = currentPath.join('::');
 
-    const Component =
-      href && !children
-        ? (anchorComponent ?? optionsAnchorComponent ?? 'a')
-        : 'div';
-
     const flattenedChildren = useMemo(
       () => flattenChildren(children) as NavigationOptionChildren,
       [children],
@@ -159,6 +154,15 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
 
       return { badge: badgeComponent, items };
     }, [flattenedChildren]);
+
+    // Group vs leaf is decided by the presence of real sub-options, not by
+    // raw `children` — a lone `Badge` child is rendered inline on a leaf.
+    const hasSubOptions = items.length > 0;
+
+    const Component =
+      href && !hasSubOptions
+        ? (anchorComponent ?? optionsAnchorComponent ?? 'a')
+        : 'div';
 
     // Default open if current path is activated
     useEffect(() => {
@@ -216,7 +220,7 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
         className={cx(
           classes.host,
           open && classes.open,
-          !children && classes.basic,
+          !hasSubOptions && classes.basic,
           (active ?? activatedPath?.[currentLevel - 1] === currentKey) &&
             classes.active,
           collapsed && classes.collapsed,
@@ -248,7 +252,7 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
                   handleCollapseChange(false);
                 }
 
-                if (!children) setActivatedPath(currentPath);
+                if (!hasSubOptions) setActivatedPath(currentPath);
               }}
               onKeyDown={(
                 e: React.KeyboardEvent<HTMLAnchorElement | HTMLDivElement>,
@@ -257,7 +261,7 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
                   e.preventDefault();
                   setOpen(!open);
 
-                  if (!children) setActivatedPath(currentPath);
+                  if (!hasSubOptions) setActivatedPath(currentPath);
                 }
               }}
               onMouseEnter={onMouseEnter}
@@ -271,19 +275,21 @@ const NavigationOption = forwardRef<HTMLLIElement, NavigationOptionProps>(
               <span className={classes.titleWrapper}>
                 <Fade ref={titleRef} in={collapsed === false || !icon}>
                   <span className={classes.title}>
-                    {collapsed && !icon ? Array.from(title).slice(0, 2).join('') : title}
+                    {collapsed && !icon
+                      ? Array.from(title).slice(0, 2).join('')
+                      : title}
                   </span>
                 </Fade>
               </span>
 
               {badge}
-              {children && (
+              {hasSubOptions && (
                 <Icon className={classes.toggleIcon} icon={GroupToggleIcon} />
               )}
             </Component>
           )}
         </Tooltip>
-        {children && !collapsed && (
+        {hasSubOptions && !collapsed && (
           <Collapse lazyMount className={cx(classes.childrenWrapper)} in={open}>
             <NavigationOptionLevelContext.Provider
               value={{


### PR DESCRIPTION
Closes #451

## Problem

A `NavigationOption` whose only child is a `Badge` (a leaf item with a count badge, no nested `NavigationOption` sub-items) was incorrectly treated as an expandable group:

1. it rendered a group toggle **chevron**,
2. its element was **downgraded from the anchor / `anchorComponent` to a plain `<div>`**, dropping `href` (breaks `optionsAnchorComponent` / router navigation),
3. it mounted an **empty `Collapse` group**, and
4. it lost the **`--basic`** leaf styling.

Root cause: every group-vs-leaf decision in `NavigationOption.tsx` keyed off the raw `children` prop (which includes the `Badge`) instead of the count of real sub-options.

## Fix

Drive those decisions off `items.length` — the real sub-`NavigationOption`s already split out of `children` — via a `hasSubOptions` flag. The `badge` is still rendered inline regardless. The `items` `useMemo` is moved above the `Component` computation that now depends on it.

Backwards compatible: groups (which have `NavigationOption` children) are unaffected; only the previously broken badge-only leaf changes behavior.

## Changes

- `NavigationOption.tsx` — classify leaf vs group by `hasSubOptions` across the 6 decision sites (Component, `--basic` class, click/keydown activation, chevron, Collapse).
- `NavigationOption.spec.tsx` — 6 new cases covering the badge-only leaf (inline badge, no chevron, stays `<a href>`, keeps `--basic`, no Collapse) plus a control for badge-alongside-sub-options.
- `Navigation.stories.tsx` — added a badge leaf to the Basic story and a dedicated `LeafWithBadge` story.

## Verification

- `@mezzanine-ui/react:test` — 24/24 NavigationOption tests pass (incl. 6 new)
- ESLint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)