### PR TITLE
fix(react/dropdown): keep trigger focus on option mousedown

### DIFF
--- a/packages/react/src/AutoComplete/AutoComplete.spec.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.spec.tsx
@@ -389,6 +389,107 @@ describe('<AutoComplete />', () => {
     });
   });
 
+  describe('regression: filtered option mousedown/blur race', () => {
+    // Regression test for a bug where, in single mode with the default
+    // inputPosition="outside" and clearSearchText=true: typing a filter
+    // narrows the option list, then pressing mousedown on a filtered row
+    // (without preventDefault) blurred the search input. The blur handler
+    // synchronously reset searchText, which restored the full unfiltered
+    // option list *underneath the cursor* before mouseup/click fired. Because
+    // the full list has a different item at that same row position, the
+    // click landed on the wrong option (or a moved/unmounted node).
+    //
+    // The fix adds `onMouseDown` on the listbox `<ul>` that calls
+    // `event.preventDefault()` (see DropdownItem.tsx `handleListMouseDown`),
+    // which keeps focus on the input, so no blur -> no reset -> the filtered
+    // list stays stable until the click lands.
+    it('should select the option actually clicked after filtering, even though mousedown could blur the input', async () => {
+      jest.useFakeTimers();
+
+      const onChange = jest.fn();
+      const inputRef = createRef<HTMLInputElement>();
+
+      // Filtering on "ap" matches 'apple' (unfiltered index 0) and 'apricot'
+      // (unfiltered index 2). In the filtered list, 'apricot' sits at index 1,
+      // which is a *different* option ('banana') in the unfiltered list. This
+      // index mismatch is essential: if the filtered click target occupied
+      // the same index in both lists, the test would pass even without the
+      // fix.
+      const options: SelectValue[] = [
+        { id: 'apple', name: 'apple' },
+        { id: 'banana', name: 'banana' },
+        { id: 'apricot', name: 'apricot' },
+        { id: 'cherry', name: 'cherry' },
+      ];
+
+      render(
+        <AutoComplete
+          inputRef={inputRef}
+          mode="single"
+          onChange={onChange}
+          options={options}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(inputRef.current).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.focus(inputRef.current!);
+        fireEvent.change(inputRef.current!, { target: { value: 'ap' } });
+      });
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      const filteredOptions = Array.from(getDropdownOptions());
+      expect(filteredOptions.map((el) => el.textContent)).toEqual([
+        'apple',
+        'apricot',
+      ]);
+
+      const targetIndex = 1; // 'apricot' - unfiltered index 2, NOT 1
+      const mouseDownTarget = filteredOptions[targetIndex];
+      expect(mouseDownTarget.textContent).toBe('apricot');
+
+      // Fire a real, cancelable mousedown on the row under the (simulated)
+      // cursor. `fireEvent` returns false when the event's default was
+      // prevented, mirroring the browser's own dispatchEvent semantics. This
+      // lets the test faithfully key off whichever behavior the component
+      // actually implements, rather than hard-coding jsdom's own (unreliable)
+      // native focus-follows-mousedown emulation.
+      let defaultNotPrevented = false;
+      act(() => {
+        defaultNotPrevented = fireEvent.mouseDown(mouseDownTarget);
+      });
+
+      if (defaultNotPrevented) {
+        // Mirrors the browser blurring the previously-focused input because
+        // the mousedown's default action was not prevented.
+        await act(async () => {
+          fireEvent.blur(inputRef.current!);
+        });
+      }
+
+      // A real click lands on whatever is now at that same on-screen row —
+      // which is a different option if the list was reset in between.
+      const optionsAfterMouseDown = Array.from(getDropdownOptions());
+      const clickTarget = optionsAfterMouseDown[targetIndex];
+
+      await act(async () => {
+        fireEvent.mouseUp(clickTarget);
+        fireEvent.click(clickTarget);
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'apricot', name: 'apricot' }),
+      );
+    });
+  });
+
   describe('prop: inputProps', () => {
     it('should trigger inputProps.onBlur when input blur', async () => {
       jest.useFakeTimers();
@@ -720,9 +821,9 @@ describe('<AutoComplete />', () => {
           currentListbox!.querySelectorAll('[role="option"]'),
         ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart'));
         expect(currentOption).toBeTruthy();
-        expect((currentOption as HTMLElement).getAttribute('aria-selected')).toBe(
-          'false',
-        );
+        expect(
+          (currentOption as HTMLElement).getAttribute('aria-selected'),
+        ).toBe('false');
       });
 
       await act(async () => {
@@ -741,7 +842,9 @@ describe('<AutoComplete />', () => {
       await waitFor(() => {
         expect(onRemoveCreated).toHaveBeenCalled();
         const lastCallArg =
-          onRemoveCreated.mock.calls[onRemoveCreated.mock.calls.length - 1]?.[0];
+          onRemoveCreated.mock.calls[
+            onRemoveCreated.mock.calls.length - 1
+          ]?.[0];
         expect(lastCallArg).toEqual(expect.any(Array));
         expect(
           (lastCallArg as SelectValue[]).some(
@@ -960,7 +1063,9 @@ describe('<AutoComplete />', () => {
       ) as HTMLElement | null;
       expect(selectedOption).toBeInTheDocument();
       expect(
-        selectedOption?.querySelector('.mzn-dropdown-item-card-append-content .mzn-icon'),
+        selectedOption?.querySelector(
+          '.mzn-dropdown-item-card-append-content .mzn-icon',
+        ),
       ).toBeInTheDocument();
 
       // Keep the input (trigger) and selection checkboxes separate:
@@ -994,9 +1099,7 @@ describe('<AutoComplete />', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ delay: null });
 
-      const onInsert = jest.fn((text: string) => [
-        { id: text, name: text },
-      ]);
+      const onInsert = jest.fn((text: string) => [{ id: text, name: text }]);
 
       render(
         <AutoComplete
@@ -1027,10 +1130,7 @@ describe('<AutoComplete />', () => {
       expect(createButton).toBeInTheDocument();
 
       fireEvent.click(createButton);
-      expect(onInsert).toHaveBeenCalledWith(
-        'newitem',
-        expect.any(Array),
-      );
+      expect(onInsert).toHaveBeenCalledWith('newitem', expect.any(Array));
     });
 
     it('should keep New tag for created option in inside mode', async () => {
@@ -1049,7 +1149,10 @@ describe('<AutoComplete />', () => {
             mode="multiple"
             onChange={setValue}
             onInsert={(text, currentOptions) => {
-              const updated = [...currentOptions, { id: `new-${text}`, name: text }];
+              const updated = [
+                ...currentOptions,
+                { id: `new-${text}`, name: text },
+              ];
               setOptions(updated);
               return updated;
             }}
@@ -1128,9 +1231,7 @@ describe('<AutoComplete />', () => {
         expect(input.value).toBe('Grid chart, Griddle, Grid');
       });
 
-      const firstCreateButton = screen.queryByText(
-        /建立.*Grid chart/i,
-      );
+      const firstCreateButton = screen.queryByText(/建立.*Grid chart/i);
       expect(firstCreateButton).toBeInTheDocument();
 
       fireEvent.click(firstCreateButton!);
@@ -1244,10 +1345,12 @@ describe('<AutoComplete />', () => {
         const currentListbox = getDropdownListbox() as HTMLElement | null;
         if (!currentListbox) return null;
         return Array.from(
-          currentListbox.querySelectorAll('[role="option"][aria-selected="true"]'),
-        ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart')) as
-          | HTMLElement
-          | null;
+          currentListbox.querySelectorAll(
+            '[role="option"][aria-selected="true"]',
+          ),
+        ).find((el) =>
+          (el as HTMLElement).textContent?.includes('Grid chart'),
+        ) as HTMLElement | null;
       };
 
       const createdSelectedOption = await waitFor(() => {
@@ -1267,9 +1370,9 @@ describe('<AutoComplete />', () => {
           currentListbox!.querySelectorAll('[role="option"]'),
         ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart'));
         expect(currentOption).toBeTruthy();
-        expect((currentOption as HTMLElement).getAttribute('aria-selected')).toBe(
-          'false',
-        );
+        expect(
+          (currentOption as HTMLElement).getAttribute('aria-selected'),
+        ).toBe('false');
       });
 
       await act(async () => {
@@ -1285,7 +1388,9 @@ describe('<AutoComplete />', () => {
       await waitFor(() => {
         expect(onRemoveCreated).toHaveBeenCalled();
         const lastCallArg =
-          onRemoveCreated.mock.calls[onRemoveCreated.mock.calls.length - 1]?.[0];
+          onRemoveCreated.mock.calls[
+            onRemoveCreated.mock.calls.length - 1
+          ]?.[0];
         expect(lastCallArg).toEqual(expect.any(Array));
         expect(
           (lastCallArg as SelectValue[]).some(

--- a/packages/react/src/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/Dropdown/DropdownItem.tsx
@@ -2,6 +2,7 @@
 
 import keycode from 'keycode';
 import {
+  MouseEvent as ReactMouseEvent,
   ReactNode,
   useCallback,
   useEffect,
@@ -988,6 +989,20 @@ export default function DropdownItem<
     onScroll,
   ]);
 
+  // Keep focus on the trigger (e.g. AutoComplete's search input) while pressing an option.
+  // Without this, mousedown blurs the input before the click lands; consumers that reset
+  // their search text on blur re-render the list underneath the cursor, so the subsequent
+  // click either selects the wrong option or hits a node that has already unmounted.
+  // The header region is excluded because `inputPosition="inside"` renders a real input there.
+  const handleListMouseDown = useCallback(
+    (event: ReactMouseEvent<HTMLUListElement>) => {
+      if (headerRef.current?.contains(event.target as Node)) return;
+
+      event.preventDefault();
+    },
+    [],
+  );
+
   return (
     <ul
       aria-label={
@@ -996,6 +1011,7 @@ export default function DropdownItem<
       }
       className={dropdownClasses.list}
       id={listboxId}
+      onMouseDown={handleListMouseDown}
       ref={listRef}
       role="listbox"
       style={listStyle}


### PR DESCRIPTION
## 問題

在 [Dropdown 的 AutoComplete 範例](https://storybook.mezzanine-ui.org/react/?path=/story/internal-dropdown--auto-complete-example) 輸入關鍵字過濾後，點選搜尋結果會選到錯的選項，或完全沒反應。沒有過濾時一切正常。

## 根因

選項列的選取綁在 `onClick`（mouseup 之後），但沒有任何地方阻止 mousedown 的預設行為，所以按下滑鼠的瞬間 trigger input 先失焦：

```
mousedown -> input blur -> onSearchInputBlur
          -> resetSearchInputsAndOptions -> resetCreationInputs
          -> setSearchText('')            <- 同步執行，filter 立刻消失
          -> 完整清單重新 render
mouseup / click -> 落在「現在」位在該座標的另一個選項
```

未過濾時清單不會變動，所以觀察不到問題。

`DropdownAction`（建立新項目的按鈕）本來就有 `onMouseDown={(e) => e.preventDefault()}`，只有選項列漏掉了。

## 做法

在 listbox 根節點 `<ul>` 上阻止 mousedown 預設行為，讓焦點留在 trigger。一處涵蓋 default / grouped / tree 三種渲染路徑，也符合 listbox 的標準行為。

header 區域排除在外 —— `inputPosition="inside"` 會把真的 `<input>` 渲染在那裡，必須維持可點擊、可定位游標。

## 驗證

**回歸測試**：新增的測試在把修正拿掉後確實失敗，錯誤訊息正是預測的失效模式：

```
Expected: ObjectContaining {"id": "apricot", "name": "apricot"}
Received: {"id": "banana", "name": "banana"}
```

`Dropdown` + `AutoComplete` 共 191 個測試通過。

**Storybook 實際互動**：

| Story | 操作 | 結果 |
| ------------------------------------------ | ------------------------- | -------------------------- |
| `internal-dropdown--auto-complete-example` | 輸入 `Colo` → 點 Colorado | 正確選到 Colorado |
| `internal-dropdown--inside` | 輸入 `Colo` → 點 Colorado | 正確，header 輸入框仍可打字 |
| `data-entry-autocomplete--multiple` | 輸入 `b` → 點第二列 bob | 正確勾選 bob，filter 保留 |

Colorado 在未過濾清單是第 7 筆、過濾後是第 1 筆，修復前這一擊會選到 Alabama。

## 審核重點

`<ul>` 層級的 `preventDefault` 會連帶阻止選單內的文字選取。對 listbox 而言這是預期行為，但若有依賴選單內反白文字的使用情境，請提出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)