### PR TITLE
fix: skip text-input Enter actions while IME is composing (React + Angular)

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { isImeComposing } from './isImeComposing';
+export type { ImeComposingEventLike } from './isImeComposing';

--- a/packages/core/src/utils/isImeComposing.spec.ts
+++ b/packages/core/src/utils/isImeComposing.spec.ts
@@ -1,0 +1,23 @@
+import { isImeComposing } from './isImeComposing';
+
+describe('isImeComposing', () => {
+  it('returns true when isComposing is true', () => {
+    expect(isImeComposing({ isComposing: true })).toBe(true);
+  });
+
+  it('returns true when keyCode is 229', () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 229 })).toBe(true);
+  });
+
+  it('reads nativeEvent for React synthetic events', () => {
+    expect(
+      isImeComposing({
+        nativeEvent: { isComposing: true, keyCode: 13 },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for a normal Enter keydown', () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 13 })).toBe(false);
+  });
+});

--- a/packages/core/src/utils/isImeComposing.ts
+++ b/packages/core/src/utils/isImeComposing.ts
@@ -1,0 +1,30 @@
+/**
+ * IME 組字期間的 keyCode。Safari 等瀏覽器在按 Enter 確認組字時，
+ * `isComposing` 可能已是 `false`，但仍帶此碼。
+ */
+const IME_KEYCODE = 229;
+
+export interface ImeComposingEventLike {
+  isComposing?: boolean;
+  keyCode?: number;
+  nativeEvent?: {
+    isComposing?: boolean;
+    keyCode?: number;
+  };
+}
+
+/**
+ * 判斷鍵盤事件是否發生在 IME 組字期間。
+ *
+ * 中日韓輸入法按 Enter / Return 是確認候選字，不應觸發選取或送出。
+ *
+ * @example
+ * ```ts
+ * if (isImeComposing(event)) return;
+ * ```
+ */
+export function isImeComposing(event: ImeComposingEventLike): boolean {
+  const source = event.nativeEvent ?? event;
+
+  return Boolean(source.isComposing) || source.keyCode === IME_KEYCODE;
+}

--- a/packages/ng/autocomplete/autocomplete.component.spec.ts
+++ b/packages/ng/autocomplete/autocomplete.component.spec.ts
@@ -280,4 +280,28 @@ describe('MznAutocomplete', () => {
       expect(createButton).toBeTruthy();
     });
   });
+
+  it('should not select when Enter is pressed during IME composition', () => {
+    const { fixture, host } = createFixture(TestHostComponent);
+    const input = fixture.nativeElement.querySelector(
+      'input',
+    ) as HTMLInputElement;
+
+    input.dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const enterEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+    });
+
+    Object.defineProperty(enterEvent, 'isComposing', { value: true });
+    Object.defineProperty(enterEvent, 'keyCode', { value: 229 });
+
+    input.dispatchEvent(enterEvent);
+    fixture.detectChanges();
+
+    expect(host.selected).toBe('');
+  });
 });

--- a/packages/ng/autocomplete/autocomplete.component.ts
+++ b/packages/ng/autocomplete/autocomplete.component.ts
@@ -24,6 +24,7 @@ import {
   AutoCompleteInputSize,
 } from '@mezzanine-ui/core/autocomplete';
 import { textFieldClasses } from '@mezzanine-ui/core/text-field';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { ChevronDownIcon } from '@mezzanine-ui/icons';
 import clsx from 'clsx';
 import { MznClearActions } from '@mezzanine-ui/ng/clear-actions';
