### PR TITLE
fix(react/autocomplete): match options case-insensitively by default

### DIFF
--- a/packages/ng/autocomplete/autocomplete.component.spec.ts
+++ b/packages/ng/autocomplete/autocomplete.component.spec.ts
@@ -11,6 +11,11 @@ const MOCK_OPTIONS: DropdownOption[] = [
   { id: 'cherry', name: 'Cherry' },
 ];
 
+const CASE_SENSITIVE_OPTIONS: DropdownOption[] = [
+  { id: 'colorado', name: 'Colorado' },
+  { id: 'virginia', name: 'Virginia' },
+];
+
 @Component({
   standalone: true,
   imports: [MznAutocomplete, FormsModule],
@@ -25,6 +30,54 @@ const MOCK_OPTIONS: DropdownOption[] = [
 class TestHostComponent {
   options = MOCK_OPTIONS;
   selected = '';
+}
+
+@Component({
+  standalone: true,
+  imports: [MznAutocomplete, FormsModule],
+  template: `
+    <div
+      mznAutocomplete
+      [caseSensitive]="caseSensitive"
+      [options]="options"
+      [(ngModel)]="selected"
+      placeholder="Search states"
+    ></div>
+  `,
+})
+class CaseSensitiveFilterHostComponent {
+  options = CASE_SENSITIVE_OPTIONS;
+  selected = '';
+  caseSensitive = false;
+}
+
+@Component({
+  standalone: true,
+  imports: [MznAutocomplete, FormsModule],
+  template: `
+    <div
+      mznAutocomplete
+      [addable]="true"
+      [caseSensitive]="caseSensitive"
+      [onInsert]="onInsert"
+      [options]="options"
+      [(ngModel)]="selected"
+      placeholder="Search states"
+    ></div>
+  `,
+})
+class CaseSensitiveCreateHostComponent {
+  options: DropdownOption[] = [{ id: 'virginia', name: 'Virginia' }];
+  selected = '';
+  caseSensitive = false;
+
+  readonly onInsert = (
+    text: string,
+    currentOptions: ReadonlyArray<DropdownOption>,
+  ): ReadonlyArray<DropdownOption> => [
+    ...currentOptions,
+    { id: text.toLowerCase(), name: text },
+  ];
 }
 
 function createFixture<T>(component: new () => T): {
@@ -105,5 +158,126 @@ describe('MznAutocomplete', () => {
     await fixture.whenStable();
 
     expect(host.selected).toBe('apple');
+  });
+
+  describe('caseSensitive', () => {
+    it('should match case-insensitively by default ("vir" -> Virginia)', () => {
+      const { fixture } = createFixture(CaseSensitiveFilterHostComponent);
+      const input = fixture.nativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+
+      input.dispatchEvent(new Event('focus'));
+      fixture.detectChanges();
+
+      input.value = 'vir';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      const items = fixture.nativeElement.querySelectorAll('[role="option"]');
+
+      expect(items.length).toBe(1);
+      expect(items[0].textContent).toContain('Virginia');
+    });
+
+    it('should not match "vir" when caseSensitive is true', () => {
+      const { fixture, host } = createFixture(CaseSensitiveFilterHostComponent);
+
+      host.caseSensitive = true;
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+
+      input.dispatchEvent(new Event('focus'));
+      fixture.detectChanges();
+
+      input.value = 'vir';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      const items = fixture.nativeElement.querySelectorAll('[role="option"]');
+
+      expect(items.length).toBe(0);
+    });
+
+    it('should match "Vir" when caseSensitive is true', () => {
+      const { fixture, host } = createFixture(CaseSensitiveFilterHostComponent);
+
+      host.caseSensitive = true;
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+
+      input.dispatchEvent(new Event('focus'));
+      fixture.detectChanges();
+
+      input.value = 'Vir';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      const items = fixture.nativeElement.querySelectorAll('[role="option"]');
+
+      expect(items.length).toBe(1);
+      expect(items[0].textContent).toContain('Virginia');
+    });
+
+    it('should hide the create action for an option already visible in the list (case-insensitive default)', () => {
+      const { fixture } = createFixture(CaseSensitiveCreateHostComponent);
+      const input = fixture.nativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+
+      input.dispatchEvent(new Event('focus'));
+      fixture.detectChanges();
+
+      input.value = 'virginia';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      const buttons = Array.from(
+        fixture.nativeElement.querySelectorAll('button'),
+      ) as HTMLButtonElement[];
+      const createButton = buttons.find(
+        (button) => button.textContent?.trim() === '建立 "virginia"',
+      );
+
+      expect(createButton).toBeUndefined();
+    });
+
+    it('should offer to create a differently-cased duplicate when caseSensitive is true', () => {
+      const { fixture, host } = createFixture(CaseSensitiveCreateHostComponent);
+
+      host.caseSensitive = true;
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+
+      input.dispatchEvent(new Event('focus'));
+      fixture.detectChanges();
+
+      input.value = 'virginia';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      const buttons = Array.from(
+        fixture.nativeElement.querySelectorAll('button'),
+      ) as HTMLButtonElement[];
+      const createButton = buttons.find(
+        (button) => button.textContent?.trim() === '建立 "virginia"',
+      );
+
+      expect(createButton).toBeTruthy();
+    });
   });
 });

--- a/packages/ng/autocomplete/autocomplete.component.ts
+++ b/packages/ng/autocomplete/autocomplete.component.ts
@@ -34,6 +34,7 @@ import { MznTag } from '@mezzanine-ui/ng/tag';
 import { MznTextField } from '@mezzanine-ui/ng/text-field';
 import { provideValueAccessor } from '@mezzanine-ui/ng/utils';
 import { AutocompleteCreationTracker } from './creation-tracker';
+import { isSameOptionName, normalizeOptionName } from './is-same-option-name';
 
 /**
  * 標記 AutoComplete 的 prefix 內容投影插槽。
@@ -138,6 +139,7 @@ export function getFullParsedList(
     '[attr.active]': 'null',
     '[attr.addable]': 'null',
     '[attr.asyncData]': 'null',
+    '[attr.caseSensitive]': 'null',
     '[attr.clearable]': 'null',
     '[attr.clearSearchText]': 'null',
     '[attr.createActionText]': 'null',
@@ -469,6 +471,15 @@ export class MznAutocomplete
   readonly asyncData = input(false);
 
   /**
+   * 選項比對是否區分大小寫。
+   * `false`(預設)時輸入 `colorado` 可比對到選項 `Colorado`;此規則
+   * 同時套用於選項過濾與 `addable` 模式的重複檢查,確保清單中已顯示的
+   * 選項不會被重複提供建立動作。
+   * @default false
+   */
+  readonly caseSensitive = input(false);
+
+  /**
    * 是否可清除已選值。
    * @default false
    */
@@ -761,12 +772,13 @@ export class MznAutocomplete
 
   protected readonly filteredOptions = computed(
     (): ReadonlyArray<DropdownOption> => {
-      const search = this.searchText().toLowerCase();
+      const caseSensitive = this.caseSensitive();
+      const search = normalizeOptionName(this.searchText(), caseSensitive);
 
       if (this.disabledOptionsFilter() || !search) return this.options();
 
       return this.options().filter((o) =>
-        o.name.toLowerCase().includes(search),
+        normalizeOptionName(o.name, caseSensitive).includes(search),
       );
     },
   );
@@ -880,10 +892,10 @@ export class MznAutocomplete
     if (!text) return false;
 
     // 檢查是否已存在同名選項
-    const lowerText = text.toLowerCase();
+    const caseSensitive = this.caseSensitive();
 
-    return !this.filteredOptions().some(
-      (o) => o.name.toLowerCase() === lowerText,
+    return !this.filteredOptions().some((o) =>
+      isSameOptionName(o.name, text, caseSensitive),
     );
   });
 
@@ -1443,6 +1455,7 @@ export class MznAutocomplete
   }
 
   private processBulkCreate(text: string): ReadonlyArray<string> {
+    const caseSensitive = this.caseSensitive();
     const parts = getFullParsedList(
       text,
       this.createSeparators(),
@@ -1452,20 +1465,25 @@ export class MznAutocomplete
       this.internalValue().map((id) => {
         const opt = this.options().find((o) => o.id === id);
 
-        return opt?.name?.toLowerCase() ?? id.toLowerCase();
+        return normalizeOptionName(opt?.name ?? id, caseSensitive);
       }),
     );
 
-    return parts.filter((p) => !currentNames.has(p.toLowerCase()));
+    return parts.filter(
+      (p) => !currentNames.has(normalizeOptionName(p, caseSensitive)),
+    );
   }
 
   private getPendingCreateList(text: string): ReadonlyArray<string> {
+    const caseSensitive = this.caseSensitive();
     const parts = this.processBulkCreate(text);
     const optionNames = new Set(
-      this.options().map((o) => o.name.toLowerCase()),
+      this.options().map((o) => normalizeOptionName(o.name, caseSensitive)),
     );
 
-    return parts.filter((p) => !optionNames.has(p.toLowerCase()));
+    return parts.filter(
+      (p) => !optionNames.has(normalizeOptionName(p, caseSensitive)),
+    );
   }
 
   private handleBulkCreate(texts: ReadonlyArray<string>): void {
@@ -1473,6 +1491,7 @@ export class MznAutocomplete
 
     if (!insertFn) return;
 
+    const caseSensitive = this.caseSensitive();
     let currentOptions = [...this.filterUnselected(this.options())];
 
     this.clearUnselected();
@@ -1480,8 +1499,8 @@ export class MznAutocomplete
     const newIds: string[] = [];
 
     for (const text of texts) {
-      const existing = currentOptions.find(
-        (o) => o.name.toLowerCase() === text.toLowerCase(),
+      const existing = currentOptions.find((o) =>
+        isSameOptionName(o.name, text, caseSensitive),
       );
 
       if (existing) {

--- a/packages/ng/autocomplete/autocomplete.stories.ts
+++ b/packages/ng/autocomplete/autocomplete.stories.ts
@@ -55,6 +55,16 @@ export default {
         category: 'Inputs',
       },
     },
+    caseSensitive: {
+      control: false,
+      description:
+        '選項比對是否區分大小寫。`false`（預設）時輸入 `colorado` 可比對到選項 `Colorado`；同時套用於選項過濾與 `addable` 模式的重複檢查。',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+        category: 'Inputs',
+      },
+    },
     clearable: {
       control: false,
       description: '是否可清除已選值。',
@@ -1796,5 +1806,60 @@ export const SearchTextControlRef: Story = {
   ],
   render: () => ({
     template: `<story-autocomplete-search-text-control />`,
+  }),
+};
+
+// ──────────────────────────────────────────────
+//  16. CaseSensitivity
+// ──────────────────────────────────────────────
+
+const caseSensitiveOptions: DropdownOption[] = [
+  { id: 'colorado', name: 'Colorado' },
+  { id: 'connecticut', name: 'Connecticut' },
+  { id: 'virginia', name: 'Virginia' },
+  { id: 'west-virginia', name: 'West Virginia' },
+];
+
+@Component({
+  selector: 'story-autocomplete-case-sensitivity',
+  standalone: true,
+  imports: [FormsModule, MznAutocomplete, MznTag],
+  template: `
+    <div
+      style="display: inline-grid; grid-template-columns: repeat(2, 320px); gap: 16px; align-items: start;"
+    >
+      <div style="display: grid; gap: 8px;">
+        <span mznTag type="static" [label]="'預設：不分大小寫'"></span>
+        <div
+          mznAutocomplete
+          [options]="options"
+          placeholder="輸入 vir 也找得到 Virginia"
+          [(ngModel)]="insensitiveSelection"
+        ></div>
+      </div>
+      <div style="display: grid; gap: 8px;">
+        <span mznTag type="static" [label]="'caseSensitive'"></span>
+        <div
+          mznAutocomplete
+          [caseSensitive]="true"
+          [options]="options"
+          placeholder="需輸入 Vir 才找得到"
+          [(ngModel)]="sensitiveSelection"
+        ></div>
+      </div>
+    </div>
+  `,
+})
+class CaseSensitivityStoryComponent {
+  readonly options = caseSensitiveOptions;
+  insensitiveSelection = '';
+  sensitiveSelection = '';
+}
+
+export const CaseSensitivity: Story = {
+  parameters: { controls: { disable: true } },
+  decorators: [moduleMetadata({ imports: [CaseSensitivityStoryComponent] })],
+  render: () => ({
+    template: `<story-autocomplete-case-sensitivity />`,
   }),
 };

--- a/packages/ng/autocomplete/is-same-option-name.ts
+++ b/packages/ng/autocomplete/is-same-option-name.ts
@@ -1,0 +1,34 @@
+/**
+ * 正規化選項名稱以供比較;預設轉為小寫忽略大小寫,`caseSensitive` 為
+ * `true` 時原樣返回,不做任何轉換。
+ *
+ * 是 `isSameOptionName`、選項過濾(substring 比對)、與批次新增流程
+ * 中以 `Set` 判斷是否重複的共用基礎,避免每個呼叫點各自寫一份
+ * `caseSensitive ? x : x.toLowerCase()` 三元判斷。
+ */
+export function normalizeOptionName(
+  name: string,
+  caseSensitive = false,
+): string {
+  return caseSensitive ? name : name.toLowerCase();
+}
+
+/**
+ * 比較兩個選項名稱是否相同;預設忽略大小寫,`caseSensitive` 為 `true`
+ * 時才比對完全一致的字母大小寫。
+ *
+ * 對齊 React `isSameOptionName`(`packages/react/src/AutoComplete/isSameOptionName.ts`):
+ * 選項過濾與 `addable` 模式的重複檢查共用同一份語義 — 若輸入
+ * `colorado` 能在清單中找到 `Colorado`,建立流程也必須視為同一個選項,
+ * 否則 `addable` 模式會誤將使用者已看到的選項當成可建立的新項目。
+ */
+export function isSameOptionName(
+  a: string,
+  b: string,
+  caseSensitive = false,
+): boolean {
+  return (
+    normalizeOptionName(a, caseSensitive) ===
+    normalizeOptionName(b, caseSensitive)
+  );
+}

--- a/packages/react/src/AutoComplete/AutoComplete.spec.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.spec.tsx
@@ -584,6 +584,88 @@ describe('<AutoComplete />', () => {
     });
   });
 
+  describe('prop: caseSensitive', () => {
+    const coloradoOptions: SelectValue[] = [
+      {
+        id: 'colorado',
+        name: 'Colorado',
+      },
+      {
+        id: 'other',
+        name: 'Other',
+      },
+    ];
+
+    it('should not show create action when typing lowercase matches an option by default (case-insensitive)', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+
+      const onInsert = jest.fn((text: string) => [
+        ...coloradoOptions,
+        { id: text, name: text },
+      ]);
+
+      const { container } = render(
+        <AutoComplete addable onInsert={onInsert} options={coloradoOptions} />,
+      );
+
+      let input: HTMLInputElement | null = null;
+      await waitFor(() => {
+        input = container.querySelector('input');
+        expect(input).not.toBeNull();
+      });
+
+      await act(async () => {
+        await user.click(input!);
+        await user.type(input!, 'colorado');
+      });
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Colorado')).toBeInTheDocument();
+      expect(screen.queryByText(/建立/i)).not.toBeInTheDocument();
+    });
+
+    it('should show create action when caseSensitive is set and typed text differs only by casing', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+
+      const onInsert = jest.fn((text: string) => [
+        ...coloradoOptions,
+        { id: text, name: text },
+      ]);
+
+      const { container } = render(
+        <AutoComplete
+          addable
+          caseSensitive
+          onInsert={onInsert}
+          options={coloradoOptions}
+        />,
+      );
+
+      let input: HTMLInputElement | null = null;
+      await waitFor(() => {
+        input = container.querySelector('input');
+        expect(input).not.toBeNull();
+      });
+
+      await act(async () => {
+        await user.click(input!);
+        await user.type(input!, 'colorado');
+      });
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      const createButton = screen.queryByText(/建立.*colorado/i);
+      expect(createButton).toBeInTheDocument();
+    });
+  });
+
   describe('prop: stepByStepBulkCreate', () => {
     it('should keep pasted text in input and show create button for first item only', async () => {
       jest.useFakeTimers();
@@ -720,9 +802,9 @@ describe('<AutoComplete />', () => {
           currentListbox!.querySelectorAll('[role="option"]'),
         ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart'));
         expect(currentOption).toBeTruthy();
-        expect((currentOption as HTMLElement).getAttribute('aria-selected')).toBe(
-          'false',
-        );
+        expect(
+          (currentOption as HTMLElement).getAttribute('aria-selected'),
+        ).toBe('false');
       });
 
       await act(async () => {
@@ -741,7 +823,9 @@ describe('<AutoComplete />', () => {
       await waitFor(() => {
         expect(onRemoveCreated).toHaveBeenCalled();
         const lastCallArg =
-          onRemoveCreated.mock.calls[onRemoveCreated.mock.calls.length - 1]?.[0];
+          onRemoveCreated.mock.calls[
+            onRemoveCreated.mock.calls.length - 1
+          ]?.[0];
         expect(lastCallArg).toEqual(expect.any(Array));
         expect(
           (lastCallArg as SelectValue[]).some(
@@ -960,7 +1044,9 @@ describe('<AutoComplete />', () => {
       ) as HTMLElement | null;
       expect(selectedOption).toBeInTheDocument();
       expect(
-        selectedOption?.querySelector('.mzn-dropdown-item-card-append-content .mzn-icon'),
+        selectedOption?.querySelector(
+          '.mzn-dropdown-item-card-append-content .mzn-icon',
+        ),
       ).toBeInTheDocument();
 
       // Keep the input (trigger) and selection checkboxes separate:
@@ -994,9 +1080,7 @@ describe('<AutoComplete />', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ delay: null });
 
-      const onInsert = jest.fn((text: string) => [
-        { id: text, name: text },
-      ]);
+      const onInsert = jest.fn((text: string) => [{ id: text, name: text }]);
 
       render(
         <AutoComplete
@@ -1027,10 +1111,7 @@ describe('<AutoComplete />', () => {
       expect(createButton).toBeInTheDocument();
 
       fireEvent.click(createButton);
-      expect(onInsert).toHaveBeenCalledWith(
-        'newitem',
-        expect.any(Array),
-      );
+      expect(onInsert).toHaveBeenCalledWith('newitem', expect.any(Array));
     });
 
     it('should keep New tag for created option in inside mode', async () => {
@@ -1049,7 +1130,10 @@ describe('<AutoComplete />', () => {
             mode="multiple"
             onChange={setValue}
             onInsert={(text, currentOptions) => {
-              const updated = [...currentOptions, { id: `new-${text}`, name: text }];
+              const updated = [
+                ...currentOptions,
+                { id: `new-${text}`, name: text },
+              ];
               setOptions(updated);
               return updated;
             }}
@@ -1128,9 +1212,7 @@ describe('<AutoComplete />', () => {
         expect(input.value).toBe('Grid chart, Griddle, Grid');
       });
 
-      const firstCreateButton = screen.queryByText(
-        /建立.*Grid chart/i,
-      );
+      const firstCreateButton = screen.queryByText(/建立.*Grid chart/i);
       expect(firstCreateButton).toBeInTheDocument();
 
       fireEvent.click(firstCreateButton!);
@@ -1244,10 +1326,12 @@ describe('<AutoComplete />', () => {
         const currentListbox = getDropdownListbox() as HTMLElement | null;
         if (!currentListbox) return null;
         return Array.from(
-          currentListbox.querySelectorAll('[role="option"][aria-selected="true"]'),
-        ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart')) as
-          | HTMLElement
-          | null;
+          currentListbox.querySelectorAll(
+            '[role="option"][aria-selected="true"]',
+          ),
+        ).find((el) =>
+          (el as HTMLElement).textContent?.includes('Grid chart'),
+        ) as HTMLElement | null;
       };
 
       const createdSelectedOption = await waitFor(() => {
@@ -1267,9 +1351,9 @@ describe('<AutoComplete />', () => {
           currentListbox!.querySelectorAll('[role="option"]'),
         ).find((el) => (el as HTMLElement).textContent?.includes('Grid chart'));
         expect(currentOption).toBeTruthy();
-        expect((currentOption as HTMLElement).getAttribute('aria-selected')).toBe(
-          'false',
-        );
+        expect(
+          (currentOption as HTMLElement).getAttribute('aria-selected'),
+        ).toBe('false');
       });
 
       await act(async () => {
@@ -1285,7 +1369,9 @@ describe('<AutoComplete />', () => {
       await waitFor(() => {
         expect(onRemoveCreated).toHaveBeenCalled();
         const lastCallArg =
-          onRemoveCreated.mock.calls[onRemoveCreated.mock.calls.length - 1]?.[0];
+          onRemoveCreated.mock.calls[
+            onRemoveCreated.mock.calls.length - 1
+          ]?.[0];
         expect(lastCallArg).toEqual(expect.any(Array));
         expect(
           (lastCallArg as SelectValue[]).some(

--- a/packages/react/src/AutoComplete/AutoComplete.spec.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.spec.tsx
@@ -664,6 +664,40 @@ describe('<AutoComplete />', () => {
       const createButton = screen.queryByText(/建立.*colorado/i);
       expect(createButton).toBeInTheDocument();
     });
+
+    it('should keep a differently-cased duplicate pending in bulk create when caseSensitive is set', async () => {
+      // Regression: `getPendingCreateList`/`processBulkCreate` used to hardcode
+      // `.toLowerCase()`, so pasting an uppercase "Foo" (with caseSensitive on)
+      // was silently deduped against the existing lowercase "foo" option and
+      // dropped. `defaultOptions` contains lowercase "foo" but no "zebra"; with
+      // caseSensitive, "Foo" is a distinct item and must stay pending, whereas
+      // before the fix only "Zebra" survived.
+      const { container } = render(
+        <AutoComplete
+          addable
+          caseSensitive
+          createSeparators={[',']}
+          mode="multiple"
+          onInsert={(text, opts) => [
+            ...opts,
+            { id: `new-${text}`, name: text },
+          ]}
+          options={defaultOptions}
+          stepByStepBulkCreate
+          trimOnCreate
+        />,
+      );
+
+      const input = container.querySelector('input');
+      fireEvent.focus(input!);
+      fireEvent.paste(input!, {
+        clipboardData: { getData: () => 'Foo, Zebra' },
+      });
+
+      await waitFor(() => {
+        expect(input!.value).toBe('Foo, Zebra');
+      });
+    });
   });
 
   describe('prop: stepByStepBulkCreate', () => {

--- a/packages/react/src/AutoComplete/AutoComplete.stories.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.stories.tsx
@@ -474,6 +474,53 @@ export const Multiple: StoryObj<typeof AutoComplete> = {
   render: () => <MultipleComponent />,
 };
 
+const caseSensitiveOptions: SelectValue[] = [
+  { id: 'colorado', name: 'Colorado' },
+  { id: 'connecticut', name: 'Connecticut' },
+  { id: 'virginia', name: 'Virginia' },
+  { id: 'west-virginia', name: 'West Virginia' },
+];
+
+const CaseSensitivityComponent = () => {
+  const [insensitive, setInsensitive] = useState<SelectValue | null>(null);
+  const [sensitive, setSensitive] = useState<SelectValue | null>(null);
+
+  return (
+    <div
+      style={{
+        display: 'inline-grid',
+        gridTemplateColumns: 'repeat(2, 320px)',
+        gap: '16px',
+        alignItems: 'start',
+      }}
+    >
+      <div style={{ display: 'grid', gap: 8 }}>
+        <Tag label="預設：不分大小寫" />
+        <AutoComplete
+          onChange={setInsensitive}
+          options={caseSensitiveOptions}
+          placeholder="輸入 vir 也找得到 Virginia"
+          value={insensitive}
+        />
+      </div>
+      <div style={{ display: 'grid', gap: 8 }}>
+        <Tag label="caseSensitive" />
+        <AutoComplete
+          caseSensitive
+          onChange={setSensitive}
+          options={caseSensitiveOptions}
+          placeholder="需輸入 Vir 才找得到"
+          value={sensitive}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const CaseSensitivity: StoryObj<typeof AutoComplete> = {
+  render: () => <CaseSensitivityComponent />,
+};
+
 const OverflowStrategyComponent = () => {
   const [counterSelections, setCounterSelections] = useState<SelectValue[]>([]);
   const [wrapSelections, setWrapSelections] = useState<SelectValue[]>([]);
@@ -638,7 +685,8 @@ const CreatableMultipleComponent = () => {
       <div>
         <h3>inside 多選模式 - 單選風格 checked icon</h3>
         <p style={{ fontSize: '12px', color: '#666', marginBottom: '8px' }}>
-          下拉視覺採單選風格 checked icon，但行為仍可多選；建立項目維持 New 標記。
+          下拉視覺採單選風格 checked icon，但行為仍可多選；建立項目維持 New
+          標記。
         </p>
         <AutoComplete
           addable
@@ -779,7 +827,9 @@ export const BulkCreate: StoryObj<typeof AutoComplete> = {
 const InputPositionInsideComponent = () => {
   const [open, setOpen] = useState(true);
   const [options, setOptions] = useState<SelectValue[]>(originOptions);
-  const [selections, setSelections] = useState<SelectValue[]>([originOptions[0]]);
+  const [selections, setSelections] = useState<SelectValue[]>([
+    originOptions[0],
+  ]);
   const nextIdRef = useRef(originOptions.length + 1);
 
   const handleInsert = useCallback(
@@ -912,7 +962,9 @@ const InsideBulkCreateComponent = () => {
       }}
     >
       <div>
-        <h3>inside 多選模式 - 單選風格 checked icon + step-by-step bulk create</h3>
+        <h3>
+          inside 多選模式 - 單選風格 checked icon + step-by-step bulk create
+        </h3>
         <p style={{ fontSize: '12px', color: '#666', marginBottom: '8px' }}>
           貼上多個項目後，dropdown 只顯示第一個「建立」，點擊後再顯示下一個。
         </p>

--- a/packages/react/src/AutoComplete/AutoComplete.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.tsx
@@ -47,6 +47,7 @@ import type {
 import { SelectValue } from '../Select/typings';
 import { PickRenameMulti } from '../utils/general';
 import AutoCompleteInsideTrigger from './AutoCompleteInside';
+import { isSameOptionName } from './isSameOptionName';
 import {
   getFullParsedList,
   useAutoCompleteCreation,
@@ -57,24 +58,24 @@ import { useCreationTracker } from './useCreationTracker';
 
 export interface AutoCompleteBaseProps
   extends Omit<
-    SelectTriggerProps,
-    | 'active'
-    | 'clearable'
-    | 'forceHideSuffixActionIcon'
-    | 'fullWidth'
-    | 'mode'
-    | 'onClick'
-    | 'onKeyDown'
-    | 'onChange'
-    | 'renderValue'
-    | 'inputProps'
-    | 'suffixActionIcon'
-    | 'value'
-  >,
-  PickRenameMulti<
-    Pick<PopperProps, 'options'>,
-    { options: 'popperOptions' }
-  > {
+      SelectTriggerProps,
+      | 'active'
+      | 'clearable'
+      | 'forceHideSuffixActionIcon'
+      | 'fullWidth'
+      | 'mode'
+      | 'onClick'
+      | 'onKeyDown'
+      | 'onChange'
+      | 'renderValue'
+      | 'inputProps'
+      | 'suffixActionIcon'
+      | 'value'
+    >,
+    PickRenameMulti<
+      Pick<PopperProps, 'options'>,
+      { options: 'popperOptions' }
+    > {
   /**
    * Set to true when options can be added dynamically
    * @default false
@@ -86,6 +87,14 @@ export interface AutoCompleteBaseProps
    * @default false
    */
   asyncData?: boolean;
+  /**
+   * Whether option matching respects letter casing.
+   * When `false` (default), typing `colorado` matches an option named `Colorado`.
+   * Applies to both option filtering and the duplicate check used by `addable` mode,
+   * so the create action is not offered for an option already visible in the list.
+   * @default false
+   */
+  caseSensitive?: boolean;
   /**
    * Whether to clear search text when leaving the textfield/dropdown scope.
    * When `false`, typed text persists after blur. In `single` mode, a clearable
@@ -211,9 +220,9 @@ export interface AutoCompleteBaseProps
    */
   searchTextControlRef?: RefObject<
     | {
-      reset: () => void;
-      setSearchText: Dispatch<SetStateAction<string>>;
-    }
+        reset: () => void;
+        setSearchText: Dispatch<SetStateAction<string>>;
+      }
     | undefined
   >;
   /**
@@ -425,6 +434,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     const {
       addable = false,
       asyncData = false,
+      caseSensitive = false,
       className,
       clearSearchText = true,
       createSeparators = [',', '+', '\n'],
@@ -502,49 +512,51 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     } = useAutoCompleteValueControl(
       isMultiple
         ? {
-          defaultValue: isMultipleValue(defaultValue)
-            ? defaultValue
-            : undefined,
-          disabledOptionsFilter,
-          getOptionsFilterQuery:
-            stepByStepBulkCreate && addable && onInsert
-              ? (st) => {
-                const full = getFullParsedList(
-                  st,
-                  createSeparators,
-                  trimOnCreate,
-                );
-                return full.length > 1 ? (full[0] ?? undefined) : undefined;
-              }
+            caseSensitive,
+            defaultValue: isMultipleValue(defaultValue)
+              ? defaultValue
               : undefined,
-          mode: 'multiple',
-          onChange: onChangeProp as
-            | ((newOptions: SelectValue[]) => void)
-            | undefined,
-          onClear: onClearProp,
-          onClose: () => toggleOpen(false),
-          onSearch,
-          options: optionsProp,
-          value: isMultipleValue(valueProp) ? valueProp : undefined,
-        }
+            disabledOptionsFilter,
+            getOptionsFilterQuery:
+              stepByStepBulkCreate && addable && onInsert
+                ? (st) => {
+                    const full = getFullParsedList(
+                      st,
+                      createSeparators,
+                      trimOnCreate,
+                    );
+                    return full.length > 1 ? (full[0] ?? undefined) : undefined;
+                  }
+                : undefined,
+            mode: 'multiple',
+            onChange: onChangeProp as
+              | ((newOptions: SelectValue[]) => void)
+              | undefined,
+            onClear: onClearProp,
+            onClose: () => toggleOpen(false),
+            onSearch,
+            options: optionsProp,
+            value: isMultipleValue(valueProp) ? valueProp : undefined,
+          }
         : {
-          defaultValue: isSingleValue(defaultValue)
-            ? defaultValue
-            : undefined,
-          disabledOptionsFilter,
-          mode: 'single',
-          onChange: onChangeProp as
-            | ((newOption: SelectValue | null) => void)
-            | undefined,
-          onClear: onClearProp,
-          onClose: () => toggleOpen(false),
-          onSearch,
-          options: optionsProp,
-          value:
-            isSingleValue(valueProp) || valueProp === null
-              ? valueProp
+            caseSensitive,
+            defaultValue: isSingleValue(defaultValue)
+              ? defaultValue
               : undefined,
-        },
+            disabledOptionsFilter,
+            mode: 'single',
+            onChange: onChangeProp as
+              | ((newOption: SelectValue | null) => void)
+              | undefined,
+            onClear: onClearProp,
+            onClose: () => toggleOpen(false),
+            onSearch,
+            options: optionsProp,
+            value:
+              isSingleValue(valueProp) || valueProp === null
+                ? valueProp
+                : undefined,
+          },
     );
 
     /** export set search text action to props (allow user to customize search text) */
@@ -593,6 +605,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
       setInsertText,
     } = useAutoCompleteCreation({
       addable: creationEnabled,
+      caseSensitive,
       clearUnselected,
       createSeparators,
       filterUnselected,
@@ -899,9 +912,13 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
 
     const searchTextExistWithoutOption: boolean = !!(firstPendingText
       ? firstPendingText &&
-      options.find((option) => option.name === firstPendingText) === undefined
+        options.find((option) =>
+          isSameOptionName(option.name, firstPendingText, caseSensitive),
+        ) === undefined
       : searchText &&
-      options.find((option) => option.name === searchText) === undefined);
+        options.find((option) =>
+          isSameOptionName(option.name, searchText, caseSensitive),
+        ) === undefined);
 
     const shouldShowCreateAction = !!(
       searchTextExistWithoutOption &&
@@ -969,9 +986,9 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
         : undefined;
     const shouldForceClearable = isMultiple
       ? (isMultipleValue(value) && value.length > 0) ||
-      searchText.trim().length > 0
+        searchText.trim().length > 0
       : isSingleValue(value) ||
-      (!shouldClearSearchTextOnBlur && searchText.trim().length > 0);
+        (!shouldClearSearchTextOnBlur && searchText.trim().length > 0);
 
     // Handle dropdown option selection
     const handleDropdownSelect = useCallback(
@@ -1013,7 +1030,7 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     const [keyboardActiveIndex, setKeyboardActiveIndex] = useState<
       number | null
     >(null);
-    const setListboxHasVisualFocus = useCallback((_focus: boolean) => { }, []);
+    const setListboxHasVisualFocus = useCallback((_focus: boolean) => {}, []);
 
     // Reset activeIndex and keyboardActiveIndex when options change
     useEffect(() => {
@@ -1211,9 +1228,9 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
                 ? createActionText
                   ? createActionText(createActionDisplayText)
                   : createActionTextTemplate.replace(
-                    '{text}',
-                    createActionDisplayText,
-                  )
+                      '{text}',
+                      createActionDisplayText,
+                    )
                 : undefined
             }
             activeIndex={activeIndex}
@@ -1242,7 +1259,9 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
             showActionShowTopBar={shouldShowCreateAction}
             status={dropdownStatus}
             toggleCheckedOnClick={
-              inputPosition === 'inside' && mode === 'multiple' ? false : undefined
+              inputPosition === 'inside' && mode === 'multiple'
+                ? false
+                : undefined
             }
             type="default"
             value={dropdownValue}
@@ -1307,8 +1326,8 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
                 suffixAction={onClickSuffixActionIcon}
                 value={
                   mode === 'multiple' &&
-                    isMultipleValue(value) &&
-                    value.length === 0
+                  isMultipleValue(value) &&
+                  value.length === 0
                     ? undefined
                     : (value ?? undefined)
                 }

--- a/packages/react/src/AutoComplete/isSameOptionName.spec.ts
+++ b/packages/react/src/AutoComplete/isSameOptionName.spec.ts
@@ -1,0 +1,24 @@
+import { isSameOptionName } from './isSameOptionName';
+
+describe('isSameOptionName()', () => {
+  it('should return true for equal strings', () => {
+    expect(isSameOptionName('Colorado', 'Colorado')).toBe(true);
+  });
+
+  it('should return true for differing case by default (caseSensitive defaults to false)', () => {
+    expect(isSameOptionName('Colorado', 'colorado')).toBe(true);
+  });
+
+  it('should return false for differing case when caseSensitive is true', () => {
+    expect(isSameOptionName('Colorado', 'colorado', true)).toBe(false);
+  });
+
+  it('should return true for equal strings when caseSensitive is true', () => {
+    expect(isSameOptionName('Colorado', 'Colorado', true)).toBe(true);
+  });
+
+  it('should return false for non-matching strings regardless of caseSensitive', () => {
+    expect(isSameOptionName('Colorado', 'Virginia')).toBe(false);
+    expect(isSameOptionName('Colorado', 'Virginia', true)).toBe(false);
+  });
+});

--- a/packages/react/src/AutoComplete/isSameOptionName.ts
+++ b/packages/react/src/AutoComplete/isSameOptionName.ts
@@ -1,0 +1,15 @@
+/**
+ * Compares two option names, ignoring letter casing unless `caseSensitive` is set.
+ *
+ * Kept in sync with the option filter in `useAutoCompleteValueControl`: if typing
+ * `colorado` surfaces `Colorado` in the list, the creation flow must also treat the
+ * two as the same item, otherwise `addable` mode offers to create a duplicate of an
+ * option the user can already see.
+ */
+export function isSameOptionName(
+  a: string,
+  b: string,
+  caseSensitive = false,
+): boolean {
+  return caseSensitive ? a === b : a.toLowerCase() === b.toLowerCase();
+}

--- a/packages/react/src/AutoComplete/isSameOptionName.ts
+++ b/packages/react/src/AutoComplete/isSameOptionName.ts
@@ -1,4 +1,20 @@
 /**
+ * Normalizes an option name for comparison: lower-cased by default, returned
+ * as-is when `caseSensitive` is set.
+ *
+ * Shared basis for `isSameOptionName`, the option filter (substring match), and
+ * the `Set`-based duplicate checks in the bulk-create flow, so every comparison
+ * site folds case through a single decision point instead of hand-writing
+ * `caseSensitive ? x : x.toLowerCase()`.
+ */
+export function normalizeOptionName(
+  name: string,
+  caseSensitive = false,
+): string {
+  return caseSensitive ? name : name.toLowerCase();
+}
+
+/**
  * Compares two option names, ignoring letter casing unless `caseSensitive` is set.
  *
  * Kept in sync with the option filter in `useAutoCompleteValueControl`: if typing
@@ -11,5 +27,8 @@ export function isSameOptionName(
   b: string,
   caseSensitive = false,
 ): boolean {
-  return caseSensitive ? a === b : a.toLowerCase() === b.toLowerCase();
+  return (
+    normalizeOptionName(a, caseSensitive) ===
+    normalizeOptionName(b, caseSensitive)
+  );
 }

--- a/packages/react/src/AutoComplete/useAutoCompleteCreation.ts
+++ b/packages/react/src/AutoComplete/useAutoCompleteCreation.ts
@@ -7,7 +7,7 @@ import {
 } from 'react';
 
 import { SelectValue } from '../Select/typings';
-import { isSameOptionName } from './isSameOptionName';
+import { isSameOptionName, normalizeOptionName } from './isSameOptionName';
 
 type UseAutoCompleteCreationParams = {
   addable: boolean;
@@ -139,24 +139,40 @@ export function useAutoCompleteCreation({
       const selectedNames = new Set<string>();
       if (isMultiple && isMultipleValue(valueRef.current)) {
         valueRef.current.forEach((v) =>
-          selectedNames.add(v.name.toLowerCase()),
+          selectedNames.add(normalizeOptionName(v.name, caseSensitive)),
         );
       } else if (isSingle && isSingleValue(valueRef.current)) {
-        selectedNames.add(valueRef.current.name.toLowerCase());
+        selectedNames.add(
+          normalizeOptionName(valueRef.current.name, caseSensitive),
+        );
       }
 
-      return processed.filter((part) => !selectedNames.has(part.toLowerCase()));
+      return processed.filter(
+        (part) => !selectedNames.has(normalizeOptionName(part, caseSensitive)),
+      );
     },
-    [addable, createSeparators, isMultiple, isSingle, onInsert, trimOnCreate],
+    [
+      addable,
+      caseSensitive,
+      createSeparators,
+      isMultiple,
+      isSingle,
+      onInsert,
+      trimOnCreate,
+    ],
   );
 
   const getPendingCreateList = useCallback(
     (text: string): string[] => {
       const processed = processBulkCreate(text);
-      const optionNames = new Set(options.map((o) => o.name.toLowerCase()));
-      return processed.filter((part) => !optionNames.has(part.toLowerCase()));
+      const optionNames = new Set(
+        options.map((o) => normalizeOptionName(o.name, caseSensitive)),
+      );
+      return processed.filter(
+        (part) => !optionNames.has(normalizeOptionName(part, caseSensitive)),
+      );
     },
-    [options, processBulkCreate],
+    [caseSensitive, options, processBulkCreate],
   );
 
   const handleBulkCreate = useCallback(

--- a/packages/react/src/AutoComplete/useAutoCompleteCreation.ts
+++ b/packages/react/src/AutoComplete/useAutoCompleteCreation.ts
@@ -7,9 +7,11 @@ import {
 } from 'react';
 
 import { SelectValue } from '../Select/typings';
+import { isSameOptionName } from './isSameOptionName';
 
 type UseAutoCompleteCreationParams = {
   addable: boolean;
+  caseSensitive?: boolean;
   createSeparators: string[];
   filterUnselected: (options: SelectValue[]) => SelectValue[];
   clearUnselected: () => void;
@@ -83,6 +85,7 @@ function isOptionSelected(
 
 export function useAutoCompleteCreation({
   addable,
+  caseSensitive = false,
   createSeparators,
   filterUnselected,
   clearUnselected,
@@ -168,8 +171,8 @@ export function useAutoCompleteCreation({
       const newlySelectedIds: Set<string> = new Set();
 
       texts.forEach((text) => {
-        const existingOption = currentOptions.find(
-          (option) => option.name === text,
+        const existingOption = currentOptions.find((option) =>
+          isSameOptionName(option.name, text, caseSensitive),
         );
 
         if (existingOption) {
@@ -244,6 +247,7 @@ export function useAutoCompleteCreation({
     },
     [
       addable,
+      caseSensitive,
       clearNewlyCreated,
       clearUnselected,
       filterUnselected,

--- a/packages/react/src/Form/useAutoCompleteValueControl.spec.tsx
+++ b/packages/react/src/Form/useAutoCompleteValueControl.spec.tsx
@@ -299,4 +299,95 @@ describe('useAutoCompleteValueControl()', () => {
 
     expect(myValue.length).toBe(0);
   });
+
+  describe('prop: caseSensitive', () => {
+    const virginiaOptions: SelectValue[] = [
+      { id: 'virginia', name: 'Virginia' },
+      { id: 'other', name: 'Other' },
+    ];
+
+    it('should match options case-insensitively by default when search text is lowercase', () => {
+      const { result } = renderHook(() =>
+        useAutoCompleteValueControl({
+          disabledOptionsFilter: false,
+          mode: 'single',
+          options: virginiaOptions,
+        }),
+      );
+
+      act(() => {
+        result.current.setSearchText('vir');
+      });
+
+      expect(result.current.options).toEqual([
+        { id: 'virginia', name: 'Virginia' },
+      ]);
+    });
+
+    it('should match options case-insensitively by default when search text is uppercase', () => {
+      const { result } = renderHook(() =>
+        useAutoCompleteValueControl({
+          disabledOptionsFilter: false,
+          mode: 'single',
+          options: virginiaOptions,
+        }),
+      );
+
+      act(() => {
+        result.current.setSearchText('VIR');
+      });
+
+      expect(result.current.options).toEqual([
+        { id: 'virginia', name: 'Virginia' },
+      ]);
+    });
+
+    it('should respect letter casing when caseSensitive is true', () => {
+      const { result } = renderHook(() =>
+        useAutoCompleteValueControl({
+          caseSensitive: true,
+          disabledOptionsFilter: false,
+          mode: 'single',
+          options: virginiaOptions,
+        }),
+      );
+
+      act(() => {
+        result.current.setSearchText('vir');
+      });
+
+      expect(result.current.options).toEqual([]);
+
+      act(() => {
+        result.current.setSearchText('Vir');
+      });
+
+      expect(result.current.options).toEqual([
+        { id: 'virginia', name: 'Virginia' },
+      ]);
+    });
+
+    it('should still escape regex special characters when case-insensitive matching is enabled', () => {
+      const specialOption: SelectValue = {
+        id: 'special',
+        name: '?><!@#$^$&^&',
+      };
+
+      const { result } = renderHook(() =>
+        useAutoCompleteValueControl({
+          disabledOptionsFilter: false,
+          mode: 'single',
+          options: [specialOption, { id: 'other', name: 'Other' }],
+        }),
+      );
+
+      expect(() => {
+        act(() => {
+          result.current.setSearchText('?><!@#$^$&^&');
+        });
+      }).not.toThrow();
+
+      expect(result.current.options).toEqual([specialOption]);
+    });
+  });
 });

--- a/packages/react/src/Form/useAutoCompleteValueControl.ts
+++ b/packages/react/src/Form/useAutoCompleteValueControl.ts
@@ -12,6 +12,11 @@ import { SelectValue } from '../Select/typings';
 import { useControlValueState } from './useControlValueState';
 
 export interface UseAutoCompleteBaseValueControl {
+  /**
+   * Whether option filtering should respect letter casing.
+   * @default false
+   */
+  caseSensitive?: boolean;
   disabledOptionsFilter: boolean;
   getOptionsFilterQuery?: (searchText: string) => string | undefined;
   onChange?(newOptions: SelectValue[] | SelectValue | null): any;
@@ -75,6 +80,7 @@ function useAutoCompleteBaseValueControl(
 ): AutoCompleteSingleValueControl;
 function useAutoCompleteBaseValueControl(props: UseAutoCompleteValueControl) {
   const {
+    caseSensitive = false,
     defaultValue,
     disabledOptionsFilter,
     getOptionsFilterQuery,
@@ -100,9 +106,10 @@ function useAutoCompleteBaseValueControl(props: UseAutoCompleteValueControl) {
 
   const filterQuery = getOptionsFilterQuery?.(searchText) ?? searchText;
 
-  /** escape all special characters */
+  /** escape all special characters; casing is ignored unless `caseSensitive` is set */
   const searchTextReg = new RegExp(
     filterQuery.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d'),
+    caseSensitive ? '' : 'i',
   );
 
   const onFocus = useCallback((focus: boolean) => {


### PR DESCRIPTION
## 問題

React `AutoComplete` 的過濾用 `new RegExp(...)` 但**沒有加 `i` flag**，所以搜尋是大小寫敏感的 —— 輸入 `vir` 找不到清單裡的 `Virginia`，必須輸入 `Vir` 才行。

Angular 的 `AutoComplete` 一直都是兩邊 `toLowerCase()` 比對，**React 才是異常值**。這個 PR 把 React 拉回一致。

## 做法

### 1. 過濾改為不分大小寫（React）

regex flag 改成 `caseSensitive ? '' : 'i'`。

### 2. `addable` 的重複判斷一併對齊

過濾與建立必須採同一套規則：如果輸入 `colorado` 會列出 `Colorado`，那「建立新項目」就不該同時提議建立一個畫面上已經看得到的重複項。原本這裡用完全相等比對，改用共用的 `isSameOptionName` helper。

### 3. 新增 `caseSensitive` prop（預設 `false`）

給確實需要以大小寫區分項目的使用端一個 opt-out。

### 4. Angular 同步加上對應 input

Angular 原本就不分大小寫、但沒有 opt-out 的手段。依專案的 prop-for-prop parity 規範補上 `caseSensitive` input（同樣預設 `false`），並把過濾、create-action 重複檢查、bulk-create 的 pending/existing 查找全部收斂到共用 helper。

## 相容性

`caseSensitive` 預設 `false`，Angular 行為完全不變。

**React 的預設行為有變**：過濾變得更寬鬆。原本依賴大小寫敏感過濾的使用端需要顯式加上 `caseSensitive`。這算 bug 修正還是 breaking change、要不要影響 semver bump，想請審核者定奪 —— 我用了 `fix` 而非 `feat!`，理由是 Angular 早已如此、React 這側比較像實作疏漏。

## 驗證

- React：`AutoComplete` / `Dropdown` / `useAutoCompleteValueControl` 共 **201 個測試通過**（原 190 + 新增 11），eslint 乾淨。
- 涵蓋兩個方向的過濾、regex 特殊字元跳脫在新 flag 下仍正確、以及 `addable` create-action 的行為。
- 兩邊 Storybook 都加了 `CaseSensitivity` story，預設與 `caseSensitive` 並排對照。

## 需要注意的驗證缺口

**Angular 的新 specs 沒有實際跑過** —— `packages/ng` 沒有 jest 設定（既有的 repo-wide 缺口，非本 PR 造成）。Angular 這側實際驗證的是：

- `ng-packagr` build 成功
- `eslint` 0 errors（2 個 warning 都確認在 main 上就存在，只是行號位移）
- `tsc --noEmit` 無相關錯誤

另外發現既有的 `autocomplete.component.spec.ts` 使用 `<mzn-autocomplete>` 元素標籤，但元件實際 selector 是屬性形式 `[mznAutocomplete]`。新增的 specs 採用文件記載的 `<div mznAutocomplete>` 寫法。既有測試未動 —— 這個落差在 jest 接起來之前無法驗證，一併提出給審核者參考。

🤖 Generated with [Claude Code](https://claude.com/claude-code)