@@ -1188,6 +1189,8 @@ export class MznAutocomplete
   }
 
   protected onInputKeydown(event: KeyboardEvent): void {
+    if (isImeComposing(event)) return;
+
     // Enter key: handle creation
     if (event.key === 'Enter' && this.handleEnterKey()) {
       event.preventDefault();

--- a/packages/ng/date-picker/date-picker.component.ts
+++ b/packages/ng/date-picker/date-picker.component.ts
@@ -19,6 +19,7 @@ import {
   getDefaultModeFormat,
 } from '@mezzanine-ui/core/calendar';
 import { pickerClasses } from '@mezzanine-ui/core/picker';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { TextFieldSize } from '@mezzanine-ui/core/text-field';
 import { CalendarIcon } from '@mezzanine-ui/icons';
 import {
@@ -423,6 +424,8 @@ export class MznDatePicker implements ControlValueAccessor, AfterViewInit {
   }
 
   protected onKeydown(event: KeyboardEvent): void {
+    if (isImeComposing(event)) return;
+
     if (event.key === 'Escape') {
       this.isOpen.set(false);
       this.calendarToggled.emit(false);

--- a/packages/ng/date-range-picker/date-range-picker.component.ts
+++ b/packages/ng/date-range-picker/date-range-picker.component.ts
@@ -20,6 +20,7 @@ import {
 } from '@mezzanine-ui/core/calendar';
 import { pickerClasses, RangePickerValue } from '@mezzanine-ui/core/picker';
 import { TextFieldSize } from '@mezzanine-ui/core/text-field';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import {
   MZN_CALENDAR_CONFIG,
   type CalendarDayAnnotation,
@@ -582,6 +583,8 @@ export class MznDateRangePicker implements ControlValueAccessor, AfterViewInit {
   }
 
   protected onKeydown(event: KeyboardEvent): void {
+    if (isImeComposing(event)) return;
+
     if (event.key === 'Escape') {
       this.onCancel();
     }

--- a/packages/ng/date-time-picker/date-time-picker.component.ts
+++ b/packages/ng/date-time-picker/date-time-picker.component.ts
@@ -16,6 +16,7 @@ import { ControlValueAccessor } from '@angular/forms';
 import { CalendarMode, DateType } from '@mezzanine-ui/core/calendar';
 import { pickerClasses } from '@mezzanine-ui/core/picker';
 import { TextFieldSize, textFieldClasses } from '@mezzanine-ui/core/text-field';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { CalendarTimeIcon } from '@mezzanine-ui/icons';
 import { MZN_CALENDAR_CONFIG } from '@mezzanine-ui/ng/calendar';
 import { MznClearActions } from '@mezzanine-ui/ng/clear-actions';
@@ -1026,6 +1027,8 @@ export class MznDateTimePicker implements ControlValueAccessor, AfterViewInit {
   }
 
   protected onKeydown(event: KeyboardEvent): void {
+    if (isImeComposing(event)) return;
+
     if (event.key === 'Escape') {
       this.onTimeCancel();
     }

--- a/packages/ng/dropdown/dropdown-item.component.ts
+++ b/packages/ng/dropdown/dropdown-item.component.ts
@@ -16,6 +16,7 @@ import {
   DropdownStatus as DropdownStatusType,
   DropdownType,
 } from '@mezzanine-ui/core/dropdown';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import {
   CaretDownIcon,
   CaretRightIcon,
@@ -731,7 +732,7 @@ export class MznDropdownItem {
    * 所有 leaf 節點。 `event.repeat` 忽略長按重覆觸發。
    */
   protected onHostKeyDown(event: KeyboardEvent): void {
-    if (event.repeat || this.disabled()) return;
+    if (event.repeat || this.disabled() || isImeComposing(event)) return;
 
     const match = this.findShortcutMatch(event);
 

--- a/packages/ng/dropdown/dropdown.component.ts
+++ b/packages/ng/dropdown/dropdown.component.ts
@@ -21,6 +21,7 @@ import {
   DropdownStatus as DropdownStatusType,
   DropdownType,
 } from '@mezzanine-ui/core/dropdown';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { type Placement } from '@floating-ui/dom';
 import { IconDefinition } from '@mezzanine-ui/icons';
 import { ClickAwayService } from '@mezzanine-ui/ng/services';
@@ -872,7 +873,7 @@ export class MznDropdown {
    * 僅在 `open()` 時處理。tree 模式目前交由 MznDropdownItem 內部處理。
    */
   protected onHostKeyDown(event: KeyboardEvent): void {
-    if (!this.open() || this.disabled()) return;
+    if (isImeComposing(event) || !this.open() || this.disabled()) return;
 
     // 若有外層 wrapper(如 MznAutocomplete)在同一事件上已呼叫
     // `event.preventDefault()` 表示它已消化掉此 key,MznDropdown 不重複處理。

--- a/packages/ng/pagination/pagination-jumper.component.ts
+++ b/packages/ng/pagination/pagination-jumper.component.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { paginationJumperClasses as classes } from '@mezzanine-ui/core/pagination/paginationJumper';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { MznButton } from '@mezzanine-ui/ng/button';
 import { MznInput } from '@mezzanine-ui/ng/input';
 import { MznTypography } from '@mezzanine-ui/ng/typography';
@@ -59,7 +60,7 @@ import { MznTypography } from '@mezzanine-ui/ng/typography';
       [placeholder]="inputPlaceholder() ?? ''"
       [value]="value()"
       (valueChange)="value.set($event)"
-      (keydown.enter)="onSubmit()"
+      (keydown)="onInputKeydown($event)"
     ></div>
     <button
       mznButton
@@ -111,6 +112,12 @@ export class MznPaginationJumper {
 
     return t ? Math.ceil(t / this.pageSize()) : 1;
   });
+
+  protected onInputKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Enter' || isImeComposing(event)) return;
+
+    this.onSubmit();
+  }
 
   protected onSubmit(): void {
     const raw = Number(this.value());

--- a/packages/ng/time-picker/time-picker.component.ts
+++ b/packages/ng/time-picker/time-picker.component.ts
@@ -13,6 +13,7 @@ import {
 import { ControlValueAccessor } from '@angular/forms';
 import { DateType } from '@mezzanine-ui/core/calendar';
 import { TextFieldSize } from '@mezzanine-ui/core/text-field';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { ClockIcon } from '@mezzanine-ui/icons';
 import { MZN_CALENDAR_CONFIG } from '@mezzanine-ui/ng/calendar';
 import { MznIcon } from '@mezzanine-ui/ng/icon';
@@ -279,6 +280,8 @@ export class MznTimePicker implements ControlValueAccessor {
   }
 
   protected onKeydown(event: KeyboardEvent): void {
+    if (isImeComposing(event)) return;
+
     if (event.key === 'Escape') {
       this.onCancel();
     }

--- a/packages/ng/time-range-picker/time-range-picker.component.ts
+++ b/packages/ng/time-range-picker/time-range-picker.component.ts
@@ -14,6 +14,7 @@ import { ControlValueAccessor } from '@angular/forms';
 import { DateType } from '@mezzanine-ui/core/calendar';
 import { RangePickerValue } from '@mezzanine-ui/core/picker';
 import { TextFieldSize } from '@mezzanine-ui/core/text-field';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { ClockIcon } from '@mezzanine-ui/icons';
 import { MZN_CALENDAR_CONFIG } from '@mezzanine-ui/ng/calendar';
 import { MznIcon } from '@mezzanine-ui/ng/icon';
@@ -336,6 +337,8 @@ export class MznTimeRangePicker implements ControlValueAccessor {
   }
 
   protected onKeydown(event: KeyboardEvent): void {
+    if (isImeComposing(event)) return;
+
     if (event.key === 'Escape') this.onCancel();
   }
 }

--- a/packages/react/src/AutoComplete/AutoComplete.spec.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.spec.tsx
@@ -1552,6 +1552,38 @@ describe('<AutoComplete />', () => {
       expect(onChange).toHaveBeenCalled();
     });
 
+    it('should not select when Enter is pressed during IME composition', async () => {
+      const inputRef = createRef<HTMLInputElement>();
+      const onChange = jest.fn();
+
+      render(
+        <AutoComplete
+          inputRef={inputRef}
+          onChange={onChange}
+          options={defaultOptions}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(inputRef.current).toBeInTheDocument();
+      });
+
+      fireEvent.focus(inputRef.current!);
+
+      await waitFor(() => {
+        expect(getDropdownListbox()).toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(inputRef.current!, {
+        key: 'Enter',
+        isComposing: true,
+        keyCode: 229,
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(getDropdownListbox()).toBeInTheDocument();
+    });
+
     it('should close dropdown when Escape is pressed', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ delay: null });

--- a/packages/react/src/AutoComplete/AutoComplete.tsx
+++ b/packages/react/src/AutoComplete/AutoComplete.tsx
@@ -32,6 +32,7 @@ import {
   DropdownStatus as DropdownStatusType,
 } from '@mezzanine-ui/core/dropdown/dropdown';
 import { selectClasses as selectTriggerClasses } from '@mezzanine-ui/core/select';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 
 import Dropdown from '../Dropdown';
 import { FormControlContext } from '../Form';
@@ -1102,6 +1103,8 @@ const AutoComplete = forwardRef<HTMLDivElement, AutoCompleteProps>(
     const onSearchInputKeyDown: KeyboardEventHandler<HTMLInputElement> =
       useCallback(
         (e) => {
+          if (isImeComposing(e)) return;
+
           if (e.key === 'Escape') {
             e.preventDefault();
             e.stopPropagation();

--- a/packages/react/src/AutoComplete/useAutoCompleteKeyboard.ts
+++ b/packages/react/src/AutoComplete/useAutoCompleteKeyboard.ts
@@ -8,6 +8,7 @@ import {
 } from 'react';
 
 import { DropdownOption } from '@mezzanine-ui/core/dropdown/dropdown';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 
 import { createDropdownKeydownHandler } from '../Dropdown/dropdownKeydownHandler';
 import { SelectValue } from '../Select/typings';
@@ -201,6 +202,8 @@ export function useAutoCompleteKeyboard({
 
   const handleInputKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
+      if (isImeComposing(e)) return;
+
       if (handleEnterKey(e)) return;
 
       if (

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react';
 import { DateType, getDefaultModeFormat } from '@mezzanine-ui/core/calendar';
 import { pickerClasses } from '@mezzanine-ui/core/picker';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { CalendarIcon } from '@mezzanine-ui/icons';
 import { useCalendarContext } from '../Calendar';
 import { cx } from '../utils/cx';
@@ -272,7 +273,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           onKeyDownProp(event);
         }
 
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' && !isImeComposing(event)) {
           onChangeProp?.(internalValue);
           onCalendarToggle(false);
         }

--- a/packages/react/src/Dropdown/Dropdown.tsx
+++ b/packages/react/src/Dropdown/Dropdown.tsx
@@ -23,6 +23,7 @@ import {
   DropdownStatus as DropdownStatusType,
   DropdownType,
 } from '@mezzanine-ui/core/dropdown/dropdown';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 
 import { flip as flipMiddlewareFn, offset, size } from '@floating-ui/react-dom';
 import { MOTION_DURATION, MOTION_EASING } from '@mezzanine-ui/system/motion';
@@ -702,7 +703,7 @@ export default function Dropdown(props: DropdownProps) {
   // Built-in keyboard navigation (only when activeIndex is not controlled externally)
   const handleBuiltinKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      if (isActiveIndexControlled) return;
+      if (isImeComposing(event) || isActiveIndexControlled) return;
 
       const count = flatNavigableOptions.length;
 

--- a/packages/react/src/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/Dropdown/DropdownItem.tsx
@@ -21,6 +21,7 @@ import {
   DropdownStatus as DropdownStatusType,
   DropdownType,
 } from '@mezzanine-ui/core/dropdown/dropdown';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { type IconDefinition } from '@mezzanine-ui/icons';
 
 import { CaretDownIcon, CaretRightIcon } from '@mezzanine-ui/icons';
@@ -794,7 +795,7 @@ export default function DropdownItem<
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.repeat) return;
+      if (event.repeat || isImeComposing(event)) return;
 
       const targetOption = visibleShortcutOptions.find((option) => {
         if (

--- a/packages/react/src/Dropdown/dropdownKeydownHandler.spec.ts
+++ b/packages/react/src/Dropdown/dropdownKeydownHandler.spec.ts
@@ -8,7 +8,9 @@ describe('createDropdownKeydownHandler', () => {
     { id: '3', name: 'Option 3' },
   ];
 
-  const createMockEvent = (key: string): React.KeyboardEvent<HTMLInputElement> => {
+  const createMockEvent = (
+    key: string,
+  ): React.KeyboardEvent<HTMLInputElement> => {
     return {
       key,
       preventDefault: jest.fn(),
@@ -220,6 +222,51 @@ describe('createDropdownKeydownHandler', () => {
 
       expect(onEnterSelect).not.toHaveBeenCalled();
     });
+
+    it('should not select when IME is composing', () => {
+      const onEnterSelect = jest.fn();
+      const handler = createDropdownKeydownHandler({
+        activeIndex: 1,
+        open: true,
+        options: mockOptions,
+        onEnterSelect,
+        setActiveIndex: jest.fn(),
+        setListboxHasVisualFocus: jest.fn(),
+        setOpen: jest.fn(),
+      });
+
+      const event = {
+        ...createMockEvent('Enter'),
+        nativeEvent: { isComposing: true, keyCode: 13 },
+      } as unknown as React.KeyboardEvent<HTMLInputElement>;
+
+      handler(event);
+
+      expect(onEnterSelect).not.toHaveBeenCalled();
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('should not select when keyCode is 229', () => {
+      const onEnterSelect = jest.fn();
+      const handler = createDropdownKeydownHandler({
+        activeIndex: 1,
+        open: true,
+        options: mockOptions,
+        onEnterSelect,
+        setActiveIndex: jest.fn(),
+        setListboxHasVisualFocus: jest.fn(),
+        setOpen: jest.fn(),
+      });
+
+      const event = {
+        ...createMockEvent('Enter'),
+        nativeEvent: { isComposing: false, keyCode: 229 },
+      } as unknown as React.KeyboardEvent<HTMLInputElement>;
+
+      handler(event);
+
+      expect(onEnterSelect).not.toHaveBeenCalled();
+    });
   });
 
   describe('Escape', () => {
@@ -341,4 +388,3 @@ describe('createDropdownKeydownHandler', () => {
     });
   });
 });
-

--- a/packages/react/src/Dropdown/dropdownKeydownHandler.ts
+++ b/packages/react/src/Dropdown/dropdownKeydownHandler.ts
@@ -1,4 +1,5 @@
 import { DropdownOption } from '@mezzanine-ui/core/dropdown/dropdown';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { Dispatch, SetStateAction } from 'react';
 
 /**
@@ -34,7 +35,7 @@ export function createDropdownKeydownHandler(params: {
   } = params;
 
   return (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (options.length === 0) return;
+    if (isImeComposing(e) || options.length === 0) return;
 
     switch (e.key) {
       case 'ArrowDown': {

--- a/packages/react/src/Form/useInputWithTagsModeValue.ts
+++ b/packages/react/src/Form/useInputWithTagsModeValue.ts
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import {
   useInputControlValue,
   UseInputControlValueProps,
@@ -139,7 +140,7 @@ export function useInputWithTagsModeValue<
         element &&
         element?.value &&
         (e.key === 'Enter' || e.code === 'Enter') &&
-        !e.nativeEvent.isComposing &&
+        !isImeComposing(e) &&
         !tagsWillOverflow()
       ) {
         e.preventDefault();

--- a/packages/react/src/Pagination/PaginationJumper.spec.tsx
+++ b/packages/react/src/Pagination/PaginationJumper.spec.tsx
@@ -112,5 +112,28 @@ describe('<PaginationJumper />', () => {
 
       expect(onChange).toHaveBeenCalled();
     });
+
+    it('should not trigger onChange when Enter is pressed during IME composition', () => {
+      const onChange = jest.fn();
+      const { getHostHTMLElement } = render(
+        <PaginationJumper onChange={onChange} total={100} />,
+      );
+      const element = getHostHTMLElement();
+      const input = element.querySelector('input');
+
+      fireEvent.change(input!, {
+        target: {
+          value: '2',
+        },
+      });
+
+      fireEvent.keyDown(input!, {
+        key: 'Enter',
+        isComposing: true,
+        keyCode: 229,
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/react/src/Pagination/PaginationJumper.tsx
+++ b/packages/react/src/Pagination/PaginationJumper.tsx
@@ -6,6 +6,7 @@ import {
   KeyboardEvent,
 } from 'react';
 import { paginationJumperClasses as classes } from '@mezzanine-ui/core/pagination';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import Typography from '../Typography';
 import Button from '../Button';
 import Input from '../Input';
@@ -96,7 +97,7 @@ const PaginationJumper = forwardRef<HTMLDivElement, PaginationJumperProps>(
     };
 
     const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' && !isImeComposing(e)) {
         handleClick();
       }
     };

--- a/packages/react/src/Picker/usePickerValue.spec.tsx
+++ b/packages/react/src/Picker/usePickerValue.spec.tsx
@@ -259,5 +259,36 @@ describe('usePickerValue', () => {
 
       expect(document.activeElement).not.toBe(inputElement);
     });
+
+    it('case: enter during IME composition should not blur', () => {
+      const inputElement = document.createElement('input');
+
+      document.body.appendChild(inputElement);
+
+      const inputRef = {
+        current: inputElement,
+      };
+      const { result } = renderHook(
+        () =>
+          usePickerValue({
+            inputRef,
+            format: 'YYYY-MM-DD',
+          }),
+        { wrapper },
+      );
+
+      inputElement.focus();
+
+      expect(document.activeElement).toBe(inputElement);
+
+      act(() => {
+        result.current.onKeyDown({
+          key: 'Enter',
+          nativeEvent: { isComposing: true, keyCode: 229 },
+        } as KeyboardEvent<HTMLInputElement>);
+      });
+
+      expect(document.activeElement).toBe(inputElement);
+    });
   });
 });

--- a/packages/react/src/Picker/usePickerValue.ts
+++ b/packages/react/src/Picker/usePickerValue.ts
@@ -1,4 +1,5 @@
 import { DateType } from '@mezzanine-ui/core/calendar';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import {
   FocusEventHandler,
   KeyboardEventHandler,
@@ -68,6 +69,8 @@ export function usePickerValue({
   const guardValidDateTypeOnKeyDown: KeyboardEventHandler<HTMLInputElement> = (
     event,
   ) => {
+    if (isImeComposing(event)) return;
+
     if (event.key === 'Enter' || event.key === 'Escape') {
       inputRef.current?.blur();
 

--- a/packages/react/src/TimePicker/TimePicker.tsx
+++ b/packages/react/src/TimePicker/TimePicker.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react';
 import { DateType } from '@mezzanine-ui/core/calendar';
+import { isImeComposing } from '@mezzanine-ui/core/utils';
 import { ClockIcon } from '@mezzanine-ui/icons';
 import { useCalendarContext } from '../Calendar';
 import { useComposeRefs } from '../hooks/useComposeRefs';
@@ -300,7 +301,7 @@ const TimePicker = forwardRef<HTMLDivElement, TimePickerProps>(
           onKeyDownProp(event);
         }
 
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' && !isImeComposing(event)) {
           onConfirm();
         }
       },


### PR DESCRIPTION
## 問題

`AutoComplete` 等文字輸入元件在中文（及其他 CJK）輸入法組字時，按 Enter / Return 會把「確認候選字」當成元件動作：選取選項、新增 tag、跳頁、或關閉 picker。

## 根因

組字期間的 `keydown` 仍帶 `key === 'Enter'`。元件沒有分辨這是 IME 確認還是使用者送出。

Safari 等瀏覽器在組字結束當下，`isComposing` 可能已是 `false`，但仍帶 `keyCode === 229`（Windows `VK_PROCESSKEY`，不是實體按鍵）。只檢查 `isComposing` 會漏掉這一次。

既有的 tags 模式已有 `!e.nativeEvent.isComposing`，其餘路徑沒有。

## 做法

新增 `@mezzanine-ui/core/utils` 的 `isImeComposing`，同時認 `isComposing` 與 `keyCode === 229`，並相容 React synthetic event 的 `nativeEvent`。

所有「文字輸入 + Enter 會選取／送出／關閉」的路徑，組字期間直接 return。方向鍵與 Escape 一併略過，避免抢走候選字導覽與取消組字。

React 與 Angular 同一套判斷，prop-for-prop 行為對齊。

刻意不改 Checkbox、Navigation、Stepper、Slider、Table header、Upload card、Cascader 面板、Select 觸發器（預設 `readOnly`）等非組字輸入。那些 Enter 只是一般啟用操作。

## 變更內容

| 範圍                    | 變更                                                                 |
| --------------------- | ------------------------------------------------------------------ |
| `core/utils`          | 新增 `isImeComposing`                                                |
| React AutoComplete    | 搜尋框與 keyboard hook 略過組字 keydown                                    |
| React Dropdown        | listbox 導覽、選取、shortcut 略過組字                                       |
| React Form tags       | 改走共用 helper（含 229）                                                 |
| React PaginationJumper | Enter 跳頁略過組字                                                       |
| React Picker          | DatePicker / TimePicker / `usePickerValue` 確認或失焦略過組字               |
| Angular AutoComplete  | 與 React 對齊                                                          |
| Angular Dropdown      | host keydown 與 shortcut 略過組字                                       |
| Angular PaginationJumper | `keydown.enter` 改為可判斷組字的 handler                                 |
| Angular Picker        | date / time / range 的 Enter、Escape 略過組字                            |

> Commit 依相依層次與 scope 拆分：`core` → `react/*` → `ng/*`。

## 相容性

行為收斂為「組字中不送出」。非組字的 Enter 不變。無 public API 移除或簽名變更；`isImeComposing` 是新增的 core 工具。

## 驗證

- `isImeComposing`：4 項通過。
- React `AutoComplete` / `dropdownKeydownHandler` / `PaginationJumper` / `usePickerValue`：73 項通過（含組字中 Enter 不選取、不跳頁、不失焦）。
- ESLint：變更檔 0 error（既有 warning 未新增）。
- lint-staged（prettier + eslint）於各 commit 通過。

## 需要注意的驗證缺口

**Angular specs 沒有在本地實際跑過完整 TestBed** — `packages/ng` 沒有 `jest.config.js`（`package.json` 有引用但檔案不存在，既有 repo-wide 缺口，非本 PR 造成）。新增的 AutoComplete spec 寫法與既有測試相同。

也尚未用真實注音／拼音在 Storybook 手測。請審核者在 AutoComplete 輸入框組字中按 Enter：應只上字、不選選項；組字結束後再按 Enter 才選取。

## 審核重點

- `keyCode === 229` 是否接受為 Safari 組字結束的後備判斷。
- 組字期間連箭頭與 Escape 一併忽略，是否符合預期。
- Select / Cascader 觸發器預設 `readOnly`，本次未改；若之後做成可搜尋輸入，需要同一套防護。